### PR TITLE
docs(roadmap): add epic #32 execution tracker

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Docs Index
 
+## Roadmap tracking
+
+- `docs/plans/2026-02-17-issue-32-epic-execution-status-tracker.md` — execution order, blocking graph, W1-W5 issue status snapshot, and remaining critical tasks for epic `#32` (status verified on 2026-02-17).
+
 ## Plugin testing
 
 - `docs/runbooks/phase2-verification.md` — end-to-end verification flow for service and plugin changes.

--- a/docs/plans/2026-02-17-issue-32-epic-execution-status-tracker.md
+++ b/docs/plans/2026-02-17-issue-32-epic-execution-status-tracker.md
@@ -1,0 +1,73 @@
+# Epic #32 Execution and Status Tracker
+
+Date: 2026-02-17  
+Scope: `#32` Epic roadmap anchor (`Invoice -> Payment -> Settlement v1`)  
+Last status verification: 2026-02-17
+
+## Objective and Acceptance Criteria Mapping
+
+Epic objective (`#32`): deliver a verifiable end-to-end flow `invoice -> payment -> settlement -> accounting` on Fiber testnet with auditable evidence.
+
+| AC | Requirement (from `#32`) | Evidence / Coverage | Status on 2026-02-17 | Remaining gap |
+| --- | --- | --- | --- | --- |
+| AC-1 | Invoice lifecycle executes on testnet and reaches persistent settlement/accounting state. | W3 data/runtime baseline closed (`#35`, `#40`, `#47`, `#51`, `#56`, `#61`); W4 implementation tasks closed (`#43`, `#50`, `#55`, `#60`, `#64`); implementation summary in `docs/06-development-progress.md`. | Partially met (implementation done; plan gate still open). | `#36` is still OPEN because legacy task `#24` is OPEN; explicit closure/defer decision is still needed. |
+| AC-2 | Status updates are observable in DB, API output, and demo evidence. | Demo/runtime docs and tasks exist (`#37` child issues `#44`, `#49`, `#53`, `#59`, `#39`, `#45` are closed); runbook `docs/runbooks/w5-demo-evidence.md`. | Partially met (most W5 deliverables done; final public proof loop still open). | `#37` remains OPEN; public proof issues `#97` and `#114` are OPEN; legacy optional UI issue `#30` is OPEN. |
+| AC-3 | W1 security and threat assumptions are mapped to evidence. | W1 plan and child tasks are all closed (`#33`, `#42`, `#48`, `#54`, `#58`, `#63`); evidence/checklist docs include `docs/05-threat-model.md`, `docs/runbooks/security-assumptions.md`, `docs/runbooks/threat-model-evidence-checklist.md`. | Met. | None for W1 baseline. |
+
+## Blocking Graph and Plan Sequence
+
+Plan sequence from `#32` (verified 2026-02-17):
+
+1. `#33` W1 Foundation
+2. `#34` W2 Deployment hardening and `#35` W3 Backend/schema after W1 baseline
+3. `#36` W4 Integration after W2 + W3 gates
+4. `#37` W5 Demo validation after W4 gate
+
+Blocking graph from `#32` (verified 2026-02-17):
+
+- `#33` blocks `#34`, `#35`, `#36`, `#37`
+- `#34` blocks `#36`
+- `#35` blocks `#36`
+- `#36` blocks `#37`
+
+## Current Status Inventory (W1/W2/W3/W4/W5)
+
+Status snapshot date: 2026-02-17
+
+| Workstream | Plan issue status | Child issue status snapshot | Notes |
+| --- | --- | --- | --- |
+| W1 | `#33` CLOSED | Closed: `#42`, `#48`, `#54`, `#58`, `#63`; legacy `#25` CLOSED | Foundation gate complete. |
+| W2 | `#34` CLOSED | Closed: `#41`, `#46`, `#52`, `#57`, `#62` | Deployment hardening gate complete. |
+| W3 | `#35` CLOSED | Closed: `#40`, `#47`, `#51`, `#56`, `#61` | Backend/schema gate complete. |
+| W4 | `#36` OPEN | Closed: `#43`, `#50`, `#55`, `#60`, `#64`; legacy `#26`, `#28`, `#29` CLOSED; legacy `#24` OPEN | Core W4 implementation delivered, but plan remains open due unresolved legacy task policy. |
+| W5 | `#37` OPEN | Closed: `#44`, `#49`, `#53`, `#59`, `#39`, `#45`; legacy `#31`, `#27` CLOSED; legacy `#30` OPEN | Demo flow mostly complete; public proof closure still pending. |
+
+Related epic-level/public-proof status on 2026-02-17:
+
+- `#32` OPEN (epic anchor)
+- `#97` OPEN (public short demo video)
+- `#114` OPEN (Milestone 1 public proof tracking issue)
+
+## Remaining Critical Tasks and Suggested Execution Order
+
+1. Decide and document disposition of open legacy tasks `#24` and `#30` on 2026-02-18:
+   - either execute them in-scope and keep gates open, or
+   - explicitly mark them deferred/non-blocking for this epic and update plan issue acceptance notes.
+2. Complete public demo proof chain on 2026-02-19:
+   - finish `#97` (publish/link short demo video),
+   - update `#114` with the latest evidence links (`docs/runbooks/w5-demo-evidence.md` and acceptance index references).
+3. Close remaining plan gates on 2026-02-20:
+   - close `#36` once W4 gate criteria are explicitly reconciled,
+   - close `#37` once demo/public-proof acceptance is explicitly reconciled.
+4. Perform epic acceptance decision on 2026-02-20:
+   - re-check AC-1/AC-2/AC-3 against issue comments and docs evidence,
+   - close `#32` only when all acceptance criteria are explicitly satisfied and linked.
+
+## References
+
+- `#32`: https://github.com/Keith-CY/fiber-link/issues/32
+- W1 plan `#33`: https://github.com/Keith-CY/fiber-link/issues/33
+- W2 plan `#34`: https://github.com/Keith-CY/fiber-link/issues/34
+- W3 plan `#35`: https://github.com/Keith-CY/fiber-link/issues/35
+- W4 plan `#36`: https://github.com/Keith-CY/fiber-link/issues/36
+- W5 plan `#37`: https://github.com/Keith-CY/fiber-link/issues/37


### PR DESCRIPTION
## Summary

- add a dated execution/status tracker doc for epic #32 under docs/plans
- map objective and acceptance criteria to current evidence/status
- capture blocking graph, plan sequence, W1-W5 status snapshot, and remaining critical tasks
- add discoverable docs index link in docs/README.md

## Validation

- checked document links/paths referenced in updated docs

Ref #32