### PR TITLE
feat: standardize rpc and worker settlement contracts

### DIFF
--- a/fiber-link-service/apps/rpc/src/contracts.test.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  RpcErrorCode,
+  RpcRequestSchema,
+  TipCreateParamsSchema,
+  TipCreateResultSchema,
+  TipStatusResultSchema,
+} from "./contracts";
+
+describe("rpc contracts", () => {
+  it("validates canonical rpc request shape", () => {
+    const parsed = RpcRequestSchema.safeParse({
+      jsonrpc: "2.0",
+      id: "1",
+      method: "tip.create",
+      params: {
+        postId: "p1",
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("pins tip.create and tip.status payload contracts", () => {
+    expect(
+      TipCreateParamsSchema.safeParse({
+        postId: "p1",
+        fromUserId: "u1",
+        toUserId: "u2",
+        asset: "USDI",
+        amount: "10",
+      }).success,
+    ).toBe(true);
+
+    expect(TipCreateResultSchema.safeParse({ invoice: "invoice-1" }).success).toBe(true);
+    expect(TipStatusResultSchema.safeParse({ state: "SETTLED" }).success).toBe(true);
+    expect(TipStatusResultSchema.safeParse({ state: "BROKEN" }).success).toBe(false);
+  });
+
+  it("keeps rpc error code constants stable", () => {
+    expect(RpcErrorCode.INVALID_REQUEST).toBe(-32600);
+    expect(RpcErrorCode.INVALID_PARAMS).toBe(-32602);
+    expect(RpcErrorCode.UNAUTHORIZED).toBe(-32001);
+    expect(RpcErrorCode.TIP_NOT_FOUND).toBe(-32004);
+  });
+});

--- a/fiber-link-service/apps/rpc/src/contracts.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const JsonRpcVersionSchema = z.literal("2.0");
+export const RpcIdSchema = z.union([z.string(), z.number(), z.null()]);
+export type RpcId = z.infer<typeof RpcIdSchema>;
+
+export const RpcRequestSchema = z.object({
+  jsonrpc: JsonRpcVersionSchema,
+  id: RpcIdSchema,
+  method: z.string().min(1),
+  params: z.unknown().optional(),
+});
+export type RpcRequest = z.infer<typeof RpcRequestSchema>;
+
+export const TipCreateParamsSchema = z.object({
+  postId: z.string().min(1),
+  fromUserId: z.string().min(1),
+  toUserId: z.string().min(1),
+  asset: z.enum(["CKB", "USDI"]),
+  amount: z.string().min(1),
+});
+
+export const TipCreateResultSchema = z.object({
+  invoice: z.string().min(1),
+});
+
+export const TipStatusParamsSchema = z.object({
+  invoice: z.string().min(1),
+});
+
+export const TipStatusResultSchema = z.object({
+  state: z.enum(["UNPAID", "SETTLED", "FAILED"]),
+});
+
+export const RpcErrorCode = {
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+  UNAUTHORIZED: -32001,
+  TIP_NOT_FOUND: -32004,
+} as const;
+
+export type RpcErrorCode = (typeof RpcErrorCode)[keyof typeof RpcErrorCode];

--- a/fiber-link-service/apps/rpc/src/rpc-error.ts
+++ b/fiber-link-service/apps/rpc/src/rpc-error.ts
@@ -1,0 +1,28 @@
+import { type RpcErrorCode, type RpcId } from "./contracts";
+
+export class RpcMethodError extends Error {
+  constructor(
+    public readonly code: RpcErrorCode,
+    message: string,
+    public readonly data?: unknown,
+  ) {
+    super(message);
+    this.name = "RpcMethodError";
+  }
+}
+
+export function rpcErrorResponse(id: RpcId, code: RpcErrorCode, message: string, data?: unknown) {
+  return {
+    jsonrpc: "2.0" as const,
+    id,
+    error: data === undefined ? { code, message } : { code, message, data },
+  };
+}
+
+export function rpcResultResponse<T>(id: RpcId, result: T) {
+  return {
+    jsonrpc: "2.0" as const,
+    id,
+    result,
+  };
+}

--- a/fiber-link-service/apps/worker/src/contracts.test.ts
+++ b/fiber-link-service/apps/worker/src/contracts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createSettlementUpdateEvent } from "./contracts";
+
+describe("worker settlement contracts", () => {
+  it("builds canonical settlement update event payload", () => {
+    const event = createSettlementUpdateEvent({
+      invoice: "inv-1",
+      previousState: "UNPAID",
+      observedState: "SETTLED",
+      nextState: "SETTLED",
+      outcome: "SETTLED_CREDIT_APPLIED",
+      ledgerCreditApplied: true,
+    });
+
+    expect(event).toEqual({
+      type: "settlement.update",
+      invoice: "inv-1",
+      previousState: "UNPAID",
+      observedState: "SETTLED",
+      nextState: "SETTLED",
+      outcome: "SETTLED_CREDIT_APPLIED",
+      ledgerCreditApplied: true,
+    });
+  });
+});

--- a/fiber-link-service/apps/worker/src/contracts.ts
+++ b/fiber-link-service/apps/worker/src/contracts.ts
@@ -1,0 +1,36 @@
+export type SettlementState = "UNPAID" | "SETTLED" | "FAILED";
+
+export type SettlementUpdateOutcome =
+  | "NO_CHANGE"
+  | "SETTLED_CREDIT_APPLIED"
+  | "SETTLED_DUPLICATE"
+  | "FAILED_MARKED";
+
+export type SettlementUpdateEvent = {
+  type: "settlement.update";
+  invoice: string;
+  previousState: SettlementState;
+  observedState: SettlementState;
+  nextState: SettlementState;
+  outcome: SettlementUpdateOutcome;
+  ledgerCreditApplied: boolean;
+};
+
+export function createSettlementUpdateEvent(input: {
+  invoice: string;
+  previousState: SettlementState;
+  observedState: SettlementState;
+  nextState: SettlementState;
+  outcome: SettlementUpdateOutcome;
+  ledgerCreditApplied: boolean;
+}): SettlementUpdateEvent {
+  return {
+    type: "settlement.update",
+    invoice: input.invoice,
+    previousState: input.previousState,
+    observedState: input.observedState,
+    nextState: input.nextState,
+    outcome: input.outcome,
+    ledgerCreditApplied: input.ledgerCreditApplied,
+  };
+}


### PR DESCRIPTION
## Summary
- add canonical RPC contract definitions (request/params/result schemas + stable error code constants) in `apps/rpc/src/contracts.ts`
- replace ad-hoc RPC error payload creation with explicit helper builders in `apps/rpc/src/rpc-error.ts`
- validate handler result payloads against canonical schemas before returning responses
- add canonical worker settlement update event contract in `apps/worker/src/contracts.ts`
- wire settlement discovery to emit typed settlement update events for each deterministic state decision

## Validation
- bun run test -- --run --silent src/contracts.test.ts src/rpc.test.ts (apps/rpc)
- bun run test -- --run --silent src/contracts.test.ts src/settlement-discovery.test.ts src/settlement.test.ts src/withdrawal-batch.test.ts (apps/worker)

Closes #51
