### PR TITLE
feat(worker): implement settlement subscription strategy with polling fallback (#24)

### DIFF
--- a/fiber-link-service/apps/worker/src/entry.ts
+++ b/fiber-link-service/apps/worker/src/entry.ts
@@ -2,6 +2,10 @@ import { createAdapter } from "@fiber-link/fiber-adapter";
 import type { TipIntentListCursor } from "@fiber-link/db";
 import { runSettlementDiscovery } from "./settlement-discovery";
 import { createFileSettlementCursorStore } from "./settlement-cursor-store";
+import {
+  startSettlementSubscriptionRunner,
+  type SettlementSubscriptionRunner,
+} from "./settlement-subscription-runner";
 import { createWorkerRuntime } from "./worker-runtime";
 
 const withdrawalIntervalMs = Number(process.env.WORKER_WITHDRAWAL_INTERVAL_MS ?? "30000");
@@ -13,6 +17,8 @@ const settlementMaxRetries = Number(process.env.WORKER_SETTLEMENT_MAX_RETRIES ??
 const settlementRetryDelayMs = Number(process.env.WORKER_SETTLEMENT_RETRY_DELAY_MS ?? String(retryDelayMs));
 const settlementPendingTimeoutMs = Number(process.env.WORKER_SETTLEMENT_PENDING_TIMEOUT_MS ?? "1800000");
 const shutdownTimeoutMs = Number(process.env.WORKER_SHUTDOWN_TIMEOUT_MS ?? "15000");
+const settlementStrategyRaw = (process.env.WORKER_SETTLEMENT_STRATEGY ?? "polling").trim().toLowerCase();
+const settlementStrategy = settlementStrategyRaw as "polling" | "subscription";
 const settlementCursorFile =
   process.env.WORKER_SETTLEMENT_CURSOR_FILE ?? "/var/lib/fiber-link/settlement-cursor.json";
 const fiberRpcUrl = process.env.FIBER_RPC_URL;
@@ -48,6 +54,9 @@ if (!Number.isInteger(settlementPendingTimeoutMs) || settlementPendingTimeoutMs 
 if (!Number.isInteger(shutdownTimeoutMs) || shutdownTimeoutMs <= 0) {
   throw new Error(`Invalid WORKER_SHUTDOWN_TIMEOUT_MS: ${process.env.WORKER_SHUTDOWN_TIMEOUT_MS ?? ""}`);
 }
+if (settlementStrategy !== "polling" && settlementStrategy !== "subscription") {
+  throw new Error(`Invalid WORKER_SETTLEMENT_STRATEGY: ${process.env.WORKER_SETTLEMENT_STRATEGY ?? ""}`);
+}
 if (!fiberRpcUrl) {
   throw new Error("FIBER_RPC_URL is required");
 }
@@ -59,6 +68,7 @@ async function main() {
   const fiberAdapter = createAdapter({ endpoint: fiberRpcUrl });
   const cursorStore = createFileSettlementCursorStore(settlementCursorFile);
   let settlementCursor: TipIntentListCursor | undefined = await cursorStore.load();
+  let subscriptionRunner: SettlementSubscriptionRunner | null = null;
 
   const runtime = createWorkerRuntime({
     intervalMs: Math.min(withdrawalIntervalMs, settlementIntervalMs),
@@ -83,11 +93,35 @@ async function main() {
     },
   });
 
+  if (settlementStrategy === "subscription") {
+    try {
+      subscriptionRunner = await startSettlementSubscriptionRunner({
+        adapter: fiberAdapter,
+      });
+      console.info("[worker] settlement strategy enabled", {
+        strategy: "subscription",
+        pollingFallback: true,
+      });
+    } catch (error) {
+      console.error("[worker] settlement subscription startup failed; continuing with polling fallback", error);
+    }
+  } else {
+    console.info("[worker] settlement strategy enabled", {
+      strategy: "polling",
+      pollingFallback: false,
+    });
+  }
+
+  async function shutdown(signal: NodeJS.Signals) {
+    await subscriptionRunner?.close();
+    await runtime.shutdown(signal);
+  }
+
   process.once("SIGINT", () => {
-    void runtime.shutdown("SIGINT");
+    void shutdown("SIGINT");
   });
   process.once("SIGTERM", () => {
-    void runtime.shutdown("SIGTERM");
+    void shutdown("SIGTERM");
   });
 
   await runtime.start();

--- a/fiber-link-service/apps/worker/src/settlement-subscription-runner.integration.test.ts
+++ b/fiber-link-service/apps/worker/src/settlement-subscription-runner.integration.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createInMemoryLedgerRepo,
+  createInMemoryTipIntentRepo,
+  type InvoiceState,
+} from "@fiber-link/db";
+import { runSettlementDiscovery } from "./settlement-discovery";
+import { startSettlementSubscriptionRunner } from "./settlement-subscription-runner";
+
+describe("settlement subscription strategy integration", () => {
+  const tipIntentRepo = createInMemoryTipIntentRepo();
+  const ledgerRepo = createInMemoryLedgerRepo();
+
+  beforeEach(() => {
+    tipIntentRepo.__resetForTests?.();
+    ledgerRepo.__resetForTests?.();
+  });
+
+  it("processes subscription events and preserves polling fallback for missed invoices", async () => {
+    const invoiceStates = new Map<string, InvoiceState>();
+    let emit: ((invoice: string) => Promise<void>) | null = null;
+
+    const adapter = {
+      async subscribeSettlements(args: {
+        onSettled: (invoice: string) => void | Promise<void>;
+        onError?: (error: unknown) => void;
+      }) {
+        emit = async (invoice: string) => {
+          await args.onSettled(invoice);
+        };
+        return {
+          close: () => undefined,
+        };
+      },
+      async getInvoiceStatus({ invoice }: { invoice: string }) {
+        return { state: invoiceStates.get(invoice) ?? "UNPAID" };
+      },
+    };
+
+    const subscriptionIntent = await tipIntentRepo.create({
+      appId: "app-sub",
+      postId: "post-sub",
+      fromUserId: "from-sub",
+      toUserId: "to-sub",
+      asset: "USDI",
+      amount: "10",
+      invoice: "inv-sub-1",
+    });
+    const pollingIntent = await tipIntentRepo.create({
+      appId: "app-poll",
+      postId: "post-poll",
+      fromUserId: "from-poll",
+      toUserId: "to-poll",
+      asset: "USDI",
+      amount: "6",
+      invoice: "inv-poll-1",
+    });
+
+    invoiceStates.set(subscriptionIntent.invoice, "SETTLED");
+    invoiceStates.set(pollingIntent.invoice, "SETTLED");
+
+    const runner = await startSettlementSubscriptionRunner({
+      adapter,
+      tipIntentRepo,
+      ledgerRepo,
+      logger: {
+        info: () => undefined,
+        error: () => undefined,
+      },
+    });
+
+    await emit?.(subscriptionIntent.invoice);
+    await emit?.(subscriptionIntent.invoice);
+
+    const summary = await runSettlementDiscovery({
+      limit: 10,
+      adapter,
+      tipIntentRepo,
+      ledgerRepo,
+    });
+    await runner.close();
+
+    expect(summary.scanned).toBe(1);
+    expect(summary.settledCredits).toBe(1);
+    expect(summary.settledDuplicates).toBe(0);
+
+    const entries = ledgerRepo.__listForTests?.() ?? [];
+    expect(entries).toHaveLength(2);
+    expect(entries.filter((entry) => entry.refId === subscriptionIntent.id)).toHaveLength(1);
+    expect(entries.filter((entry) => entry.refId === pollingIntent.id)).toHaveLength(1);
+  });
+
+  it("keeps polling fallback usable when subscription emits an invalid invoice", async () => {
+    const invoiceStates = new Map<string, InvoiceState>();
+    let emit: ((invoice: string) => Promise<void>) | null = null;
+
+    const adapter = {
+      async subscribeSettlements(args: {
+        onSettled: (invoice: string) => void | Promise<void>;
+        onError?: (error: unknown) => void;
+      }) {
+        emit = async (invoice: string) => {
+          await args.onSettled(invoice);
+        };
+        return {
+          close: () => undefined,
+        };
+      },
+      async getInvoiceStatus({ invoice }: { invoice: string }) {
+        return { state: invoiceStates.get(invoice) ?? "UNPAID" };
+      },
+    };
+
+    const fallbackIntent = await tipIntentRepo.create({
+      appId: "app-fallback",
+      postId: "post-fallback",
+      fromUserId: "from-fallback",
+      toUserId: "to-fallback",
+      asset: "USDI",
+      amount: "8",
+      invoice: "inv-fallback-1",
+    });
+    invoiceStates.set(fallbackIntent.invoice, "SETTLED");
+
+    const runner = await startSettlementSubscriptionRunner({
+      adapter,
+      tipIntentRepo,
+      ledgerRepo,
+      logger: {
+        info: () => undefined,
+        error: () => undefined,
+      },
+    });
+
+    await emit?.("missing-invoice");
+
+    const summary = await runSettlementDiscovery({
+      limit: 10,
+      adapter,
+      tipIntentRepo,
+      ledgerRepo,
+    });
+    await runner.close();
+
+    expect(summary.scanned).toBe(1);
+    expect(summary.settledCredits).toBe(1);
+    expect(ledgerRepo.__listForTests?.()).toHaveLength(1);
+  });
+});

--- a/fiber-link-service/apps/worker/src/settlement-subscription-runner.ts
+++ b/fiber-link-service/apps/worker/src/settlement-subscription-runner.ts
@@ -1,0 +1,80 @@
+import type { LedgerRepo, TipIntentRepo } from "@fiber-link/db";
+import { markSettled } from "./settlement";
+
+type SettlementSubscriptionLogger = {
+  info: (message: string, context?: Record<string, unknown>) => void;
+  error: (message: string, error?: unknown) => void;
+};
+
+type SettlementSubscriptionHandle = {
+  close: () => void | Promise<void>;
+};
+
+type SettlementSubscriptionAdapter = {
+  subscribeSettlements: (args: {
+    onSettled: (invoice: string) => void | Promise<void>;
+    onError?: (error: unknown) => void;
+  }) => Promise<SettlementSubscriptionHandle>;
+};
+
+export type StartSettlementSubscriptionRunnerOptions = {
+  adapter: SettlementSubscriptionAdapter;
+  tipIntentRepo?: TipIntentRepo;
+  ledgerRepo?: LedgerRepo;
+  logger?: SettlementSubscriptionLogger;
+};
+
+export type SettlementSubscriptionRunner = {
+  close: () => Promise<void>;
+};
+
+const defaultLogger: SettlementSubscriptionLogger = {
+  info(message, context) {
+    console.log(message, context ?? {});
+  },
+  error(message, error) {
+    console.error(message, error);
+  },
+};
+
+export async function startSettlementSubscriptionRunner(
+  options: StartSettlementSubscriptionRunnerOptions,
+): Promise<SettlementSubscriptionRunner> {
+  const logger = options.logger ?? defaultLogger;
+  const subscription = await options.adapter.subscribeSettlements({
+    onSettled: async (invoice) => {
+      try {
+        const result = await markSettled(
+          { invoice },
+          {
+            tipIntentRepo: options.tipIntentRepo,
+            ledgerRepo: options.ledgerRepo,
+          },
+        );
+        logger.info("[worker] settlement subscription event", {
+          invoice,
+          credited: result.credited,
+          idempotencyKey: result.idempotencyKey,
+        });
+      } catch (error) {
+        logger.error("[worker] settlement subscription invoice handling failed", {
+          invoice,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    onError: (error) => {
+      logger.error("[worker] settlement subscription stream failed", error);
+    },
+  });
+
+  return {
+    async close() {
+      try {
+        await subscription.close();
+      } catch (error) {
+        logger.error("[worker] settlement subscription shutdown failed", error);
+      }
+    },
+  };
+}

--- a/fiber-link-service/packages/fiber-adapter/src/index.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/index.ts
@@ -12,6 +12,24 @@ export type ExecuteWithdrawalArgs = {
   toAddress: string;
   requestId: string;
 };
+export type SubscribeSettlementsArgs = {
+  onSettled: (invoice: string) => void | Promise<void>;
+  onError?: (error: unknown) => void;
+};
+export type SettlementSubscriptionHandle = {
+  close: () => void | Promise<void>;
+};
+export type SettlementSubscriptionConfig = {
+  enabled?: boolean;
+  url?: string;
+  reconnectDelayMs?: number;
+  authToken?: string;
+};
+export type CreateAdapterArgs = {
+  endpoint: string;
+  settlementSubscription?: SettlementSubscriptionConfig;
+  fetchFn?: typeof fetch;
+};
 
 function mapInvoiceState(value: string): InvoiceState {
   const normalized = value.trim().toLowerCase();
@@ -75,7 +93,285 @@ function pickTxEvidence(result: Record<string, unknown> | undefined): string | n
   return null;
 }
 
-export function createAdapter({ endpoint }: { endpoint: string }) {
+const DEFAULT_SETTLEMENT_SUBSCRIPTION_RECONNECT_DELAY_MS = 3_000;
+
+function parseBoolean(input: string | undefined): boolean | undefined {
+  if (typeof input !== "string") {
+    return undefined;
+  }
+  const normalized = input.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on") {
+    return true;
+  }
+  if (normalized === "0" || normalized === "false" || normalized === "no" || normalized === "off") {
+    return false;
+  }
+  return undefined;
+}
+
+function parsePositiveInteger(input: string | undefined): number | undefined {
+  if (typeof input !== "string") {
+    return undefined;
+  }
+  if (!/^[0-9]+$/.test(input)) {
+    return undefined;
+  }
+  const parsed = Number(input);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function pickStringCandidate(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  return null;
+}
+
+function pickInvoiceFromEventShape(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const event = value as Record<string, unknown>;
+  const nestedCandidates = [
+    event.result as Record<string, unknown> | undefined,
+    event.data as Record<string, unknown> | undefined,
+    event.payload as Record<string, unknown> | undefined,
+    event.event as Record<string, unknown> | undefined,
+    event.notification as Record<string, unknown> | undefined,
+  ];
+  const directCandidates = [
+    event.invoice,
+    event.invoice_address,
+    event.invoiceAddress,
+    nestedCandidates[0]?.invoice,
+    nestedCandidates[0]?.invoice_address,
+    nestedCandidates[1]?.invoice,
+    nestedCandidates[1]?.invoice_address,
+    nestedCandidates[2]?.invoice,
+    nestedCandidates[2]?.invoice_address,
+  ];
+
+  for (const candidate of directCandidates) {
+    const invoice = pickStringCandidate(candidate);
+    if (invoice) {
+      return invoice;
+    }
+  }
+  return null;
+}
+
+function pickStateFromEventShape(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const event = value as Record<string, unknown>;
+  const nestedCandidates = [
+    event.result as Record<string, unknown> | undefined,
+    event.data as Record<string, unknown> | undefined,
+    event.payload as Record<string, unknown> | undefined,
+    event.event as Record<string, unknown> | undefined,
+    event.notification as Record<string, unknown> | undefined,
+  ];
+  const directCandidates = [
+    event.state,
+    event.status,
+    nestedCandidates[0]?.state,
+    nestedCandidates[0]?.status,
+    nestedCandidates[1]?.state,
+    nestedCandidates[1]?.status,
+    nestedCandidates[2]?.state,
+    nestedCandidates[2]?.status,
+  ];
+
+  for (const candidate of directCandidates) {
+    const state = pickStringCandidate(candidate);
+    if (state) {
+      return state;
+    }
+  }
+  return null;
+}
+
+function collectSettledInvoices(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectSettledInvoices(item));
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  const record = value as Record<string, unknown>;
+  const invoice = pickInvoiceFromEventShape(record);
+  const state = pickStateFromEventShape(record);
+  const invoices: string[] = [];
+  if (invoice) {
+    if (!state || mapInvoiceState(state) === "SETTLED") {
+      invoices.push(invoice);
+    }
+  }
+
+  const nested = [record.events, record.result, record.data, record.payload, record.event, record.notification];
+  for (const node of nested) {
+    if (node && typeof node === "object") {
+      invoices.push(...collectSettledInvoices(node));
+    }
+  }
+  return Array.from(new Set(invoices));
+}
+
+async function dispatchSettledInvoices(
+  payload: string,
+  args: SubscribeSettlementsArgs,
+): Promise<void> {
+  const trimmed = payload.trim();
+  if (!trimmed || trimmed === "[DONE]") {
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return;
+  }
+
+  const invoices = collectSettledInvoices(parsed);
+  for (const invoice of invoices) {
+    try {
+      await args.onSettled(invoice);
+    } catch (error) {
+      args.onError?.(error);
+    }
+  }
+}
+
+async function consumeSettlementStream(
+  stream: ReadableStream<Uint8Array>,
+  args: SubscribeSettlementsArgs,
+  signal: AbortSignal,
+) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const pendingSseData: string[] = [];
+
+  function waitForAbort(): Promise<never> {
+    return new Promise((_, reject) => {
+      if (signal.aborted) {
+        reject(new Error("settlement subscription aborted"));
+        return;
+      }
+      signal.addEventListener(
+        "abort",
+        () => {
+          reject(new Error("settlement subscription aborted"));
+        },
+        { once: true },
+      );
+    });
+  }
+
+  async function flushSseData() {
+    if (pendingSseData.length === 0) {
+      return;
+    }
+    const payload = pendingSseData.join("\n");
+    pendingSseData.length = 0;
+    await dispatchSettledInvoices(payload, args);
+  }
+
+  async function processLine(rawLine: string) {
+    const line = rawLine.replace(/\r$/, "");
+    const trimmed = line.trim();
+
+    if (trimmed === "") {
+      await flushSseData();
+      return;
+    }
+    if (line.startsWith(":")) {
+      return;
+    }
+    if (line.startsWith("data:")) {
+      pendingSseData.push(line.slice("data:".length).trimStart());
+      return;
+    }
+
+    await flushSseData();
+    await dispatchSettledInvoices(trimmed, args);
+  }
+
+  while (!signal.aborted) {
+    let readResult: ReadableStreamReadResult<Uint8Array>;
+    try {
+      readResult = await Promise.race([reader.read(), waitForAbort()]);
+    } catch (error) {
+      if (signal.aborted) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Ignore stream cancellation failures during shutdown.
+        }
+        break;
+      }
+      throw error;
+    }
+
+    const { value, done } = readResult;
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    let lineBreakIndex = buffer.indexOf("\n");
+    while (lineBreakIndex >= 0) {
+      const line = buffer.slice(0, lineBreakIndex);
+      buffer = buffer.slice(lineBreakIndex + 1);
+      await processLine(line);
+      lineBreakIndex = buffer.indexOf("\n");
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.trim()) {
+    await processLine(buffer);
+  } else {
+    await flushSseData();
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function resolveSettlementSubscriptionConfig(config: SettlementSubscriptionConfig | undefined) {
+  const enabled = config?.enabled ?? parseBoolean(process.env.FIBER_SETTLEMENT_SUBSCRIPTION_ENABLED) ?? false;
+  const url = config?.url ?? process.env.FIBER_SETTLEMENT_SUBSCRIPTION_URL ?? null;
+  const reconnectDelayMs =
+    config?.reconnectDelayMs ??
+    parsePositiveInteger(process.env.FIBER_SETTLEMENT_SUBSCRIPTION_RECONNECT_DELAY_MS) ??
+    DEFAULT_SETTLEMENT_SUBSCRIPTION_RECONNECT_DELAY_MS;
+  const authToken = config?.authToken ?? process.env.FIBER_SETTLEMENT_SUBSCRIPTION_AUTH_TOKEN ?? null;
+  return {
+    enabled,
+    url,
+    reconnectDelayMs,
+    authToken,
+  };
+}
+
+export function createAdapter({ endpoint, settlementSubscription, fetchFn }: CreateAdapterArgs) {
+  const resolvedFetch = fetchFn ?? fetch;
+  const subscriptionConfig = resolveSettlementSubscriptionConfig(settlementSubscription);
+
   return {
     async createInvoice({ amount, asset }: CreateInvoiceArgs) {
       const result = (await rpcCall(endpoint, "new_invoice", {
@@ -104,8 +400,59 @@ export function createAdapter({ endpoint }: { endpoint: string }) {
       }
       return { state: mapInvoiceState(result.status) };
     },
-    async subscribeSettlements(_: { onSettled: (invoice: string) => void }) {
-      return { close: () => undefined };
+    async subscribeSettlements(args: SubscribeSettlementsArgs): Promise<SettlementSubscriptionHandle> {
+      if (!subscriptionConfig.enabled) {
+        return { close: () => undefined };
+      }
+      if (!subscriptionConfig.url) {
+        throw new Error("FIBER_SETTLEMENT_SUBSCRIPTION_URL is required when settlement subscription is enabled");
+      }
+
+      const controller = new AbortController();
+      let closed = false;
+      const runner = (async () => {
+        while (!closed) {
+          try {
+            const headers: Record<string, string> = {
+              accept: "text/event-stream, application/x-ndjson, application/json",
+            };
+            if (subscriptionConfig.authToken) {
+              headers.authorization = `Bearer ${subscriptionConfig.authToken}`;
+            }
+            const response = await resolvedFetch(subscriptionConfig.url, {
+              method: "GET",
+              headers,
+              signal: controller.signal,
+            });
+
+            if (!response.ok) {
+              throw new Error(`settlement subscription request failed with HTTP ${response.status}`);
+            }
+            if (!response.body) {
+              throw new Error("settlement subscription response body is missing");
+            }
+
+            await consumeSettlementStream(response.body, args, controller.signal);
+          } catch (error) {
+            if (closed || controller.signal.aborted) {
+              break;
+            }
+            args.onError?.(error);
+            await delay(subscriptionConfig.reconnectDelayMs);
+          }
+        }
+      })();
+
+      return {
+        async close() {
+          if (closed) {
+            return;
+          }
+          closed = true;
+          controller.abort();
+          await runner;
+        },
+      };
     },
     async executeWithdrawal({ amount, asset, toAddress, requestId }: ExecuteWithdrawalArgs) {
       const parsed = (await rpcCall(endpoint, "parse_invoice", {
@@ -128,6 +475,5 @@ export function createAdapter({ endpoint }: { endpoint: string }) {
       }
       return { txHash };
     }
-
   };
 }


### PR DESCRIPTION
## Summary
- add configurable settlement subscription support in fiber adapter via stream consumption (SSE/NDJSON payload parsing + reconnect handling)
- add worker settlement strategy flag (`WORKER_SETTLEMENT_STRATEGY`) and subscription runner while retaining polling fallback for recovery
- add integration coverage for subscription event handling + polling fallback safety

## Testing
- cd fiber-link-service/packages/fiber-adapter && bun run test -- --run src/fiber-adapter.test.ts
- cd fiber-link-service/apps/worker && bun run test -- --run src/settlement-subscription-runner.integration.test.ts src/worker-runtime.test.ts
- cd fiber-link-service/apps/worker && bun run test -- --run src/settlement-discovery.test.ts

Fixes #24