### PR TITLE
feat(rpc): add tip.get invoice read path and happy-path tests (#50)

### DIFF
--- a/fiber-link-service/apps/rpc/src/rpc.ts
+++ b/fiber-link-service/apps/rpc/src/rpc.ts
@@ -265,7 +265,7 @@ export function registerRpc(
           return reply.send(rpcErrorResponse(rpc.id, RpcErrorCode.INTERNAL_ERROR, "Internal error"));
         }
       }
-      if (rpc.method === "tip.status") {
+      if (rpc.method === "tip.status" || rpc.method === "tip.get") {
         const parsed = TipStatusParamsSchema.safeParse(rpc.params);
         if (!parsed.success) {
           return reply.send(
@@ -276,7 +276,7 @@ export function registerRpc(
           const result = await handleTipStatus({ ...parsed.data });
           const validated = TipStatusResultSchema.safeParse(result);
           if (!validated.success) {
-            req.log.error(validated.error, "tip.status produced invalid response payload");
+            req.log.error(validated.error, "tip.status/tip.get produced invalid response payload");
             return reply.send(rpcErrorResponse(rpc.id, RpcErrorCode.INTERNAL_ERROR, "Internal error"));
           }
           return reply.send(rpcResultResponse(rpc.id, validated.data));


### PR DESCRIPTION
## Summary
- add `tip.get` as an alias of the existing `tip.status` read path for create/get contract consistency
- reuse the same param and result schemas so `tip.status` and `tip.get` stay contract-equivalent
- add happy-path integration coverage for `tip.create -> tip.get`
- add request validation coverage for invalid `tip.get` params

## Verification
- `bun run test src/rpc.test.ts --run`
- `bun run test --run`

Closes #50