### PR TITLE
chore: align compose env schema and testnet config

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -1,19 +1,25 @@
+# Required runtime values (set these before first bootstrap).
+# POSTGRES_PASSWORD and FIBER_LINK_HMAC_SECRET must not stay default-like in shared envs.
+# FNN_ASSET_SHA256 must match the selected FNN release asset digest exactly.
 POSTGRES_DB=fiber_link
 POSTGRES_USER=fiber
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=change-me-before-prod
 POSTGRES_PORT=5432
 
 REDIS_PORT=6379
 RPC_PORT=3000
 
+# FNN_*_PORT values only affect host publish ports in docker-compose.
+# Internal FNN ports remain 8227/8228 per deploy/compose/fnn/config/testnet.yml.
 FNN_VERSION=v0.6.1
 FNN_ASSET=fnn_v0.6.1-x86_64-linux-portable.tar.gz
-FNN_ASSET_SHA256=
+FNN_ASSET_SHA256=replace-with-release-sha256
 FNN_RPC_PORT=8227
 FNN_P2P_PORT=8228
 FIBER_SECRET_KEY_PASSWORD=change-me-before-prod
 
-FIBER_LINK_HMAC_SECRET=
+# Compose-internal endpoint for Fiber Node RPC (used by rpc/worker containers).
+FIBER_LINK_HMAC_SECRET=change-me-before-prod
 FIBER_RPC_URL=http://fnn:8227
 
 WORKER_WITHDRAWAL_INTERVAL_MS=30000

--- a/deploy/compose/fnn/config/testnet.yml
+++ b/deploy/compose/fnn/config/testnet.yml
@@ -1,5 +1,9 @@
 # Based on official Fiber release testnet config:
 # https://github.com/nervosnetwork/fiber/releases
+# Compose contract:
+# - FNN internal ports stay fixed at rpc=8227 / p2p=8228 (host mappings are configured via .env).
+# - docker-compose startup order expects fnn to be reachable before rpc/worker bootstrap checks.
+# - ckb.rpc_url is an external dependency and must be reachable from the fnn container.
 fiber:
   listening_addr: "/ip4/0.0.0.0/tcp/8228"
   bootnode_addrs:

--- a/docs/runbooks/compose-reference.md
+++ b/docs/runbooks/compose-reference.md
@@ -18,6 +18,9 @@ For a strict deterministic execution sequence (precheck -> spin-up -> signed RPC
 - Outbound network access to:
   - GitHub release download (for FNN image build)
   - CKB testnet RPC endpoint (`https://testnet.ckbapp.dev/`)
+- Required external dependency behavior:
+  - the FNN release asset (`${FNN_ASSET}`) must remain available for the pinned `${FNN_VERSION}`
+  - the CKB RPC endpoint configured in `deploy/compose/fnn/config/testnet.yml` must be reachable from container network
 
 ## Quick Start
 From repo root:
@@ -38,6 +41,14 @@ Edit `.env` minimally:
 - Optional: tune settlement polling knobs:
   - `WORKER_SETTLEMENT_INTERVAL_MS`
   - `WORKER_SETTLEMENT_BATCH_SIZE`
+
+## Config and Override Semantics
+- Internal ports are fixed by service config:
+  - FNN listens on `8227` (RPC) and `8228` (P2P) in `deploy/compose/fnn/config/testnet.yml`.
+  - RPC service listens on `3000` in container.
+- `.env` port overrides (`FNN_RPC_PORT`, `FNN_P2P_PORT`, `RPC_PORT`) control host-published ports only.
+- `FIBER_RPC_URL` is the compose-network endpoint used by `rpc` and `worker`; default is `http://fnn:8227`.
+- Compose startup order is `postgres/redis/fnn` -> `rpc` -> `worker` (current dependency wiring in `docker-compose.yml`).
 
 Start:
 


### PR DESCRIPTION
## Summary
- align deploy/compose/.env.example defaults and placeholders with required runtime variables
- document compose override semantics and required external dependencies in the runbook
- add guard checks to keep testnet config ports, compose mappings, and env variable conventions consistent

## Validation
- bash deploy/compose/compose-reference.test.sh

Closes #41