### PR TITLE
fix: map withdrawal asset to currency in send_payment

### DIFF
--- a/fiber-link-service/packages/fiber-adapter/src/fiber-adapter.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/fiber-adapter.test.ts
@@ -119,7 +119,7 @@ describe("fiber adapter", () => {
     );
   });
 
-  it("executeWithdrawal calls send_payment and returns txHash evidence", async () => {
+  it("executeWithdrawal maps asset to currency for send_payment", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
       json: async () => ({ jsonrpc: "2.0", id: 1, result: { payment_hash: "0xabc123" } }),
@@ -143,7 +143,7 @@ describe("fiber adapter", () => {
     );
     expect(fetchSpy.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
-        body: expect.stringContaining("\"request_id\":\"w-1\""),
+        body: expect.stringContaining("\"currency\":\"USDI\""),
       }),
     );
   });

--- a/fiber-link-service/packages/fiber-adapter/src/index.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/index.ts
@@ -101,11 +101,11 @@ export function createAdapter({ endpoint }: { endpoint: string }) {
       return { close: () => undefined };
     },
     async executeWithdrawal({ amount, asset, toAddress, requestId }: ExecuteWithdrawalArgs) {
-      void asset;
-      // Current executor uses Fiber payment RPC; toAddress is treated as a payment request string.
+      const currency = mapAssetToCurrency(asset);
       const result = (await rpcCall(endpoint, "send_payment", {
         invoice: toAddress,
         amount: toHexQuantity(amount),
+        currency,
         request_id: requestId,
       })) as Record<string, unknown> | undefined;
       const txHash = pickTxEvidence(result);


### PR DESCRIPTION
Closes #118.

- map executeWithdrawal asset to send_payment currency payload instead of always using default env
- keep existing behavior of request_id/address conversion untouched
