### PR TITLE
Refactor Kanban project ID resolver and document fallback precedence

### DIFF
--- a/.github/scripts/kanban-project-id.js
+++ b/.github/scripts/kanban-project-id.js
@@ -1,0 +1,98 @@
+// Keep this in sync with docs/runbooks/kanban-project-id.md.
+const DEFAULT_PROJECT_ID = 'PVT_kwHOAG7zoc4BPPlp';
+
+const sanitizeProjectIdValue = (value) => String(value || '').trim().replace(/^["']|["']$/g, '');
+
+const USER_OR_ORG_PROJECT_URL = /^https?:\/\/github\.com\/(users|orgs)\/([^/]+)\/projects\/(\d+)(?:[/?#].*)?$/i;
+const REPO_PROJECT_URL = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/projects\/(\d+)(?:[/?#].*)?$/i;
+
+async function resolveProjectId(candidate, options = {}) {
+  const raw = sanitizeProjectIdValue(candidate);
+  const { graphql, log = () => {} } = options;
+
+  if (!raw) {
+    return '';
+  }
+
+  if (/^PVT_[A-Za-z0-9_]+$/.test(raw) || /^PD_[A-Za-z0-9_]+$/.test(raw)) {
+    return raw;
+  }
+
+  if (typeof graphql !== 'function') {
+    return raw;
+  }
+
+  const userOrOrgProject = raw.match(USER_OR_ORG_PROJECT_URL);
+  if (userOrOrgProject) {
+    const [, scope, login, number] = userOrOrgProject;
+    const num = Number.parseInt(number, 10);
+    if (!Number.isFinite(num)) {
+      return raw;
+    }
+
+    try {
+      const query =
+        scope === 'users'
+          ? 'query($login: String!, $number: Int!) { user(login: $login) { projectV2(number: $number) { id } } }'
+          : 'query($login: String!, $number: Int!) { organization(login: $login) { projectV2(number: $number) { id } } }';
+      const response = await graphql(query, { login, number: num });
+      const node = scope === 'users' ? response?.user?.projectV2 : response?.organization?.projectV2;
+      if (node?.id) {
+        return node.id;
+      }
+    } catch (error) {
+      log(`Could not resolve project URL "${raw}" via GraphQL: ${error?.message || error}`);
+    }
+
+    return '';
+  }
+
+  const repoProject = raw.match(REPO_PROJECT_URL);
+  if (repoProject) {
+    const [, owner, repo, number] = repoProject;
+    const num = Number.parseInt(number, 10);
+    if (!Number.isFinite(num)) {
+      return raw;
+    }
+
+    try {
+      const response = await graphql(
+        `query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            projectV2(number: $number) {
+              id
+            }
+          }
+        }`,
+        { owner, repo, number: num }
+      );
+      if (response?.repository?.projectV2?.id) {
+        return response.repository.projectV2.id;
+      }
+    } catch (error) {
+      log(`Could not resolve repo project URL "${raw}" via GraphQL: ${error?.message || error}`);
+    }
+
+    return '';
+  }
+
+  return raw;
+}
+
+async function resolveProjectIdFromCandidates(candidates, options = {}) {
+  for (const candidate of candidates) {
+    const resolved = await resolveProjectId(candidate, options);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return '';
+}
+
+module.exports = {
+  DEFAULT_PROJECT_ID,
+  sanitizeProjectIdValue,
+  resolveProjectId,
+  resolveProjectIdFromCandidates,
+};

--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
       - name: Sync issue/pr to Projects Kanban
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
@@ -24,87 +30,16 @@ jobs:
         with:
           github-token: ${{ secrets.FIBER_LINK_PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
-            const sanitizeProjectIdValue = (value) => String(value || '').trim().replace(/^["']|["']$/g, '');
-            const defaultProjectId = 'PVT_kwHOAG7zoc4BPPlp';
-
-            const resolveProjectId = async (candidate) => {
-              const raw = sanitizeProjectIdValue(candidate);
-              if (!raw) {
-                return '';
-              }
-              if (/^PVT_[A-Za-z0-9_]+$/.test(raw) || /^PD_[A-Za-z0-9_]+$/.test(raw)) {
-                return raw;
-              }
-
-              const userOrOrgProject = raw.match(/^https?:\/\/github\.com\/(users|orgs)\/([^/]+)\/projects\/(\d+)(?:[/?#].*)?$/i);
-              if (userOrOrgProject) {
-                const [, scope, login, number] = userOrOrgProject;
-                const num = Number.parseInt(number, 10);
-                if (!Number.isFinite(num)) {
-                  return raw;
-                }
-
-                try {
-                  const query = scope === 'users'
-                    ? `query($login: String!, $number: Int!) { user(login: $login) { projectV2(number: $number) { id } } }`
-                    : `query($login: String!, $number: Int!) { organization(login: $login) { projectV2(number: $number) { id } } }`;
-                  const response = await github.graphql(query, { login, number: num });
-                  const node = scope === 'users' ? response?.user?.projectV2 : response?.organization?.projectV2;
-                  if (node?.id) {
-                    return node.id;
-                  }
-                } catch (error) {
-                  core.info(`Could not resolve project URL "${raw}" via GraphQL: ${error?.message || error}`);
-                }
-
-                return '';
-              }
-
-              const repoProject = raw.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/projects\/(\d+)(?:[/?#].*)?$/i);
-              if (repoProject) {
-                const [, owner, repo, number] = repoProject;
-                const num = Number.parseInt(number, 10);
-                if (!Number.isFinite(num)) {
-                  return raw;
-                }
-
-                try {
-                  const response = await github.graphql(
-                    `query($owner: String!, $repo: String!, $number: Int!) {
-                      repository(owner: $owner, name: $repo) {
-                        projectV2(number: $number) {
-                          id
-                        }
-                      }
-                    }`,
-                    { owner, repo, number: num }
-                  );
-                  if (response?.repository?.projectV2?.id) {
-                    return response.repository.projectV2.id;
-                  }
-                } catch (error) {
-                  core.info(`Could not resolve repo project URL "${raw}" via GraphQL: ${error?.message || error}`);
-                }
-
-                return '';
-              }
-
-              return raw;
-            };
-
+            const { DEFAULT_PROJECT_ID, resolveProjectIdFromCandidates } = require('./.github/scripts/kanban-project-id');
             const resolveProjectCandidates = [
               process.env.FIBER_LINK_PROJECT_ID,
               process.env.FIBER_LINK_CANONICAL_PROJECT_ID,
-              defaultProjectId,
+              DEFAULT_PROJECT_ID,
             ];
-            let projectId = '';
-            for (const candidate of resolveProjectCandidates) {
-              const resolved = await resolveProjectId(candidate);
-              if (resolved) {
-                projectId = resolved;
-                break;
-              }
-            }
+            const projectId = await resolveProjectIdFromCandidates(resolveProjectCandidates, {
+              graphql: github.graphql,
+              log: (message) => core.info(message),
+            });
             const ghClient = github;
             const statusFieldNames = ['Status', '状态'];
             const fieldAliases = {

--- a/.github/workflows/carrier-kanban-operations.yml
+++ b/.github/workflows/carrier-kanban-operations.yml
@@ -33,78 +33,12 @@ jobs:
           github-token: ${{ secrets.FIBER_LINK_PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
+            const { DEFAULT_PROJECT_ID, resolveProjectIdFromCandidates } = require('./.github/scripts/kanban-project-id');
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const dryRunInput = String((context.payload.inputs?.dry_run || process.env.DRY_RUN || 'false')).toLowerCase() === 'true';
             const ghClient = github;
-            const defaultProjectId = 'PVT_kwHOAG7zoc4BPPlp';
-            const sanitizeProjectIdValue = (value) => String(value || '').trim().replace(/^["']|["']$/g, '');
-
-            const resolveProjectId = async (candidate) => {
-              const raw = sanitizeProjectIdValue(candidate);
-              if (!raw) {
-                return '';
-              }
-              if (/^PVT_[A-Za-z0-9_]+$/.test(raw) || /^PD_[A-Za-z0-9_]+$/.test(raw)) {
-                return raw;
-              }
-
-              const userOrOrgProject = raw.match(/^https?:\/\/github\.com\/(users|orgs)\/([^/]+)\/projects\/(\d+)(?:[/?#].*)?$/i);
-              if (userOrOrgProject) {
-                const [, scope, login, number] = userOrOrgProject;
-                const num = Number.parseInt(number, 10);
-                if (!Number.isFinite(num)) {
-                  return raw;
-                }
-
-                try {
-                  const query = scope === 'users'
-                    ? `query($login: String!, $number: Int!) { user(login: $login) { projectV2(number: $number) { id } } }`
-                    : `query($login: String!, $number: Int!) { organization(login: $login) { projectV2(number: $number) { id } } }`;
-                  const response = await ghClient.graphql(query, { login, number: num });
-                  const node = scope === 'users' ? response?.user?.projectV2 : response?.organization?.projectV2;
-                  if (node?.id) {
-                    return node.id;
-                  }
-                } catch (error) {
-                  core.info(`Could not resolve project URL "${raw}" via GraphQL: ${error?.message || error}`);
-                }
-
-                return '';
-              }
-
-              const repoProject = raw.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/projects\/(\d+)(?:[/?#].*)?$/i);
-              if (repoProject) {
-                const [, ownerName, repoName, number] = repoProject;
-                const num = Number.parseInt(number, 10);
-                if (!Number.isFinite(num)) {
-                  return raw;
-                }
-
-                try {
-                  const response = await ghClient.graphql(
-                    `query($owner: String!, $repo: String!, $number: Int!) {
-                      repository(owner: $owner, name: $repo) {
-                        projectV2(number: $number) {
-                          id
-                        }
-                      }
-                    }`,
-                    { owner: ownerName, repo: repoName, number: num }
-                  );
-                  if (response?.repository?.projectV2?.id) {
-                    return response.repository.projectV2.id;
-                  }
-                } catch (error) {
-                  core.info(`Could not resolve repo project URL "${raw}" via GraphQL: ${error?.message || error}`);
-                }
-
-                return '';
-              }
-
-              return raw;
-            };
 
             let repoMeta = null;
             try {
@@ -137,16 +71,12 @@ jobs:
               process.env.FIBER_LINK_PROJECT_ID,
               process.env.FIBER_LINK_CANONICAL_PROJECT_ID,
               config.projectId,
-              defaultProjectId,
+              DEFAULT_PROJECT_ID,
             ];
-            let projectId = '';
-            for (const candidate of projectCandidates) {
-              const resolved = await resolveProjectId(candidate);
-              if (resolved) {
-                projectId = resolved;
-                break;
-              }
-            }
+            const projectId = await resolveProjectIdFromCandidates(projectCandidates, {
+              graphql: ghClient.graphql,
+              log: (message) => core.info(message),
+            });
 
             if (!projectId) {
               core.setFailed('Missing projectId. Set vars.FIBER_LINK_CANONICAL_PROJECT_ID, FIBER_LINK_PROJECT_ID secret, or ensure .github/kanban-config.json contains projectId.');

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,10 @@
 
 - `docs/runbooks/testnet-bootstrap.md` — deterministic precheck -> spin-up -> RPC validation -> invoice smoke -> cleanup flow.
 
+## Kanban operations
+
+- `docs/runbooks/kanban-project-id.md` — project ID resolution order, fallback ID ownership, and rotation procedure.
+
 ### Request-spec coverage tracked in CI
 
 The CI `plugin-smoke` job runs:

--- a/docs/runbooks/kanban-project-id.md
+++ b/docs/runbooks/kanban-project-id.md
@@ -1,0 +1,48 @@
+# Kanban Project ID Resolution
+
+This runbook documents how the Kanban workflows resolve `projectId`, including the fallback ID used for recovery.
+
+## Workflows
+
+- `.github/workflows/carrier-kanban-automation.yml`
+- `.github/workflows/carrier-kanban-operations.yml`
+
+Both workflows use the shared helper:
+
+- `.github/scripts/kanban-project-id.js`
+
+## Resolution order
+
+`carrier-kanban-automation.yml` checks candidates in this order:
+
+1. `secrets.FIBER_LINK_PROJECT_ID`
+2. `vars.FIBER_LINK_CANONICAL_PROJECT_ID`
+3. hardcoded fallback `DEFAULT_PROJECT_ID` (`PVT_kwHOAG7zoc4BPPlp`)
+
+`carrier-kanban-operations.yml` checks candidates in this order:
+
+1. `secrets.FIBER_LINK_PROJECT_ID`
+2. `vars.FIBER_LINK_CANONICAL_PROJECT_ID`
+3. `.github/kanban-config.json` -> `projectId`
+4. hardcoded fallback `DEFAULT_PROJECT_ID` (`PVT_kwHOAG7zoc4BPPlp`)
+
+## When to rotate/update
+
+Rotate/update project ID sources when one of these happens:
+
+- Kanban board moved to a new GitHub ProjectV2.
+- Existing ProjectV2 ID is archived, deleted, or inaccessible.
+- Ownership moved to another user/org/repo scope.
+
+## Rotation procedure
+
+1. Update `vars.FIBER_LINK_CANONICAL_PROJECT_ID` in repository variables.
+2. Update `.github/kanban-config.json` `projectId`.
+3. Update `DEFAULT_PROJECT_ID` in `.github/scripts/kanban-project-id.js`.
+4. Run `carrier-kanban-operations.yml` with `dry_run=true` and verify project lookup succeeds.
+5. Trigger or wait for `carrier-kanban-automation.yml` and verify item sync succeeds.
+
+## Notes
+
+- URL candidates like `https://github.com/orgs/<org>/projects/<number>` are supported and resolved to node IDs via GraphQL.
+- If no candidate resolves, automation skips sync and operations marks the run failed with explicit guidance.


### PR DESCRIPTION
## Summary
- extract ProjectV2 ID resolution into shared helper `.github/scripts/kanban-project-id.js`
- update `carrier-kanban-automation.yml` and `carrier-kanban-operations.yml` to reuse the helper instead of duplicating resolver logic
- document fallback project ID precedence and rotation steps in `docs/runbooks/kanban-project-id.md` and index it in `docs/README.md`

## Validation
- `node -e "const m=require('./.github/scripts/kanban-project-id.js'); if(!m.DEFAULT_PROJECT_ID||typeof m.resolveProjectIdFromCandidates!=='function'){process.exit(1)}"`
- manual diff review for both workflows to confirm behavior parity and shared resolver usage

Closes #67
Closes #68
