### PR TITLE
Followup-117: keep deterministic requestId for send_payment

### DIFF
--- a/fiber-link-service/packages/fiber-adapter/src/index.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { rpcCall } from "./fiber-client";
 export { FiberRpcError } from "./fiber-client";
 
@@ -27,6 +28,10 @@ function toHexQuantity(value: string): string {
     throw new Error(`invalid amount: ${value}`);
   }
   return `0x${BigInt(value).toString(16)}`;
+}
+
+function generateFallbackRequestId({ invoice, amount, asset }: { invoice: string; amount: string; asset: Asset }) {
+  return `fiber:${createHash("sha256").update(`${invoice}|${amount}|${asset}`).digest("hex").slice(0, 20)}`;
 }
 
 const DEFAULT_INVOICE_CURRENCY_BY_ASSET: Record<Asset, string> = {
@@ -108,17 +113,19 @@ export function createAdapter({ endpoint }: { endpoint: string }) {
       if (!paymentHash) {
         throw new Error("parse_invoice response is missing 'invoice.data.payment_hash' string");
       }
+      const resolvedRequestId = requestId?.trim() || generateFallbackRequestId({ invoice: toAddress, amount, asset });
       const result = (await rpcCall(endpoint, "send_payment", {
         payment_hash: paymentHash,
         amount: toHexQuantity(amount),
         currency: mapAssetToCurrency(asset),
-        request_id: requestId,
+        request_id: resolvedRequestId,
       })) as Record<string, unknown> | undefined;
       const txHash = pickTxEvidence(result);
       if (!txHash) {
         throw new Error("send_payment response is missing transaction evidence");
       }
       return { txHash };
-    },
+    }
+
   };
 }


### PR DESCRIPTION
Closes #117. Always include a deterministic request_id fallback in send_payment payloads to keep retry behavior idempotent when caller omits requestId.,