### PR TITLE
docs: sync roadmap/progress after Phase 3 Sprint 2 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Primary reference thread:
 - `docs/runbooks/phase2-verification.md` — Phase 2 verification gate (happy path + failure path)
 - `docs/runbooks/compose-reference.md` — Docker Compose reference (service + FNN)
 - `docs/runbooks/settlement-recovery.md` — settlement replay/backfill recovery operations
-- `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md` — next implementation plan (Phase 3 Sprint 1)
+- `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md` — historical Sprint 1 implementation plan (settlement v1 baseline)
 
 ## Configuration (service)
 Environment variables used by the Fiber Link service:

--- a/docs/06-development-progress.md
+++ b/docs/06-development-progress.md
@@ -127,4 +127,6 @@ Phase 3 Sprint 1 and Sprint 2 baselines are complete. Next work should move to d
 
 - Sprint 3 (next): balance/debit invariants and insufficient-funds gate.
 
-Detailed next plan: `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md`
+Historical reference (Sprint 1 plan): `docs/plans/2026-02-11-phase3-sprint1-settlement-v1-plan.md`
+
+Next plan for Sprint 3 balance/debit invariants is TBD and should be added as a dedicated Sprint 3 plan doc.


### PR DESCRIPTION
## Summary
Sync docs to match the current merged implementation status after Phase 3 Sprint 2 baseline.

## Updated
- `README.md`
  - refresh **Next steps** to Sprint 3+ priorities (remove outdated Sprint 1/2 action items)
- `docs/04-research-plan.md`
  - mark Sprint 2 withdrawal execution checklist items as completed
- `docs/06-development-progress.md`
  - update withdrawal section from "still stubbed" to delivered Sprint 2 baseline
  - add recent Phase 3 baseline delivery references (PR #15/#16/#17)
  - move next milestone to Sprint 3

## Why
Recent merged PRs already delivered:
- settlement polling/replay + observability (Sprint 1)
- withdrawal execution + tx evidence + retry classification (Sprint 2)

This PR removes stale status text so roadmap and runbooks reflect current reality.
