### PR TITLE
docs: align roadmap and todo for phase3 sprint1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Primary reference thread:
 - `docs/06-development-progress.md` — development progress + post-Phase 2 roadmap
 - `docs/runbooks/phase2-verification.md` — Phase 2 verification gate (happy path + failure path)
 - `docs/runbooks/compose-reference.md` — Docker Compose reference (service + FNN)
+- `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md` — next implementation plan (Phase 3 Sprint 1)
 
 ## Configuration (service)
 Environment variables used by the Fiber Link service:
 - `FIBER_LINK_NONCE_REDIS_URL` — Redis URL for shared nonce replay cache. If unset, the RPC service falls back to an in-memory cache (single-instance only).
 
 ## Next steps
-1) Close open Phase 2 decisions (asset set, custody boundary, timeouts).
-2) Implement settlement detection and reconciliation loop (worker).
-3) Implement withdrawal execution + insufficient-funds rejection.
-4) Tighten admin scoping (if required) and expand verification coverage.
+1) Phase 3 Sprint 1: implement settlement detection + reconciliation/backfill loop (worker).
+2) Implement withdrawal execution with real node actions + tx evidence persistence.
+3) Implement balance/debit invariants + insufficient-funds gate.
+4) Align CI and runbooks (plugin requests scope + optional system-spec coverage).

--- a/docs/04-research-plan.md
+++ b/docs/04-research-plan.md
@@ -1,49 +1,64 @@
 # Research & Planning Checklist
 
-Reference plan: `docs/plans/2026-02-07-phase2-delivery-plan.md`
+Last updated: 2026-02-11
 
-## Phase 0: Confirm product boundaries
-- [ ] Confirm MVP assets: CKB + which stablecoin UDT (USDI?) (Owner: @Keith-CY, Target: 2026-02-10, Linked Task: Phase2 Task 1)
-- [ ] Confirm custody model for MVP (hosted hub) and risk controls (Owner: @Keith-CY, Target: 2026-02-10, Linked Task: Phase2 Task 1)
-- [ ] Confirm target Discourse version and plugin distribution approach (Owner: @Keith-CY, Target: 2026-02-11, Linked Task: Phase2 Task 9)
+This checklist is now a live TODO board after Phase 2 completion.
 
-## Phase 1: Fiber technical research
-- [ ] Identify Fiber node RPC/API surface for invoice lifecycle (Owner: @Keith-CY, Target: 2026-02-11, Linked Task: Phase2 Task 3)
-- [ ] Determine best settlement detection method (subscribe vs poll) (Owner: @Keith-CY, Target: 2026-02-11, Linked Task: Phase2 Task 5)
-- [ ] Document required operational actions: liquidity management, node monitoring, failure/restart recovery (Owner: @Keith-CY, Target: 2026-02-12, Linked Task: Phase2 Task 10)
+References:
+- Phase 2 status: `docs/06-development-progress.md`
+- Phase 3 Sprint 1 plan: `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md`
+- 3-year strategy: `docs/plans/2026-02-09-3-year-strategy-design.md`
 
-## Phase 2: Service design
-- [ ] API spec (`tip.create`, `tip.status`, `withdrawal.request`, admin endpoints) (Owner: @Keith-CY, Target: 2026-02-12, Linked Task: Phase2 Task 1)
-- [ ] DB schema + invariants (Owner: @Keith-CY, Target: 2026-02-12, Linked Task: Phase2 Task 2)
-- [ ] Idempotency + reconciliation plan (Owner: @Keith-CY, Target: 2026-02-12, Linked Task: Phase2 Task 5)
-- [ ] Security plan (keys, secrets, rate limiting, auth between plugin and service) (Owner: @Keith-CY, Target: 2026-02-12, Linked Task: Phase2 Task 7)
+## Completed Baseline (Done)
 
