### PR TITLE
chore: batch close review-followup issues

### DIFF
--- a/docs/admin-installation.md
+++ b/docs/admin-installation.md
@@ -121,6 +121,8 @@ Additional checks:
 
 If setup breaks or secrets are suspected leaked:
 
+Warning: this command removes compose volumes and deletes local database / worker persisted state.
+
 ```bash
 cd deploy/compose
 docker compose down --remove-orphans --volumes

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
@@ -53,7 +53,7 @@
   <hr />
   <h3>Admin Inspection (Operational)</h3>
 
-  <form method="GET" action="/fiber-link">
+  <form method="GET">
     <label>
       Withdrawal state:
       <select name="withdrawalState">
@@ -79,6 +79,11 @@
     <strong>Active filters:</strong>
     withdrawals={{this.model.adminFiltersApplied.withdrawalState}},
     settlements={{this.model.adminFiltersApplied.settlementState}}
+    ({{#link-to
+      "fiber-link-dashboard"
+      (query-params withdrawalState="ALL" settlementState="ALL")
+      title="Clear both filters and reload full admin inspection data."
+    }}Reset to ALL{{/link-to}})
   </p>
 
   <h4>Apps</h4>
@@ -93,7 +98,9 @@
           <td>{{row.createdAt}}</td>
         </tr>
       {{else}}
-        <tr><td colspan="2">No app records.</td></tr>
+        <tr>
+          <td colspan="2">No app records from admin payload. Verify plugin app credentials and refresh.</td>
+        </tr>
       {{/each}}
     </tbody>
   </table>
@@ -117,7 +124,18 @@
           <td>{{row.updatedAt}}</td>
         </tr>
       {{else}}
-        <tr><td colspan="7">No withdrawals for current filter.</td></tr>
+        <tr>
+          <td colspan="7">
+            No withdrawals for current filter.
+            {{#link-to
+              "fiber-link-dashboard"
+              (query-params
+                withdrawalState="ALL"
+                settlementState=this.model.adminFiltersApplied.settlementState
+              )
+            }}Show all withdrawal states{{/link-to}}.
+          </td>
+        </tr>
       {{/each}}
     </tbody>
   </table>
@@ -141,7 +159,18 @@
           <td>{{row.lastError}}</td>
         </tr>
       {{else}}
-        <tr><td colspan="7">No settlement rows for current filter.</td></tr>
+        <tr>
+          <td colspan="7">
+            No settlement rows for current filter.
+            {{#link-to
+              "fiber-link-dashboard"
+              (query-params
+                withdrawalState=this.model.adminFiltersApplied.withdrawalState
+                settlementState="ALL"
+              )
+            }}Show all settlement states{{/link-to}}.
+          </td>
+        </tr>
       {{/each}}
     </tbody>
   </table>

--- a/fiber-link-service/packages/fiber-adapter/src/index.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/index.ts
@@ -31,6 +31,8 @@ function toHexQuantity(value: string): string {
 }
 
 function generateFallbackRequestId({ invoice, amount, asset }: { invoice: string; amount: string; asset: Asset }) {
+  // Deterministic fallback keeps retries idempotent when caller-provided requestId is empty.
+  // We keep only 20 hex chars (80-bit space): collision risk is low for retries, but non-zero for long-term global dedupe.
   return `fiber:${createHash("sha256").update(`${invoice}|${amount}|${asset}`).digest("hex").slice(0, 20)}`;
 }
 


### PR DESCRIPTION
## Summary
Batch-resolve open `review-followup` issues in one PR.

### Implemented follow-ups
- #145: assert invalid cursor backup file preserves original malformed payload bytes.
- #141: add explicit warning that rollback with `--volumes` deletes local DB/worker state.
- #138: document deterministic fallback request-id collision characteristics in adapter code comments.
- #136 / #137: remove hardcoded absolute admin filter form action to keep subfolder deployments working.
- #135: improve admin empty-state guidance and add filter reset/navigation links; add system spec coverage.

### No-op informational follow-ups included in this batch
These issues were created from approval/acknowledgement comments and need no additional code delta:
- #144 #143 #142 #140 #139 #112 #110 #109 #107

## Verification
- `bun run --cwd fiber-link-service/apps/worker test -- --run src/settlement-cursor-store.test.ts` ✅
- `bun run --cwd fiber-link-service/packages/fiber-adapter test -- --run src/fiber-adapter.test.ts` ⚠️ one existing env-dependent failure (`ECONNREFUSED 127.0.0.1:8119`) unrelated to this diff.
- `/tmp/discourse-dev/bin/docker/rspec --format documentation plugins/fiber-link/spec/system/fiber_link_dashboard_spec.rb` ❌ command path not present in current environment.

Closes #145
Closes #144
Closes #143
Closes #142
Closes #141
Closes #140
Closes #139
Closes #138
Closes #137
Closes #136
Closes #135
Closes #112
Closes #110
Closes #109
Closes #107
