### PR TITLE
Followup-108: harden compose reference merge-marker check

### DIFF
--- a/deploy/compose/compose-reference.test.sh
+++ b/deploy/compose/compose-reference.test.sh
@@ -56,7 +56,7 @@ if [[ ! -x "${EVIDENCE_SCRIPT}" ]]; then
 fi
 
 for compose_file in "${ENV_FILE}" "${COMPOSE_FILE}"; do
-  if rg -n "^(<<<<<<<|=======|>>>>>>> )" "${compose_file}" >/dev/null; then
+  if grep -nE "^(<<<<<<<|=======|>>>>>>> )" "${compose_file}" >/dev/null; then
     echo "merge-conflict marker found in ${compose_file}" >&2
     exit 1
   fi


### PR DESCRIPTION
Closes #108. Use portable grep-based conflict-marker detection in compose reference checks and avoid brittle rg dependency.