### PR TITLE
Fix issue #99: add merge-conflict marker checks

### DIFF
--- a/deploy/compose/compose-reference.test.sh
+++ b/deploy/compose/compose-reference.test.sh
@@ -55,6 +55,13 @@ if [[ ! -x "${EVIDENCE_SCRIPT}" ]]; then
   exit 1
 fi
 
+for compose_file in "${ENV_FILE}" "${COMPOSE_FILE}"; do
+  if rg -n "^(<<<<<<<|=======|>>>>>>> )" "${compose_file}" >/dev/null; then
+    echo "merge-conflict marker found in ${compose_file}" >&2
+    exit 1
+  fi
+done
+
 if ! grep -q "capture-deployment-evidence.sh" "${RUNBOOK_FILE}"; then
   echo "compose runbook missing deployment evidence script reference" >&2
   exit 1


### PR DESCRIPTION
Closes #99

Scope:
- Add a deterministic merge-conflict marker check for deploy compose artifacts in `deploy/compose/compose-reference.test.sh`.
- The check fails if conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) are present in:
  - `deploy/compose/.env.example`
  - `deploy/compose/docker-compose.yml`

Validation:
- `bash deploy/compose/compose-reference.test.sh`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" deploy/compose/.env.example deploy/compose/docker-compose.yml`
