### PR TITLE
feat: add settlement observability metrics and sprint1 sync

### DIFF
--- a/docs/04-research-plan.md
+++ b/docs/04-research-plan.md
@@ -1,6 +1,6 @@
 # Research & Planning Checklist
 
-Last updated: 2026-02-11
+Last updated: 2026-02-12
 
 This checklist is now a live TODO board after Phase 2 completion.
 
@@ -30,11 +30,11 @@ References:
 Owner: `@Keith-CY`  
 Target: 2026-02-18
 
-- [ ] Implement polling-based settlement discovery worker loop
-- [ ] Add reconciliation/backfill command (idempotent replay by app/time window)
-- [ ] Add settlement observability metrics (pending backlog, detection latency, replay count)
-- [ ] Add incident/repair runbook for missed settlement events
-- [ ] Add tests for crash-recovery, duplicate observations, and missed-event backfill
+- [x] Implement polling-based settlement discovery worker loop
+- [x] Add reconciliation/backfill command (idempotent replay by app/time window)
+- [x] Add settlement observability metrics (pending backlog, detection latency, replay count)
+- [x] Add incident/repair runbook for missed settlement events
+- [x] Add tests for crash-recovery, duplicate observations, and missed-event backfill
 
 ### Priority 2: Withdrawal Execution (Sprint 2)
 

--- a/docs/06-development-progress.md
+++ b/docs/06-development-progress.md
@@ -1,6 +1,6 @@
 # Fiber Link Development Progress
 
-Last updated: 2026-02-11
+Last updated: 2026-02-12
 
 This document summarizes what has shipped so far (Phase 2) and what remains (post-Phase 2 roadmap).
 
@@ -57,16 +57,20 @@ Decisions are now explicitly captured and accepted:
 Remaining policy item to finalize in implementation tickets:
 - concrete MVP asset tuple (CKB + selected stablecoin UDT symbol/id in code/config)
 
-### B) Settlement Detection Worker (Not Yet Implemented)
+### B) Settlement Detection Worker (Implemented in Sprint 1)
 
-Current state:
-- The worker has a settlement entrypoint (`fiber-link-service/apps/worker/src/settlement.ts`) that can credit once given `{ invoice }`.
+Delivered:
+- Polling-based settlement discovery loop in worker runtime (`fiber-link-service/apps/worker/src/worker-runtime.ts`, `fiber-link-service/apps/worker/src/settlement-discovery.ts`).
+- Reconciliation/backfill command with app/time window filters (`fiber-link-service/apps/worker/src/scripts/backfill-settlements.ts`).
+- Idempotent replay behavior preserved through settlement credit invariants (`fiber-link-service/apps/worker/src/settlement.ts`).
+- Cursor-based scan progression to avoid fixed-limit starvation of newer unpaid invoices (`fiber-link-service/apps/worker/src/entry.ts`, `fiber-link-service/packages/db/src/tip-intent-repo.ts`).
+- Settlement observability fields in discovery summaries:
+  - pending backlog before/after scan
+  - detection latency (p50/p95/max)
+  - replay/scan counts
 
-Missing:
-- A durable mechanism to discover invoice settlement events:
-  - polling Fiber node invoice status
-  - subscription/event stream (if available)
-  - reconciliation/backfill loop for missed events
+Remaining optimization (non-blocking):
+- Event-subscription path for lower latency once upstream interface stability is proven.
 
 ### C) Withdrawal Execution (Still Stubbed)
 
@@ -112,10 +116,9 @@ Next work:
 
 ## Suggested Next Milestone (Phase 3)
 
-Phase 3 should start with a narrow Sprint 1 focused on settlement discovery reliability, then expand to execution/debit flows.
+Phase 3 Sprint 1 is complete (settlement polling/replay/observability baseline). Next work should move to execution/debit flows.
 
-- Sprint 1 (next): settlement polling + reconciliation/backfill loop, with operational metrics/runbook.
-- Sprint 2: real withdrawal execution + failure classification + tx evidence persistence.
+- Sprint 2 (next): real withdrawal execution + failure classification + tx evidence persistence.
 - Sprint 3: balance/debit invariants and insufficient-funds gate.
 
 Detailed next plan: `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md`

--- a/docs/runbooks/settlement-recovery.md
+++ b/docs/runbooks/settlement-recovery.md
@@ -42,13 +42,23 @@ Expected output shape:
     "settledDuplicates": 1,
     "failed": 2,
     "stillUnpaid": 36,
-    "errors": 0
+    "errors": 0,
+    "backlogUnpaidBeforeScan": 42,
+    "backlogUnpaidAfterScan": 38,
+    "detectionLatencyMs": {
+      "count": 4,
+      "p50": 84500,
+      "p95": 126000,
+      "max": 126000
+    }
   }
 }
 ```
 
 Notes:
 - `settledDuplicates > 0` is expected during replays; this indicates idempotent no-op credits.
+- `backlogUnpaidBeforeScan - backlogUnpaidAfterScan` shows how much backlog was cleared in the run.
+- `detectionLatencyMs` is computed from tip-intent creation time to discovery time for settled invoices in this run.
 - Command is safe to re-run for the same window.
 
 ## 2) Verify repaired state


### PR DESCRIPTION
## Summary
- add settlement observability metrics to discovery summary: backlog before/after scan and detection latency (p50/p95/max)
- add `countByInvoiceState` to tip-intent repo (db + in-memory) and use it for backlog measurement
- update Sprint 1 tracking docs/runbook to reflect completed settlement discovery + reconciliation + observability scope

## Test Plan
- `cd fiber-link-service/packages/db && bun run test -- --run --silent`
- `cd fiber-link-service/apps/worker && bun run test -- --run --silent`
- `bash deploy/compose/compose-reference.test.sh`
