### PR TITLE
feat(security): secure-by-default baseline control module

### DIFF
--- a/fiber-link-service/apps/admin/src/features/security/secure-defaults.test.ts
+++ b/fiber-link-service/apps/admin/src/features/security/secure-defaults.test.ts
@@ -14,8 +14,19 @@ describe("secure defaults", () => {
     expect(canRunHighRiskAction(true)).toBe(true);
   });
 
-  it("fails closed when policy is uncertain and masks secrets", () => {
+  it("fails closed when policy is uncertain", () => {
     expect(evaluatePolicyDecision({ policyKnown: false })).toBe("deny");
-    expect(maskSensitive("abc123secretxyz")).toContain("***");
+  });
+
+  describe("maskSensitive", () => {
+    it("masks long strings and preserves prefix/suffix", () => {
+      expect(maskSensitive("abc123secretxyz")).toBe("ab***yz");
+    });
+
+    it("masks short strings completely", () => {
+      expect(maskSensitive("1234")).toBe("****");
+      expect(maskSensitive("abc")).toBe("****");
+      expect(maskSensitive("")).toBe("****");
+    });
   });
 });

--- a/fiber-link-service/apps/admin/src/features/security/secure-defaults.ts
+++ b/fiber-link-service/apps/admin/src/features/security/secure-defaults.ts
@@ -13,6 +13,7 @@ export const SECURE_DEFAULTS: SecurityDefaults = {
 };
 
 export function maskSensitive(value: string): string {
+  if (value.length <= 4) return "****";
   return value.replace(/([A-Za-z0-9]{2})[A-Za-z0-9]+([A-Za-z0-9]{2})/g, "$1***$2");
 }
 


### PR DESCRIPTION
## Summary
Implements secure-by-default baseline logic for first-run and day-2 safety behavior.

## Changes
- Added explicit secure defaults (least-privilege mode, output masking, confirmation gates, fail-closed policy behavior)
- Added sensitive-value masking helper
- Added explicit confirmation requirement for high-risk actions
- Added fail-closed decision path when policy certainty is missing
- Added unit tests that guard against accidental default broadening

## Issue
Closes #187

## Acceptance Mapping
- **Fresh install secure by default**: baseline defaults are all secure-first and enabled.
- **Sensitive data consistently redacted**: masking helper is included and tested.
- **High-risk actions require explicit confirmation**: unconfirmed high-risk actions are blocked.
