### PR TITLE
feat(observability): runtime dashboard summary with redaction

### DIFF
--- a/fiber-link-service/apps/admin/src/features/runtime-dashboard/runtime-dashboard.test.ts
+++ b/fiber-link-service/apps/admin/src/features/runtime-dashboard/runtime-dashboard.test.ts
@@ -16,8 +16,18 @@ describe("runtime dashboard", () => {
     expect(summary.topErrorClass).toBe("NETWORK_TIMEOUT");
   });
 
-  it("redacts sensitive values", () => {
+  it("redacts sensitive values in whitespace-delimited text", () => {
     const redacted = redactSecrets("token=abc password=123 secret=xyz");
     expect(redacted).toBe("token=[REDACTED] password=[REDACTED] secret=[REDACTED]");
+  });
+
+  it("redacts query-like values without eating neighbor params", () => {
+    const redacted = redactSecrets("token=abc&user=456 password=123;mode=fast");
+    expect(redacted).toBe("token=[REDACTED]&user=456 password=[REDACTED];mode=fast");
+  });
+
+  it("redacts multiple occurrences and mixed delimiters", () => {
+    const redacted = redactSecrets("secret=one;token=two password=three&next=ok");
+    expect(redacted).toBe("secret=[REDACTED];token=[REDACTED] password=[REDACTED]&next=ok");
   });
 });

--- a/fiber-link-service/apps/admin/src/features/runtime-dashboard/runtime-dashboard.ts
+++ b/fiber-link-service/apps/admin/src/features/runtime-dashboard/runtime-dashboard.ts
@@ -18,10 +18,10 @@ export type DashboardSummary = {
   severity: RuntimeSeverity;
 };
 
-const SECRET_PATTERNS = [/token=[^\s]+/gi, /password=[^\s]+/gi, /secret=[^\s]+/gi];
+const SECRET_VALUE_PATTERN = /\b(token|password|secret)=([^&;\s]*)/gi;
 
 export function redactSecrets(input: string): string {
-  return SECRET_PATTERNS.reduce((acc, pattern) => acc.replace(pattern, (m) => `${m.split("=")[0]}=[REDACTED]`), input);
+  return input.replace(SECRET_VALUE_PATTERN, (_m, key) => `${key}=[REDACTED]`);
 }
 
 export function classifySeverity(signal: RuntimeSignal): RuntimeSeverity {


### PR DESCRIPTION
## Summary
Implements runtime dashboard summary logic for rapid operator triage with severity classification and secret redaction.

## Changes
- Added runtime summary model covering runtime state, last success timestamp, failure counters, error class, and retry/backoff signal
- Added deterministic severity mapping (`info`/`warning`/`critical`)
- Added secret redaction helper for dashboard-safe display
- Added unit tests for state/severity mapping and secret masking behavior

## Issue
Closes #184

## Acceptance Mapping
- **Operator identifies state and top error quickly**: summary exposes runtime state + top error class directly.
- **Dashboard matches backend signals**: summary is built from explicit backend signal inputs.
- **No sensitive values in summary views**: `redactSecrets` masks token/password/secret values.
