### PR TITLE
feat: phase3 sprint2 withdrawal execution baseline

### DIFF
--- a/deploy/compose/postgres/init/001_schema.sql
+++ b/deploy/compose/postgres/init/001_schema.sql
@@ -81,7 +81,8 @@ CREATE TABLE IF NOT EXISTS withdrawals (
   last_error TEXT,
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-  completed_at TIMESTAMP
+  completed_at TIMESTAMP,
+  tx_hash TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_tip_intents_invoice_state ON tip_intents(invoice_state);

--- a/docs/04-research-plan.md
+++ b/docs/04-research-plan.md
@@ -41,9 +41,9 @@ Target: 2026-02-18
 Owner: `@Keith-CY`  
 Target: 2026-02-25
 
-- [ ] Replace withdrawal executor stub with real node action
-- [ ] Persist execution evidence (for example tx hash) and structured error details
-- [ ] Confirm transient/permanent failure classification with retry contract
+- [x] Replace withdrawal executor stub with real node action
+- [x] Persist execution evidence (for example tx hash) and structured error details
+- [x] Confirm transient/permanent failure classification with retry contract
 
 ### Priority 3: Balance + Debit Invariants (Sprint 3)
 

--- a/docs/06-development-progress.md
+++ b/docs/06-development-progress.md
@@ -72,15 +72,17 @@ Delivered:
 Remaining optimization (non-blocking):
 - Event-subscription path for lower latency once upstream interface stability is proven.
 
-### C) Withdrawal Execution (Still Stubbed)
+### C) Withdrawal Execution (Implemented Baseline in Sprint 2)
 
-Current state:
-- Withdrawals are persisted and the batch runner can claim and transition records with retry metadata.
-- The actual execution function defaults to `ok: true` and must be replaced with real on-chain/Hub actions.
+Delivered:
+- Worker default executor now invokes Fiber node RPC via adapter (`send_payment`) instead of returning `ok: true` stub (`fiber-link-service/apps/worker/src/withdrawal-batch.ts`, `fiber-link-service/packages/fiber-adapter/src/index.ts`).
+- Completed withdrawals persist execution evidence via `tx_hash` / `txHash` (`fiber-link-service/packages/db/src/schema.ts`, `fiber-link-service/packages/db/src/withdrawal-repo.ts`).
+- Retry classification now distinguishes transient vs permanent execution failures using RPC code/message heuristics (`fiber-link-service/apps/worker/src/withdrawal-batch.ts`).
+- Admin withdrawal listing includes `txHash` for operational traceability (`fiber-link-service/apps/admin/src/server/api/routers/withdrawal.ts`).
 
-Next work:
-- Implement execution via the Fiber adapter / node RPC.
-- Capture permanent vs transient failures correctly and record tx hash / error details.
+Remaining follow-up:
+- Replace heuristic classification with explicit Fiber error contract mapping once upstream error taxonomy is stabilized.
+- Confirm long-term destination semantics (`toAddress` vs payment request) before plugin withdrawal UI rollout.
 
 ### D) Balance + Insufficient Funds Gate (Not Yet Implemented)
 
@@ -116,9 +118,8 @@ Next work:
 
 ## Suggested Next Milestone (Phase 3)
 
-Phase 3 Sprint 1 is complete (settlement polling/replay/observability baseline). Next work should move to execution/debit flows.
+Phase 3 Sprint 1 and Sprint 2 baselines are complete. Next work should move to debit invariants and request-time balance controls.
 
-- Sprint 2 (next): real withdrawal execution + failure classification + tx evidence persistence.
-- Sprint 3: balance/debit invariants and insufficient-funds gate.
+- Sprint 3 (next): balance/debit invariants and insufficient-funds gate.
 
 Detailed next plan: `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md`

--- a/fiber-link-service/apps/admin/src/server/api/routers/withdrawal.test.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/withdrawal.test.ts
@@ -21,6 +21,7 @@ function createDbMock({
     createdAt: Date;
     updatedAt: Date;
     completedAt: Date | null;
+    txHash: string | null;
   }>;
   appAdminsRows: Array<{ appId: string; adminUserId: string }>;
 }): DbClient {
@@ -77,6 +78,7 @@ describe("withdrawal router", () => {
         createdAt: now,
         updatedAt: now,
         completedAt: null,
+        txHash: null,
       },
     ];
     const db = createDbMock({ withdrawalsRows: rows, appAdminsRows: [] });
@@ -105,6 +107,7 @@ describe("withdrawal router", () => {
         createdAt: now,
         updatedAt: now,
         completedAt: null,
+        txHash: null,
       },
       {
         id: "w2",
@@ -120,6 +123,7 @@ describe("withdrawal router", () => {
         createdAt: now,
         updatedAt: now,
         completedAt: null,
+        txHash: null,
       },
     ];
     const db = createDbMock({

--- a/fiber-link-service/apps/admin/src/server/api/routers/withdrawal.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/withdrawal.ts
@@ -23,6 +23,7 @@ export const withdrawalRouter = t.router({
       createdAt: true,
       updatedAt: true,
       completedAt: true,
+      txHash: true,
     } as const;
 
     if (ctx.role === "SUPER_ADMIN") {

--- a/fiber-link-service/packages/db/src/schema.ts
+++ b/fiber-link-service/packages/db/src/schema.ts
@@ -72,4 +72,5 @@ export const withdrawals = pgTable("withdrawals", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
   completedAt: timestamp("completed_at"),
+  txHash: text("tx_hash"),
 });


### PR DESCRIPTION
## Summary
- replace worker withdrawal stub with Fiber RPC execution (`send_payment`) and persist execution evidence (`txHash`)
- add retry classification for withdrawal execution errors (transient vs permanent) and wire it into batch transitions
- extend withdrawal schema/repo/admin output to include `txHash`, and sync Phase 3 docs to mark Sprint 2 baseline complete

## Test Plan
- `cd fiber-link-service/packages/fiber-adapter && bun run test -- --run --silent`
- `cd fiber-link-service/packages/db && bun run test -- --run --silent`
- `cd fiber-link-service/apps/worker && bun run test -- --run --silent`
- `cd fiber-link-service/apps/admin && bun run test -- --run --silent`
- `bash deploy/compose/compose-reference.test.sh`
- `POSTGRES_PASSWORD=test-pass FIBER_LINK_HMAC_SECRET=test-hmac FNN_ASSET_SHA256=testsha FIBER_SECRET_KEY_PASSWORD=test-key docker compose --env-file deploy/compose/.env.example -f deploy/compose/docker-compose.yml config >/tmp/compose-config-s2.out`
