### PR TITLE
feat: implement RPC tip.status endpoint

### DIFF
--- a/fiber-link-service/apps/rpc/src/methods/tip.test.ts
+++ b/fiber-link-service/apps/rpc/src/methods/tip.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { handleTipCreate } from "./tip";
+import { handleTipCreate, handleTipStatus } from "./tip";
 import { createInMemoryTipIntentRepo } from "@fiber-link/db";
+
+let invoiceStatusByInvoice: Record<string, "UNPAID" | "SETTLED" | "FAILED"> = {};
 
 vi.mock("@fiber-link/fiber-adapter", () => {
   return {
@@ -8,6 +10,9 @@ vi.mock("@fiber-link/fiber-adapter", () => {
       return {
         async createInvoice() {
           return { invoice: "inv-tip-1" };
+        },
+        async getInvoiceStatus({ invoice }: { invoice: string }) {
+          return { state: invoiceStatusByInvoice[invoice] ?? "UNPAID" };
         },
       };
     },
@@ -19,20 +24,79 @@ const tipIntentRepo = createInMemoryTipIntentRepo();
 beforeEach(() => {
   process.env.FIBER_RPC_URL = "http://localhost:8119";
   tipIntentRepo.__resetForTests?.();
+  invoiceStatusByInvoice = {};
 });
 
-it("creates a tip intent with invoice", async () => {
-  const res = await handleTipCreate({
-    appId: "app1",
-    postId: "p1",
-    fromUserId: "u1",
-    toUserId: "u2",
-    asset: "USDI",
-    amount: "10",
-  }, { tipIntentRepo });
+describe("tip methods", () => {
+  it("creates a tip intent with invoice", async () => {
+    const res = await handleTipCreate({
+      appId: "app1",
+      postId: "p1",
+      fromUserId: "u1",
+      toUserId: "u2",
+      asset: "USDI",
+      amount: "10",
+    }, { tipIntentRepo });
 
-  expect(res.invoice).toBe("inv-tip-1");
-  const saved = await tipIntentRepo.findByInvoiceOrThrow("inv-tip-1");
-  expect(saved.invoiceState).toBe("UNPAID");
-  expect(saved.postId).toBe("p1");
+    expect(res.invoice).toBe("inv-tip-1");
+    const saved = await tipIntentRepo.findByInvoiceOrThrow("inv-tip-1");
+    expect(saved.invoiceState).toBe("UNPAID");
+    expect(saved.postId).toBe("p1");
+  });
+
+  it("returns UNPAID when upstream invoice is still unpaid", async () => {
+    const res = await handleTipCreate({
+      appId: "app1",
+      postId: "p1",
+      fromUserId: "u1",
+      toUserId: "u2",
+      asset: "USDI",
+      amount: "10",
+    }, { tipIntentRepo });
+
+    const status = await handleTipStatus({ invoice: res.invoice }, { tipIntentRepo });
+    expect(status).toEqual({ state: "UNPAID" });
+  });
+
+  it("updates and returns SETTLED when upstream invoice is settled", async () => {
+    const res = await handleTipCreate({
+      appId: "app1",
+      postId: "p1",
+      fromUserId: "u1",
+      toUserId: "u2",
+      asset: "USDI",
+      amount: "10",
+    }, { tipIntentRepo });
+    invoiceStatusByInvoice[res.invoice] = "SETTLED";
+
+    const status = await handleTipStatus({ invoice: res.invoice }, { tipIntentRepo });
+    const saved = await tipIntentRepo.findByInvoiceOrThrow(res.invoice);
+
+    expect(status).toEqual({ state: "SETTLED" });
+    expect(saved.invoiceState).toBe("SETTLED");
+  });
+
+  it("updates and returns FAILED when upstream invoice is failed", async () => {
+    const res = await handleTipCreate({
+      appId: "app1",
+      postId: "p1",
+      fromUserId: "u1",
+      toUserId: "u2",
+      asset: "USDI",
+      amount: "10",
+    }, { tipIntentRepo });
+    invoiceStatusByInvoice[res.invoice] = "FAILED";
+
+    const status = await handleTipStatus({ invoice: res.invoice }, { tipIntentRepo });
+    const saved = await tipIntentRepo.findByInvoiceOrThrow(res.invoice);
+
+    expect(status).toEqual({ state: "FAILED" });
+    expect(saved.invoiceState).toBe("FAILED");
+  });
+
+  it("throws when invoice does not exist", async () => {
+    await expect(handleTipStatus({ invoice: "missing-invoice" }, { tipIntentRepo })).rejects.toThrow(
+      "tip intent not found",
+    );
+  });
 });

--- a/fiber-link-service/apps/rpc/src/rpc.ts
+++ b/fiber-link-service/apps/rpc/src/rpc.ts
@@ -1,8 +1,8 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { createDbClient } from "@fiber-link/db";
+import { TipIntentNotFoundError, createDbClient } from "@fiber-link/db";
 import { verifyHmac } from "./auth/hmac";
-import { handleTipCreate } from "./methods/tip";
+import { handleTipCreate, handleTipStatus } from "./methods/tip";
 import { createNonceStore } from "./nonce-store";
 import { type AppRepo, createDbAppRepo } from "./repositories/app-repo";
 import { loadSecretMap, resolveSecretForApp } from "./secret-map";
@@ -27,6 +27,10 @@ const TipCreateSchema = z.object({
   toUserId: z.string().min(1),
   asset: z.enum(["CKB", "USDI"]),
   amount: z.string().min(1),
+});
+
+const TipStatusSchema = z.object({
+  invoice: z.string().min(1),
 });
 
 const NONCE_TTL_MS = 5 * 60 * 1000;
@@ -159,6 +163,34 @@ export function registerRpc(app: FastifyInstance, options: { appRepo?: AppRepo }
           const result = await handleTipCreate({ ...parsed.data, appId });
           return reply.send({ jsonrpc: "2.0", id: rpc.id, result });
         } catch (error) {
+          req.log.error(error);
+          return reply.send({
+            jsonrpc: "2.0",
+            id: rpc.id,
+            error: { code: -32603, message: "Internal error" },
+          });
+        }
+      }
+      if (rpc.method === "tip.status") {
+        const parsed = TipStatusSchema.safeParse(rpc.params);
+        if (!parsed.success) {
+          return reply.send({
+            jsonrpc: "2.0",
+            id: rpc.id,
+            error: { code: -32602, message: "Invalid params", data: parsed.error.issues },
+          });
+        }
+        try {
+          const result = await handleTipStatus({ ...parsed.data });
+          return reply.send({ jsonrpc: "2.0", id: rpc.id, result });
+        } catch (error) {
+          if (error instanceof TipIntentNotFoundError) {
+            return reply.send({
+              jsonrpc: "2.0",
+              id: rpc.id,
+              error: { code: -32004, message: "Tip not found" },
+            });
+          }
           req.log.error(error);
           return reply.send({
             jsonrpc: "2.0",


### PR DESCRIPTION
## Summary
- add tip.status dispatch path in RPC with strict payload validation (invoice required)
- add handleTipStatus logic to map upstream invoice status to stable UNPAID/SETTLED/FAILED states
- standardize not-found responses for tip.status as JSON-RPC error -32004 Tip not found
- add unit tests for success, invalid params, and not-found behavior

## Validation
- bun run test --run src/rpc.test.ts src/methods/tip.test.ts (in fiber-link-service/apps/rpc)

Closes #43