### PR TITLE
fix: align compose-reference probe check with host-IP healthcheck

### DIFF
--- a/deploy/compose/compose-reference.test.sh
+++ b/deploy/compose/compose-reference.test.sh
@@ -171,7 +171,13 @@ if ! grep -q "apps/worker/src/scripts/healthcheck.ts" "${COMPOSE_FILE}"; then
   exit 1
 fi
 
-if ! grep -q "curl -sS --max-time 3 http://127.0.0.1:8227" "${COMPOSE_FILE}"; then
+FNN_HEALTHCHECK_PATTERNS=(
+  "curl -sS --max-time 3 http://127.0.0.1:8227"
+  '\$\${FNN_HOST_IP}:8227'
+)
+
+if ! grep -q "${FNN_HEALTHCHECK_PATTERNS[0]}" "${COMPOSE_FILE}" \
+  && ! grep -q "${FNN_HEALTHCHECK_PATTERNS[1]}" "${COMPOSE_FILE}"; then
   echo "docker-compose missing fnn liveness/readiness probe" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- update deploy/compose/compose-reference.test.sh to accept either legacy loopback probe or the current FNN_HOST_IP probe format
- prevent false negatives when validating deploy/compose/docker-compose.yml

## Verification
- bash deploy/compose/compose-reference.test.sh
- bash scripts/testnet-smoke.sh --dry-run
- bash scripts/capture-deployment-evidence.sh --invoice-id ISSUE34-VERIFY --settlement-id ISSUE34-VERIFY --output-root /tmp/fiber-link-evidence-check --dry-run

## Context
- During Issue #34 completion verification, issue-119 branch reported a false failure from compose-reference.test.sh even though compose used a valid host-IP FNN healthcheck probe.
