### PR TITLE
feat(ux): productized error contract with guided actions

### DIFF
--- a/fiber-link-service/apps/admin/src/features/errors/productized-errors.test.ts
+++ b/fiber-link-service/apps/admin/src/features/errors/productized-errors.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { toProductError } from "./productized-errors";
+
+describe("productized errors", () => {
+  it("maps known error codes to guided actions", () => {
+    const e = toProductError("ERR_CONFIG_INVALID", "missing DATABASE_URL");
+    expect(e.id).toBe("ERR_CONFIG_INVALID");
+    expect(e.summary).toContain("invalid");
+    expect(e.nextActions.length).toBeGreaterThan(1);
+  });
+
+  it("provides safe fallback for unknown errors", () => {
+    const e = toProductError("ERR_SOMETHING_NEW", "stack trace id=abc");
+    expect(e.id).toBe("ERR_UNKNOWN");
+    expect(e.summary).toContain("unexpected");
+    expect(e.nextActions).toContain("Open diagnostics");
+  });
+});

--- a/fiber-link-service/apps/admin/src/features/errors/productized-errors.ts
+++ b/fiber-link-service/apps/admin/src/features/errors/productized-errors.ts
@@ -1,0 +1,33 @@
+export type ProductError = {
+  id: string;
+  summary: string;
+  technicalDetail: string;
+  nextActions: string[];
+};
+
+const KNOWN_ERROR_MAP: Record<string, Omit<ProductError, "technicalDetail">> = {
+  ERR_CONFIG_INVALID: {
+    id: "ERR_CONFIG_INVALID",
+    summary: "Configuration is invalid.",
+    nextActions: ["Open diagnostics", "Review required fields", "Retry after fixing config"],
+  },
+  ERR_ENDPOINT_TIMEOUT: {
+    id: "ERR_ENDPOINT_TIMEOUT",
+    summary: "Unable to reach critical endpoint.",
+    nextActions: ["Check endpoint URL", "Verify network connectivity", "Retry"],
+  },
+};
+
+export function toProductError(code: string, technicalDetail: string): ProductError {
+  const known = KNOWN_ERROR_MAP[code];
+  if (known) {
+    return { ...known, technicalDetail };
+  }
+
+  return {
+    id: "ERR_UNKNOWN",
+    summary: "An unexpected error occurred.",
+    technicalDetail,
+    nextActions: ["Retry", "Open diagnostics", "Contact support with the shown error ID"],
+  };
+}


### PR DESCRIPTION
## Summary
Implements a user-facing error contract that translates runtime errors into clear summaries, technical detail, and next actions.

## Changes
- Added stable product error shape (`id`, `summary`, `technicalDetail`, `nextActions`)
- Added known error mapping for top classes with deterministic IDs
- Added safe fallback behavior for unknown errors
- Added unit tests for known and unknown error flows

## Issue
Closes #185

## Acceptance Mapping
- **Known errors render with guided actions**: known map returns explicit next actions.
- **Unknown errors still provide safe fallback guidance**: unknown codes map to `ERR_UNKNOWN` with support-safe steps.
- **Support can map visible IDs to backend traces**: stable error IDs are preserved in the user-facing contract.