-## Phase 3: Discourse plugin design
-- [ ] UI/UX mock flow (tip modal, status, dashboard) (Owner: @Keith-CY, Target: 2026-02-13, Linked Task: Phase2 Task 9)
-- [ ] Auth model: plugin-to-service credentialing (Owner: @Keith-CY, Target: 2026-02-12, Linked Task: Phase2 Task 7)
-- [ ] Deployment steps for a demo Discourse instance (Owner: @Keith-CY, Target: 2026-02-13, Linked Task: Phase2 Task 9)
+- [x] Architecture + threat model baseline (`docs/02-architecture.md`, `docs/05-threat-model.md`)
+- [x] Phase 2 implementation (Task 1 to Task 10) merged to `main`
+- [x] Admin role gating in service (`SUPER_ADMIN` + app-scoped `COMMUNITY_ADMIN`)
+- [x] Discourse tip UI + hardened RPC proxy
+- [x] CI verification gate and runbook baseline
+- [x] Service + FNN Docker Compose reference baseline (`docs/runbooks/compose-reference.md`)
+- [x] Scaling decision set locked:
+  - settlement discovery strategy
+  - custody ops controls
+  - USD price feed policy
+  - admin membership model
 
-## Phase 4: Delivery plan (8 weeks per proposal)
-### Milestone 1 (Weeks 1-2): Design + Fiber prototype
-- [x] Architecture + threat model (Completed: 2026-02-03, Evidence: `docs/02-architecture.md`, `docs/05-threat-model.md`)
-- [ ] Hub node on testnet (Owner: @Keith-CY, Target: 2026-02-14, Linked Task: Phase2 Task 3)
-- [x] Backend skeleton + DB schema baseline (Completed: 2026-02-07, Evidence: PR #1)
-- [ ] Demo: invoice -> payment -> ledger credit (Owner: @Keith-CY, Target: 2026-02-16, Linked Task: Phase2 Task 5)
+## Active TODO (Phase 3)
 
-### Milestone 2 (Weeks 3-5): Discourse plugin + end-to-end tipping
-- [ ] Tip UI + modal (Owner: @Keith-CY, Target: 2026-02-18, Linked Task: Phase2 Task 9)
-- [ ] Endpoints for plugin integration (Owner: @Keith-CY, Target: 2026-02-17, Linked Task: Phase2 Task 3)
-- [ ] Payment state updates (Owner: @Keith-CY, Target: 2026-02-18, Linked Task: Phase2 Task 5)
-- [ ] Creator dashboard (Owner: @Keith-CY, Target: 2026-02-19, Linked Task: Phase2 Task 9)
+### Priority 1: Settlement Discovery + Reconciliation (Sprint 1)
 
-### Milestone 3 (Weeks 6-8): Withdrawals + mainnet readiness
-- [ ] Withdrawal flow + admin controls (Owner: @Keith-CY, Target: 2026-02-21, Linked Task: Phase2 Task 6)
-- [ ] Production hardening checklist (Owner: @Keith-CY, Target: 2026-02-22, Linked Task: Phase2 Task 10)
-- [ ] Full docs + demo (Owner: @Keith-CY, Target: 2026-02-23, Linked Task: Phase2 Task 10)
+Owner: `@Keith-CY`  
+Target: 2026-02-18
 
-## Outputs (what we will produce)
-- [x] Architecture diagram(s) (Completed: 2026-02-03, Evidence: `docs/02-architecture.md`)
-- [ ] API spec draft (Owner: @Keith-CY, Target: 2026-02-12, Linked Task: Phase2 Task 1)
-- [x] DB schema draft (Completed: 2026-02-07, Evidence: `fiber-link-service/packages/db/src/schema.ts`)
-- [ ] Risk register + mitigations (Owner: @Keith-CY, Target: 2026-02-12, Linked Task: Phase2 Task 1)
-- [x] Repo structure proposal (Completed: 2026-02-03, Evidence: `docs/02-architecture.md`)
+- [ ] Implement polling-based settlement discovery worker loop
+- [ ] Add reconciliation/backfill command (idempotent replay by app/time window)
+- [ ] Add settlement observability metrics (pending backlog, detection latency, replay count)
+- [ ] Add incident/repair runbook for missed settlement events
+- [ ] Add tests for crash-recovery, duplicate observations, and missed-event backfill
+
+### Priority 2: Withdrawal Execution (Sprint 2)
+
+Owner: `@Keith-CY`  
+Target: 2026-02-25
+
+- [ ] Replace withdrawal executor stub with real node action
+- [ ] Persist execution evidence (for example tx hash) and structured error details
+- [ ] Confirm transient/permanent failure classification with retry contract
+
+### Priority 3: Balance + Debit Invariants (Sprint 3)
+
+Owner: `@Keith-CY`  
+Target: 2026-03-03
+
+- [ ] Implement balance read model: credits - debits by user/app/asset
+- [ ] Enforce insufficient-funds rejection on withdrawal request
+- [ ] Couple debit idempotency to successful withdrawal completion
+
+### Cross-Cutting Ops/Docs
+
+Owner: `@Keith-CY`  
+Target: 2026-02-20
+
+- [ ] Align `docs/runbooks/phase2-verification.md` with CI request-spec scope (`plugins/fiber-link/spec/requests`)
+- [ ] Decide whether plugin system specs are part of CI default gate
+- [ ] Document Year 1 admin membership SOP (`app_admins` grant/revoke + audit trail)

--- a/docs/06-development-progress.md
+++ b/docs/06-development-progress.md
@@ -1,6 +1,6 @@
 # Fiber Link Development Progress
 
-Last updated: 2026-02-09
+Last updated: 2026-02-11
 
 This document summarizes what has shipped so far (Phase 2) and what remains (post-Phase 2 roadmap).
 
@@ -17,6 +17,7 @@ All Phase 2 tasks (Task 1 to Task 10) are now merged into `main` via PRs:
 - PR #7: Admin tRPC wired to DB + role gating (Phase2 Task 8)
 - PR #8: Verification gate (CI + runbook) (Phase2 Task 10)
 - PR #9: Discourse tip UI + hardened RPC proxy + request/system specs (Phase2 Task 9)
+- PR #13: Service + FNN Docker Compose reference deployment baseline
 
 ### Phase 2 Delivered Capabilities
 
@@ -45,17 +46,16 @@ Verification:
 
 Phase 2 intentionally shipped scaffolding + durable state machines + safety rails, but several production-critical behaviors are still placeholders or policy decisions.
 
-### A) Close Open Decisions (Product + Protocol)
+### A) Product/Protocol Baseline Decisions (Locked)
 
-See: `docs/decisions/2026-02-07-phase2-decisions.md`
+Decisions are now explicitly captured and accepted:
+- `docs/decisions/2026-02-10-settlement-discovery-strategy.md` (Option C: Year 1 = polling + backfill baseline)
+- `docs/decisions/2026-02-10-custody-ops-controls.md` (Option A baseline controls + conservative retained balances)
+- `docs/decisions/2026-02-10-usd-price-feed-policy.md` (Option B: primary + secondary + bounded fallback)
+- `docs/decisions/2026-02-10-admin-membership-model.md` (Option A: app-scoped COMMUNITY_ADMIN via `app_admins`)
 
-Open items include:
-- Asset set (CKB + which stablecoin UDT)
-- Custody boundary and required risk controls
-- Invoice timeout/retry contract
-- Withdrawal batching cadence/targets
-
-These decisions should be closed before implementing withdrawal execution and settlement detection, otherwise the code will bake in the wrong contract.
+Remaining policy item to finalize in implementation tickets:
+- concrete MVP asset tuple (CKB + selected stablecoin UDT symbol/id in code/config)
 
 ### B) Settlement Detection Worker (Not Yet Implemented)
 
@@ -90,17 +90,15 @@ Next work:
   - withdrawal request validation (reject insufficient funds)
   - debit idempotency and coupling to withdrawal completion
 
-### E) Admin Data Scoping (Needs Product Confirmation)
+### E) Admin Data Scoping (Policy Chosen, Ops Path Still Needed)
 
 Current state:
 - Admin routers allow `SUPER_ADMIN` and `COMMUNITY_ADMIN`.
 - `SUPER_ADMIN` can list all apps and withdrawals.
 - `COMMUNITY_ADMIN` is scoped by app membership via `app_admins` (requires `adminUserId` in admin tRPC context).
 
-Open question:
-- What is the intended admin model for MVP (app-scoped vs community-scoped vs global)?
-  - If app-scoped: define how `app_admins` memberships are managed and mapped to BetterAuth identity.
-  - If community-scoped/global: update schema and queries accordingly.
+Open implementation question:
+- How are `app_admins` memberships managed operationally in Year 1 (seed script vs SUPER_ADMIN endpoint) and audited?
 
 ### F) CI/Runbook Alignment and Coverage
 
@@ -114,9 +112,10 @@ Next work:
 
 ## Suggested Next Milestone (Phase 3)
 
-Deliver a production-aligned end-to-end money movement milestone:
+Phase 3 should start with a narrow Sprint 1 focused on settlement discovery reliability, then expand to execution/debit flows.
 
-- Close open decisions (asset set, custody/risk controls, timeouts)
-- Add settlement detection + reconciliation loop
-- Implement withdrawal execution + balance debits + insufficient-funds rejections
-- Tighten admin scoping if required
+- Sprint 1 (next): settlement polling + reconciliation/backfill loop, with operational metrics/runbook.
+- Sprint 2: real withdrawal execution + failure classification + tx evidence persistence.
+- Sprint 3: balance/debit invariants and insufficient-funds gate.
+
+Detailed next plan: `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md`

--- a/docs/decisions/2026-02-07-phase2-decisions.md
+++ b/docs/decisions/2026-02-07-phase2-decisions.md
@@ -4,6 +4,13 @@ Date: 2026-02-07
 Owner: @Keith-CY
 Reference plan: `docs/plans/2026-02-07-phase2-delivery-plan.md`
 
+Note (2026-02-11): this file is a historical Phase 2 draft register.  
+Current decision source-of-truth is the accepted one-page records:
+- `docs/decisions/2026-02-10-settlement-discovery-strategy.md`
+- `docs/decisions/2026-02-10-custody-ops-controls.md`
+- `docs/decisions/2026-02-10-usd-price-feed-policy.md`
+- `docs/decisions/2026-02-10-admin-membership-model.md`
+
 ## Decision register
 
 ### Asset set

--- a/docs/decisions/2026-02-10-admin-membership-model.md
+++ b/docs/decisions/2026-02-10-admin-membership-model.md
@@ -1,9 +1,11 @@
 # Decision: Admin Membership Model (BetterAuth -> app_admins)
 
-Date: 2026-02-10 (scheduled)
+Date: 2026-02-10
 Owner: Fiber Link
-Status: OPEN
+Status: ACCEPTED (2026-02-11)
 Related: `docs/plans/2026-02-09-3-year-strategy-design.md`
+
+Decision outcome: Option A is accepted (`SUPER_ADMIN` global + `COMMUNITY_ADMIN` scoped by `app_admins` via BetterAuth identity), with Year 1 manual-auditable membership management.
 
 ## Decision
 

--- a/docs/decisions/2026-02-10-custody-ops-controls.md
+++ b/docs/decisions/2026-02-10-custody-ops-controls.md
@@ -1,9 +1,11 @@
 # Decision: Custody Ops Controls (Hosted Hub)
 
-Date: 2026-02-10 (scheduled)
+Date: 2026-02-10
 Owner: Fiber Link
-Status: OPEN
+Status: ACCEPTED (2026-02-11)
 Related: `docs/plans/2026-02-09-3-year-strategy-design.md`
+
+Decision outcome: Option A is accepted as Year 1 baseline controls, with one Option C bias (conservative retained balances and smaller, more frequent withdrawals).
 
 ## Decision
 

--- a/docs/decisions/2026-02-10-settlement-discovery-strategy.md
+++ b/docs/decisions/2026-02-10-settlement-discovery-strategy.md
@@ -1,9 +1,11 @@
 # Decision: Settlement Discovery Strategy (Poll vs Subscribe vs Hybrid)
 
-Date: 2026-02-10 (scheduled)
+Date: 2026-02-10
 Owner: Fiber Link
-Status: OPEN
+Status: ACCEPTED (2026-02-11)
 Related: `docs/plans/2026-02-09-3-year-strategy-design.md`
+
+Decision outcome: Option C (hybrid) is accepted; Year 1 implementation baseline is polling + periodic backfill, with subscription as an optional latency optimization after stability validation.
 
 ## Decision
 

--- a/docs/decisions/2026-02-10-usd-price-feed-policy.md
+++ b/docs/decisions/2026-02-10-usd-price-feed-policy.md
@@ -1,9 +1,11 @@
 # Decision: USD Price Feed Policy (Snapshots at Withdrawal Completion)
 
-Date: 2026-02-10 (scheduled)
+Date: 2026-02-10
 Owner: Fiber Link
-Status: OPEN
+Status: ACCEPTED (2026-02-11)
 Related: `docs/plans/2026-02-09-3-year-strategy-design.md`
+
+Decision outcome: Option B (primary + secondary + bounded cached fallback + null-snapshot backfill) is accepted for Year 1.
 
 ## Decision
 

--- a/docs/plans/2026-02-09-3-year-strategy-design.md
+++ b/docs/plans/2026-02-09-3-year-strategy-design.md
@@ -188,9 +188,9 @@ Must-win themes:
 - Complex multi-chain asset routing in Year 1
 - Heavy rule engines before the core state machine is stable
 
-## Open Questions That Block Scaling
+## Scaling Decisions (Locked)
 
-This section is tracked as 4 short decision records (1 page each):
+This section is tracked as 4 short decision records (1 page each), now accepted for Year 1 baseline:
 
 - Custody ops controls (hosted hub): `docs/decisions/2026-02-10-custody-ops-controls.md`
 - Admin membership model (BetterAuth identity -> app_admins): `docs/decisions/2026-02-10-admin-membership-model.md`

--- a/docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md
+++ b/docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md
@@ -1,0 +1,73 @@
+# Phase 3 Sprint 1 Plan: Settlement Detection v1
+
+Date: 2026-02-11  
+Owner: Fiber Link  
+Status: Planned
+
+## Goal
+
+Ship a durable settlement discovery path that can recover missed events without double-crediting:
+- discover settled invoices via polling
+- reconcile/backfill safely after outages
+- make settlement backlog visible operationally
+
+This sprint is intentionally narrow. It does not include real withdrawal execution or balance debit gating.
+
+## Scope
+
+In scope:
+- polling worker loop for unpaid/pending tip intents
+- settlement status fetch and transition handling
+- idempotent crediting using existing settlement/ledger invariants
+- reconciliation/backfill command by app/time window
+- observability metrics + runbook updates
+
+Out of scope:
+- subscription/event-stream settlement path
+- withdrawal executor implementation
+- pricing snapshot implementation
+
+## Implementation Work Items
+
+1. Discovery loop
+- Add worker entry flow that periodically scans pending invoices and fetches invoice status.
+- Define polling interval + batch size via env.
+
+2. State transitions
+- For settled invoices: call settlement credit path (already idempotent).
+- For expired/failed invoices: move to terminal non-credited state.
+- For still-pending invoices: keep pending and recheck later.
+
+3. Reconciliation/backfill
+- Add CLI/job: replay settlement detection for `appId` + `[from,to]` window.
+- Guarantee safe re-run behavior (no double credit, deterministic end state).
+
+4. Observability
+- Emit metrics/logs:
+  - pending invoice backlog
+  - settlement detection latency
+  - replay/backfill processed count
+  - settlement credit dedupe count
+
+5. Runbook
+- Add operational playbook:
+  - detect backlog growth
+  - trigger backfill command
+  - verify repaired state
+
+## Verification Gate
+
+Required before merge:
+- Unit/integration tests:
+  - duplicate settlement observations do not double-credit
+  - worker restart/crash does not lose eventual crediting
+  - backfill command is idempotent
+- Existing worker test suite passes.
+- Runbook contains exact recovery steps for missed settlement events.
+
+## Exit Criteria
+
+Sprint 1 is complete when:
+- settlement events are discoverable without manual SQL edits in normal failures
+- missed events can be repaired with a documented backfill command
+- operators can observe backlog/latency and know when recovery is needed


### PR DESCRIPTION
## Summary
- align planning docs with actual post-Phase-2 state
- lock the four Year-1 scaling decisions as accepted and mark old phase2 decision register as historical
- define a concrete next step via a new Phase 3 Sprint 1 settlement-detection plan

## What changed
- update progress snapshot and roadmap in `docs/06-development-progress.md`
- rewrite `docs/04-research-plan.md` into a live TODO board for Phase 3 priorities
- add `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md`
- update `README.md` docs index + next steps
- mark decision docs as `ACCEPTED`:
  - `docs/decisions/2026-02-10-settlement-discovery-strategy.md`
  - `docs/decisions/2026-02-10-custody-ops-controls.md`
  - `docs/decisions/2026-02-10-usd-price-feed-policy.md`
  - `docs/decisions/2026-02-10-admin-membership-model.md`
- mark `docs/decisions/2026-02-07-phase2-decisions.md` as historical/superseded context

## Verification
- `bash deploy/compose/compose-reference.test.sh`
- `rg -n "Status: ACCEPTED|Last updated: 2026-02-11|Phase 3 Sprint 1" docs README.md`
