### PR TITLE
feat(worker): harden settlement subscription resilience and config typing

### DIFF
--- a/fiber-link-service/apps/admin/src/pages/dashboard-model.type.test.ts
+++ b/fiber-link-service/apps/admin/src/pages/dashboard-model.type.test.ts
@@ -1,0 +1,17 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { appRouter } from "../server/api/routers/app";
+import { withdrawalRouter } from "../server/api/routers/withdrawal";
+import type { DashboardApp, DashboardWithdrawal } from "./dashboard-model";
+
+type AppListOutput = Awaited<ReturnType<ReturnType<typeof appRouter.createCaller>["list"]>>;
+type WithdrawalListOutput = Awaited<ReturnType<ReturnType<typeof withdrawalRouter.createCaller>["list"]>>;
+
+describe("dashboard-model type alignment", () => {
+  it("keeps dashboard app type aligned to router output", () => {
+    expectTypeOf<DashboardApp>().toEqualTypeOf<AppListOutput[number]>();
+  });
+
+  it("keeps dashboard withdrawal type aligned to router output", () => {
+    expectTypeOf<DashboardWithdrawal>().toEqualTypeOf<WithdrawalListOutput[number]>();
+  });
+});

--- a/fiber-link-service/apps/worker/src/config.test.ts
+++ b/fiber-link-service/apps/worker/src/config.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { parseWorkerConfig } from "./config";
+
+describe("parseWorkerConfig", () => {
+  const baseEnv: NodeJS.ProcessEnv = {
+    FIBER_RPC_URL: "http://127.0.0.1:8227",
+  };
+
+  it("loads defaults and derives dependent retries", () => {
+    const config = parseWorkerConfig(baseEnv);
+
+    expect(config.withdrawalIntervalMs).toBe(30_000);
+    expect(config.settlementIntervalMs).toBe(30_000);
+    expect(config.settlementBatchSize).toBe(200);
+    expect(config.maxRetries).toBe(3);
+    expect(config.settlementMaxRetries).toBe(3);
+    expect(config.retryDelayMs).toBe(60_000);
+    expect(config.settlementRetryDelayMs).toBe(60_000);
+    expect(config.settlementStrategy).toBe("polling");
+    expect(config.subscriptionConcurrency).toBe(1);
+    expect(config.subscriptionMaxPendingEvents).toBe(1000);
+    expect(config.subscriptionRecentInvoiceDedupeSize).toBe(256);
+  });
+
+  it("normalizes settlement strategy and cursor file", () => {
+    const config = parseWorkerConfig({
+      ...baseEnv,
+      WORKER_SETTLEMENT_STRATEGY: " Subscription ",
+      WORKER_SETTLEMENT_CURSOR_FILE: "  /tmp/worker-cursor.json  ",
+    });
+
+    expect(config.settlementStrategy).toBe("subscription");
+    expect(config.settlementCursorFile).toBe("/tmp/worker-cursor.json");
+  });
+
+  it.each([
+    {
+      name: "invalid positive integer field",
+      env: { ...baseEnv, WORKER_SETTLEMENT_BATCH_SIZE: "0" },
+      expectedMessage: "Invalid WORKER_SETTLEMENT_BATCH_SIZE: expected integer >= 1",
+    },
+    {
+      name: "invalid non-negative integer field",
+      env: { ...baseEnv, WORKER_MAX_RETRIES: "-1" },
+      expectedMessage: "Invalid WORKER_MAX_RETRIES: expected integer >= 0",
+    },
+    {
+      name: "invalid settlement strategy enum",
+      env: { ...baseEnv, WORKER_SETTLEMENT_STRATEGY: "stream" },
+      expectedMessage:
+        "Invalid WORKER_SETTLEMENT_STRATEGY: expected one of polling, subscription, received \"stream\"",
+    },
+    {
+      name: "missing rpc endpoint",
+      env: { ...baseEnv, FIBER_RPC_URL: "   " },
+      expectedMessage: "FIBER_RPC_URL is required",
+    },
+    {
+      name: "empty cursor file",
+      env: { ...baseEnv, WORKER_SETTLEMENT_CURSOR_FILE: "   " },
+      expectedMessage: "WORKER_SETTLEMENT_CURSOR_FILE must not be empty",
+    },
+    {
+      name: "invalid subscription concurrency",
+      env: { ...baseEnv, WORKER_SETTLEMENT_SUBSCRIPTION_CONCURRENCY: "0" },
+      expectedMessage: "Invalid WORKER_SETTLEMENT_SUBSCRIPTION_CONCURRENCY: expected integer >= 1",
+    },
+    {
+      name: "invalid subscription pending queue size",
+      env: { ...baseEnv, WORKER_SETTLEMENT_SUBSCRIPTION_MAX_PENDING_EVENTS: "-1" },
+      expectedMessage: "Invalid WORKER_SETTLEMENT_SUBSCRIPTION_MAX_PENDING_EVENTS: expected integer >= 0",
+    },
+    {
+      name: "invalid dedupe window size",
+      env: { ...baseEnv, WORKER_SETTLEMENT_SUBSCRIPTION_RECENT_INVOICE_DEDUPE_SIZE: "-1" },
+      expectedMessage:
+        "Invalid WORKER_SETTLEMENT_SUBSCRIPTION_RECENT_INVOICE_DEDUPE_SIZE: expected integer >= 0",
+    },
+  ])("$name", ({ env, expectedMessage }) => {
+    expect(() => parseWorkerConfig(env)).toThrow(expectedMessage);
+  });
+});

--- a/fiber-link-service/apps/worker/src/config.ts
+++ b/fiber-link-service/apps/worker/src/config.ts
@@ -1,0 +1,117 @@
+export type WorkerSettlementStrategy = "polling" | "subscription";
+
+export type WorkerConfig = {
+  withdrawalIntervalMs: number;
+  settlementIntervalMs: number;
+  settlementBatchSize: number;
+  maxRetries: number;
+  retryDelayMs: number;
+  settlementMaxRetries: number;
+  settlementRetryDelayMs: number;
+  settlementPendingTimeoutMs: number;
+  shutdownTimeoutMs: number;
+  settlementStrategy: WorkerSettlementStrategy;
+  settlementCursorFile: string;
+  fiberRpcUrl: string;
+  subscriptionConcurrency: number;
+  subscriptionMaxPendingEvents: number;
+  subscriptionRecentInvoiceDedupeSize: number;
+};
+
+function parseInteger(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number,
+  min: number,
+): number {
+  const raw = env[name];
+  const value = raw === undefined ? fallback : Number(raw);
+  if (!Number.isInteger(value) || value < min) {
+    throw new Error(`Invalid ${name}: expected integer >= ${min}`);
+  }
+  return value;
+}
+
+function parseStrategy(env: NodeJS.ProcessEnv): WorkerSettlementStrategy {
+  const raw = (env.WORKER_SETTLEMENT_STRATEGY ?? "polling").trim().toLowerCase();
+  if (raw === "polling" || raw === "subscription") {
+    return raw;
+  }
+  throw new Error(
+    `Invalid WORKER_SETTLEMENT_STRATEGY: expected one of polling, subscription, received "${raw}"`,
+  );
+}
+
+export function parseWorkerConfig(env: NodeJS.ProcessEnv = process.env): WorkerConfig {
+  const withdrawalIntervalMs = parseInteger(env, "WORKER_WITHDRAWAL_INTERVAL_MS", 30_000, 1);
+  const settlementIntervalMs = parseInteger(env, "WORKER_SETTLEMENT_INTERVAL_MS", 30_000, 1);
+  const settlementBatchSize = parseInteger(env, "WORKER_SETTLEMENT_BATCH_SIZE", 200, 1);
+  const maxRetries = parseInteger(env, "WORKER_MAX_RETRIES", 3, 0);
+  const retryDelayMs = parseInteger(env, "WORKER_RETRY_DELAY_MS", 60_000, 1);
+  const settlementMaxRetries = parseInteger(
+    env,
+    "WORKER_SETTLEMENT_MAX_RETRIES",
+    maxRetries,
+    0,
+  );
+  const settlementRetryDelayMs = parseInteger(
+    env,
+    "WORKER_SETTLEMENT_RETRY_DELAY_MS",
+    retryDelayMs,
+    1,
+  );
+  const settlementPendingTimeoutMs = parseInteger(
+    env,
+    "WORKER_SETTLEMENT_PENDING_TIMEOUT_MS",
+    30 * 60_000,
+    1,
+  );
+  const shutdownTimeoutMs = parseInteger(env, "WORKER_SHUTDOWN_TIMEOUT_MS", 15_000, 1);
+  const settlementStrategy = parseStrategy(env);
+  const settlementCursorFile = (env.WORKER_SETTLEMENT_CURSOR_FILE ?? "/var/lib/fiber-link/settlement-cursor.json")
+    .trim();
+  const fiberRpcUrl = (env.FIBER_RPC_URL ?? "").trim();
+  const subscriptionConcurrency = parseInteger(
+    env,
+    "WORKER_SETTLEMENT_SUBSCRIPTION_CONCURRENCY",
+    1,
+    1,
+  );
+  const subscriptionMaxPendingEvents = parseInteger(
+    env,
+    "WORKER_SETTLEMENT_SUBSCRIPTION_MAX_PENDING_EVENTS",
+    1000,
+    0,
+  );
+  const subscriptionRecentInvoiceDedupeSize = parseInteger(
+    env,
+    "WORKER_SETTLEMENT_SUBSCRIPTION_RECENT_INVOICE_DEDUPE_SIZE",
+    256,
+    0,
+  );
+
+  if (!fiberRpcUrl) {
+    throw new Error("FIBER_RPC_URL is required");
+  }
+  if (!settlementCursorFile) {
+    throw new Error("WORKER_SETTLEMENT_CURSOR_FILE must not be empty");
+  }
+
+  return {
+    withdrawalIntervalMs,
+    settlementIntervalMs,
+    settlementBatchSize,
+    maxRetries,
+    retryDelayMs,
+    settlementMaxRetries,
+    settlementRetryDelayMs,
+    settlementPendingTimeoutMs,
+    shutdownTimeoutMs,
+    settlementStrategy,
+    settlementCursorFile,
+    fiberRpcUrl,
+    subscriptionConcurrency,
+    subscriptionMaxPendingEvents,
+    subscriptionRecentInvoiceDedupeSize,
+  };
+}

--- a/fiber-link-service/apps/worker/src/entry.ts
+++ b/fiber-link-service/apps/worker/src/entry.ts
@@ -1,5 +1,6 @@
 import { createAdapter } from "@fiber-link/fiber-adapter";
 import type { TipIntentListCursor } from "@fiber-link/db";
+import { parseWorkerConfig } from "./config";
 import { runSettlementDiscovery } from "./settlement-discovery";
 import { createFileSettlementCursorStore } from "./settlement-cursor-store";
 import {
@@ -8,84 +9,29 @@ import {
 } from "./settlement-subscription-runner";
 import { createWorkerRuntime } from "./worker-runtime";
 
-const withdrawalIntervalMs = Number(process.env.WORKER_WITHDRAWAL_INTERVAL_MS ?? "30000");
-const settlementIntervalMs = Number(process.env.WORKER_SETTLEMENT_INTERVAL_MS ?? "30000");
-const settlementBatchSize = Number(process.env.WORKER_SETTLEMENT_BATCH_SIZE ?? "200");
-const maxRetries = Number(process.env.WORKER_MAX_RETRIES ?? "3");
-const retryDelayMs = Number(process.env.WORKER_RETRY_DELAY_MS ?? "60000");
-const settlementMaxRetries = Number(process.env.WORKER_SETTLEMENT_MAX_RETRIES ?? String(maxRetries));
-const settlementRetryDelayMs = Number(process.env.WORKER_SETTLEMENT_RETRY_DELAY_MS ?? String(retryDelayMs));
-const settlementPendingTimeoutMs = Number(process.env.WORKER_SETTLEMENT_PENDING_TIMEOUT_MS ?? "1800000");
-const shutdownTimeoutMs = Number(process.env.WORKER_SHUTDOWN_TIMEOUT_MS ?? "15000");
-const settlementStrategyRaw = (process.env.WORKER_SETTLEMENT_STRATEGY ?? "polling").trim().toLowerCase();
-const settlementStrategy = settlementStrategyRaw as "polling" | "subscription";
-const settlementCursorFile =
-  process.env.WORKER_SETTLEMENT_CURSOR_FILE ?? "/var/lib/fiber-link/settlement-cursor.json";
-const fiberRpcUrl = process.env.FIBER_RPC_URL;
-
-if (!Number.isInteger(withdrawalIntervalMs) || withdrawalIntervalMs <= 0) {
-  throw new Error(`Invalid WORKER_WITHDRAWAL_INTERVAL_MS: ${process.env.WORKER_WITHDRAWAL_INTERVAL_MS ?? ""}`);
-}
-if (!Number.isInteger(settlementIntervalMs) || settlementIntervalMs <= 0) {
-  throw new Error(`Invalid WORKER_SETTLEMENT_INTERVAL_MS: ${process.env.WORKER_SETTLEMENT_INTERVAL_MS ?? ""}`);
-}
-if (!Number.isInteger(settlementBatchSize) || settlementBatchSize <= 0) {
-  throw new Error(`Invalid WORKER_SETTLEMENT_BATCH_SIZE: ${process.env.WORKER_SETTLEMENT_BATCH_SIZE ?? ""}`);
-}
-if (!Number.isInteger(maxRetries) || maxRetries < 0) {
-  throw new Error(`Invalid WORKER_MAX_RETRIES: ${process.env.WORKER_MAX_RETRIES ?? ""}`);
-}
-if (!Number.isInteger(retryDelayMs) || retryDelayMs <= 0) {
-  throw new Error(`Invalid WORKER_RETRY_DELAY_MS: ${process.env.WORKER_RETRY_DELAY_MS ?? ""}`);
-}
-if (!Number.isInteger(settlementMaxRetries) || settlementMaxRetries < 0) {
-  throw new Error(`Invalid WORKER_SETTLEMENT_MAX_RETRIES: ${process.env.WORKER_SETTLEMENT_MAX_RETRIES ?? ""}`);
-}
-if (!Number.isInteger(settlementRetryDelayMs) || settlementRetryDelayMs <= 0) {
-  throw new Error(
-    `Invalid WORKER_SETTLEMENT_RETRY_DELAY_MS: ${process.env.WORKER_SETTLEMENT_RETRY_DELAY_MS ?? ""}`,
-  );
-}
-if (!Number.isInteger(settlementPendingTimeoutMs) || settlementPendingTimeoutMs <= 0) {
-  throw new Error(
-    `Invalid WORKER_SETTLEMENT_PENDING_TIMEOUT_MS: ${process.env.WORKER_SETTLEMENT_PENDING_TIMEOUT_MS ?? ""}`,
-  );
-}
-if (!Number.isInteger(shutdownTimeoutMs) || shutdownTimeoutMs <= 0) {
-  throw new Error(`Invalid WORKER_SHUTDOWN_TIMEOUT_MS: ${process.env.WORKER_SHUTDOWN_TIMEOUT_MS ?? ""}`);
-}
-if (settlementStrategy !== "polling" && settlementStrategy !== "subscription") {
-  throw new Error(`Invalid WORKER_SETTLEMENT_STRATEGY: ${process.env.WORKER_SETTLEMENT_STRATEGY ?? ""}`);
-}
-if (!fiberRpcUrl) {
-  throw new Error("FIBER_RPC_URL is required");
-}
-if (!settlementCursorFile.trim()) {
-  throw new Error("WORKER_SETTLEMENT_CURSOR_FILE must not be empty");
-}
-
 async function main() {
-  const fiberAdapter = createAdapter({ endpoint: fiberRpcUrl });
-  const cursorStore = createFileSettlementCursorStore(settlementCursorFile);
+  const config = parseWorkerConfig(process.env);
+  const fiberAdapter = createAdapter({ endpoint: config.fiberRpcUrl });
+  const cursorStore = createFileSettlementCursorStore(config.settlementCursorFile);
   let settlementCursor: TipIntentListCursor | undefined = await cursorStore.load();
   let subscriptionRunner: SettlementSubscriptionRunner | null = null;
 
   const runtime = createWorkerRuntime({
-    intervalMs: Math.min(withdrawalIntervalMs, settlementIntervalMs),
-    withdrawalIntervalMs,
-    maxRetries,
-    retryDelayMs,
-    shutdownTimeoutMs,
-    settlementIntervalMs,
-    settlementBatchSize,
+    intervalMs: Math.min(config.withdrawalIntervalMs, config.settlementIntervalMs),
+    withdrawalIntervalMs: config.withdrawalIntervalMs,
+    maxRetries: config.maxRetries,
+    retryDelayMs: config.retryDelayMs,
+    shutdownTimeoutMs: config.shutdownTimeoutMs,
+    settlementIntervalMs: config.settlementIntervalMs,
+    settlementBatchSize: config.settlementBatchSize,
     pollSettlements: async ({ limit }) => {
       const summary = await runSettlementDiscovery({
         limit,
         cursor: settlementCursor,
         adapter: fiberAdapter,
-        maxRetries: settlementMaxRetries,
-        retryDelayMs: settlementRetryDelayMs,
-        pendingTimeoutMs: settlementPendingTimeoutMs,
+        maxRetries: config.settlementMaxRetries,
+        retryDelayMs: config.settlementRetryDelayMs,
+        pendingTimeoutMs: config.settlementPendingTimeoutMs,
       });
       settlementCursor = summary.nextCursor ?? undefined;
       await cursorStore.save(settlementCursor);
@@ -93,14 +39,20 @@ async function main() {
     },
   });
 
-  if (settlementStrategy === "subscription") {
+  if (config.settlementStrategy === "subscription") {
     try {
       subscriptionRunner = await startSettlementSubscriptionRunner({
         adapter: fiberAdapter,
+        concurrency: config.subscriptionConcurrency,
+        maxPendingEvents: config.subscriptionMaxPendingEvents,
+        recentInvoiceDedupeSize: config.subscriptionRecentInvoiceDedupeSize,
       });
       console.info("[worker] settlement strategy enabled", {
         strategy: "subscription",
         pollingFallback: true,
+        subscriptionConcurrency: config.subscriptionConcurrency,
+        maxPendingEvents: config.subscriptionMaxPendingEvents,
+        recentInvoiceDedupeSize: config.subscriptionRecentInvoiceDedupeSize,
       });
     } catch (error) {
       console.error("[worker] settlement subscription startup failed; continuing with polling fallback", error);

--- a/fiber-link-service/apps/worker/src/logger-contract.test.ts
+++ b/fiber-link-service/apps/worker/src/logger-contract.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createInMemoryLedgerRepo,
+  createInMemoryTipIntentRepo,
+  type InvoiceState,
+} from "@fiber-link/db";
+import { runSettlementDiscovery } from "./settlement-discovery";
+import { startSettlementSubscriptionRunner } from "./settlement-subscription-runner";
+import { createWorkerRuntime } from "./worker-runtime";
+
+describe("worker structured logging contract", () => {
+  const tipIntentRepo = createInMemoryTipIntentRepo();
+  const ledgerRepo = createInMemoryLedgerRepo();
+
+  beforeEach(() => {
+    tipIntentRepo.__resetForTests?.();
+    ledgerRepo.__resetForTests?.();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits structured startup/shutdown payloads", async () => {
+    const logs: unknown[] = [];
+    const errors: unknown[] = [];
+    const warnings: unknown[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args[0]);
+    });
+    vi.spyOn(console, "error").mockImplementation((...args) => {
+      errors.push(args[0]);
+    });
+    vi.spyOn(console, "warn").mockImplementation((...args) => {
+      warnings.push(args[0]);
+    });
+
+    const runtime = createWorkerRuntime({
+      intervalMs: 1000,
+      maxRetries: 3,
+      retryDelayMs: 100,
+      shutdownTimeoutMs: 100,
+      runWithdrawalBatch: async () => undefined,
+      exitFn: () => undefined,
+      setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval>,
+      clearIntervalFn: () => undefined,
+    });
+    await runtime.start();
+    await runtime.shutdown("manual");
+
+    const started = logs.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        (entry as Record<string, unknown>).event === "worker.runtime.started",
+    ) as Record<string, unknown> | undefined;
+    const shutdown = logs.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        (entry as Record<string, unknown>).event === "worker.runtime.shutdown",
+    ) as Record<string, unknown> | undefined;
+
+    expect(started).toMatchObject({
+      component: "worker-runtime",
+      event: "worker.runtime.started",
+      severity: "info",
+    });
+    expect(shutdown).toMatchObject({
+      component: "worker-runtime",
+      event: "worker.runtime.shutdown",
+      severity: "info",
+    });
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("emits structured subscription event payload with settlement correlation id", async () => {
+    const logs: unknown[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args[0]);
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const intent = await tipIntentRepo.create({
+      appId: "app-log",
+      postId: "post-log",
+      fromUserId: "from-log",
+      toUserId: "to-log",
+      asset: "USDI",
+      amount: "7",
+      invoice: "inv-log-1",
+    });
+    let emit: ((invoice: string) => void | Promise<void>) | null = null;
+    const runner = await startSettlementSubscriptionRunner({
+      adapter: {
+        async subscribeSettlements(args) {
+          emit = args.onSettled;
+          return { close: () => undefined };
+        },
+      },
+      tipIntentRepo,
+      ledgerRepo,
+    });
+
+    await emit?.(intent.invoice);
+    await runner.close();
+
+    const payload = logs.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        (entry as Record<string, unknown>).event === "settlement.subscription.processed",
+    ) as Record<string, unknown> | undefined;
+
+    expect(payload).toMatchObject({
+      component: "settlement-subscription-runner",
+      event: "settlement.subscription.processed",
+      severity: "info",
+      invoice: intent.invoice,
+      requestId: `settlement:${intent.invoice}`,
+    });
+  });
+
+  it("emits structured fallback scan summary payload", async () => {
+    const logs: unknown[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args[0]);
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const invoiceStates = new Map<string, InvoiceState>();
+    const intent = await tipIntentRepo.create({
+      appId: "app-fallback-log",
+      postId: "post-fallback-log",
+      fromUserId: "from-fallback-log",
+      toUserId: "to-fallback-log",
+      asset: "USDI",
+      amount: "6",
+      invoice: "inv-fallback-log",
+    });
+    invoiceStates.set(intent.invoice, "SETTLED");
+
+    await runSettlementDiscovery({
+      limit: 10,
+      adapter: {
+        async getInvoiceStatus({ invoice }) {
+          return { state: invoiceStates.get(invoice) ?? "UNPAID" };
+        },
+      },
+      tipIntentRepo,
+      ledgerRepo,
+    });
+
+    const summary = logs.find(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        (entry as Record<string, unknown>).event === "settlement.discovery.summary",
+    ) as Record<string, unknown> | undefined;
+
+    expect(summary).toMatchObject({
+      component: "settlement-discovery",
+      event: "settlement.discovery.summary",
+      severity: "info",
+    });
+    expect(summary?.scanned).toBe(1);
+    expect(summary?.settledCredits).toBe(1);
+  });
+});

--- a/fiber-link-service/apps/worker/src/logger.ts
+++ b/fiber-link-service/apps/worker/src/logger.ts
@@ -1,0 +1,82 @@
+export type WorkerLogSeverity = "info" | "warn" | "error";
+
+export type WorkerLogContext = {
+  requestId?: string;
+  invoice?: string;
+  appId?: string;
+  [key: string]: unknown;
+};
+
+export type WorkerStructuredLog = WorkerLogContext & {
+  component: string;
+  event: string;
+  severity: WorkerLogSeverity;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toJsonSafe(value: unknown): unknown {
+  try {
+    return JSON.parse(
+      JSON.stringify(value, (_key, current) => {
+        if (typeof current === "bigint") {
+          return current.toString();
+        }
+        if (current instanceof Error) {
+          return {
+            name: current.name,
+            message: current.message,
+            stack: current.stack,
+          };
+        }
+        return current;
+      }),
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+function buildPayload(
+  component: string,
+  event: string,
+  severity: WorkerLogSeverity,
+  context?: WorkerLogContext,
+): WorkerStructuredLog {
+  const safeContext = toJsonSafe(context ?? {});
+  const payloadBase = {
+    component,
+    event,
+    severity,
+  };
+  if (!isRecord(safeContext)) {
+    return {
+      ...payloadBase,
+      details: safeContext,
+    };
+  }
+  return {
+    ...payloadBase,
+    ...safeContext,
+  };
+}
+
+export function createComponentLogger(component: string): {
+  info: (event: string, context?: WorkerLogContext) => void;
+  warn: (event: string, context?: WorkerLogContext) => void;
+  error: (event: string, context?: WorkerLogContext) => void;
+} {
+  return {
+    info(event, context) {
+      console.log(buildPayload(component, event, "info", context));
+    },
+    warn(event, context) {
+      console.warn(buildPayload(component, event, "warn", context));
+    },
+    error(event, context) {
+      console.error(buildPayload(component, event, "error", context));
+    },
+  };
+}

--- a/fiber-link-service/apps/worker/src/settlement-subscription-runner.test.ts
+++ b/fiber-link-service/apps/worker/src/settlement-subscription-runner.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { startSettlementSubscriptionRunner } from "./settlement-subscription-runner";
+import { markSettled } from "./settlement";
+
+vi.mock("./settlement", () => ({
+  markSettled: vi.fn(),
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("startSettlementSubscriptionRunner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("drops overflow events once pending queue is full", async () => {
+    const overflowed: string[] = [];
+    const first = createDeferred<{ credited: boolean; idempotencyKey: string }>();
+    const settleMock = vi.mocked(markSettled);
+    settleMock.mockImplementationOnce(async () => first.promise);
+    settleMock.mockResolvedValue({
+      credited: true,
+      idempotencyKey: "settlement:key:next",
+    });
+
+    let onSettled: ((invoice: string) => void | Promise<void>) | null = null;
+    const runner = await startSettlementSubscriptionRunner({
+      adapter: {
+        async subscribeSettlements(args) {
+          onSettled = args.onSettled;
+          return {
+            close: () => undefined,
+          };
+        },
+      },
+      maxPendingEvents: 1,
+      onQueueOverflow(info) {
+        overflowed.push(info.invoice);
+      },
+      logger: {
+        info: () => undefined,
+        error: () => undefined,
+      },
+    });
+
+    await onSettled?.("inv-1");
+    await onSettled?.("inv-2");
+    await onSettled?.("inv-3");
+    await Promise.resolve();
+
+    expect(settleMock).toHaveBeenCalledTimes(1);
+    expect(overflowed).toEqual(["inv-3"]);
+
+    first.resolve({
+      credited: true,
+      idempotencyKey: "settlement:key:first",
+    });
+    await runner.close();
+
+    expect(settleMock).toHaveBeenCalledTimes(2);
+    expect(settleMock.mock.calls.map((call) => call[0].invoice)).toEqual(["inv-1", "inv-2"]);
+  });
+
+  it("dedupes duplicate burst invoices inside active and recent windows", async () => {
+    const settleMock = vi.mocked(markSettled);
+    settleMock.mockResolvedValue({
+      credited: true,
+      idempotencyKey: "settlement:key",
+    });
+
+    let onSettled: ((invoice: string) => void | Promise<void>) | null = null;
+    const runner = await startSettlementSubscriptionRunner({
+      adapter: {
+        async subscribeSettlements(args) {
+          onSettled = args.onSettled;
+          return {
+            close: () => undefined,
+          };
+        },
+      },
+      recentInvoiceDedupeSize: 32,
+      logger: {
+        info: () => undefined,
+        error: () => undefined,
+      },
+    });
+
+    await onSettled?.("inv-dup");
+    await onSettled?.("inv-dup");
+    await onSettled?.("inv-dup");
+    await runner.close();
+
+    expect(settleMock).toHaveBeenCalledTimes(1);
+    expect(settleMock).toHaveBeenCalledWith(
+      { invoice: "inv-dup" },
+      expect.any(Object),
+    );
+  });
+
+  it("drains queued work before shutdown resolves", async () => {
+    const settleMock = vi.mocked(markSettled);
+    const deferred = createDeferred<{ credited: boolean; idempotencyKey: string }>();
+    settleMock.mockImplementationOnce(async () => deferred.promise);
+
+    let onSettled: ((invoice: string) => void | Promise<void>) | null = null;
+    let subscriptionClosed = false;
+    const runner = await startSettlementSubscriptionRunner({
+      adapter: {
+        async subscribeSettlements(args) {
+          onSettled = args.onSettled;
+          return {
+            close: async () => {
+              subscriptionClosed = true;
+            },
+          };
+        },
+      },
+      logger: {
+        info: () => undefined,
+        error: () => undefined,
+      },
+    });
+
+    await onSettled?.("inv-close");
+    await Promise.resolve();
+
+    let closed = false;
+    const closePromise = runner.close().then(() => {
+      closed = true;
+    });
+    await Promise.resolve();
+
+    expect(subscriptionClosed).toBe(true);
+    expect(closed).toBe(false);
+
+    deferred.resolve({
+      credited: true,
+      idempotencyKey: "settlement:key:close",
+    });
+    await closePromise;
+
+    expect(closed).toBe(true);
+    expect(settleMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/fiber-link-service/apps/worker/src/settlement-subscription-runner.ts
+++ b/fiber-link-service/apps/worker/src/settlement-subscription-runner.ts
@@ -1,9 +1,18 @@
 import type { LedgerRepo, TipIntentRepo } from "@fiber-link/db";
+import { createComponentLogger, type WorkerLogContext } from "./logger";
 import { markSettled } from "./settlement";
 
+type QueueOverflowInfo = {
+  invoice: string;
+  queueLength: number;
+  inFlight: number;
+  droppedTotal: number;
+  policy: "drop_new";
+};
+
 type SettlementSubscriptionLogger = {
-  info: (message: string, context?: Record<string, unknown>) => void;
-  error: (message: string, error?: unknown) => void;
+  info: (event: string, context?: WorkerLogContext) => void;
+  error: (event: string, context?: WorkerLogContext) => void;
 };
 
 type SettlementSubscriptionHandle = {
@@ -22,6 +31,10 @@ export type StartSettlementSubscriptionRunnerOptions = {
   tipIntentRepo?: TipIntentRepo;
   ledgerRepo?: LedgerRepo;
   logger?: SettlementSubscriptionLogger;
+  concurrency?: number;
+  maxPendingEvents?: number;
+  recentInvoiceDedupeSize?: number;
+  onQueueOverflow?: (info: QueueOverflowInfo) => void;
 };
 
 export type SettlementSubscriptionRunner = {
@@ -29,52 +42,207 @@ export type SettlementSubscriptionRunner = {
 };
 
 const defaultLogger: SettlementSubscriptionLogger = {
-  info(message, context) {
-    console.log(message, context ?? {});
-  },
-  error(message, error) {
-    console.error(message, error);
-  },
+  ...createComponentLogger("settlement-subscription-runner"),
 };
+
+function parseIntegerOption({
+  name,
+  value,
+  min,
+  fallback,
+}: {
+  name: string;
+  value: number | undefined;
+  min: number;
+  fallback: number;
+}): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (!Number.isInteger(value) || value < min) {
+    throw new Error(`Invalid ${name}: expected integer >= ${min}, received ${String(value)}`);
+  }
+  return value;
+}
 
 export async function startSettlementSubscriptionRunner(
   options: StartSettlementSubscriptionRunnerOptions,
 ): Promise<SettlementSubscriptionRunner> {
   const logger = options.logger ?? defaultLogger;
+  const concurrency = parseIntegerOption({
+    name: "concurrency",
+    value: options.concurrency,
+    min: 1,
+    fallback: 1,
+  });
+  const maxPendingEvents = parseIntegerOption({
+    name: "maxPendingEvents",
+    value: options.maxPendingEvents,
+    min: 0,
+    fallback: 1000,
+  });
+  const recentInvoiceDedupeSize = parseIntegerOption({
+    name: "recentInvoiceDedupeSize",
+    value: options.recentInvoiceDedupeSize,
+    min: 0,
+    fallback: 256,
+  });
+
+  const queue: string[] = [];
+  const activeInvoices = new Set<string>();
+  const recentInvoices = new Set<string>();
+  const recentOrder: string[] = [];
+  let inFlight = 0;
+  let closing = false;
+  let overflowDropped = 0;
+  let deduped = 0;
+  let drainingPromise: Promise<void> | null = null;
+  let resolveDraining: (() => void) | null = null;
+
+  const markRecent = (invoice: string) => {
+    if (recentInvoiceDedupeSize === 0 || recentInvoices.has(invoice)) {
+      return;
+    }
+    recentInvoices.add(invoice);
+    recentOrder.push(invoice);
+    while (recentOrder.length > recentInvoiceDedupeSize) {
+      const removed = recentOrder.shift();
+      if (removed) {
+        recentInvoices.delete(removed);
+      }
+    }
+  };
+
+  const createDrainingPromise = () => {
+    if (drainingPromise) {
+      return drainingPromise;
+    }
+    drainingPromise = new Promise<void>((resolve) => {
+      resolveDraining = resolve;
+    });
+    return drainingPromise;
+  };
+
+  const notifyIfDrained = () => {
+    if (queue.length === 0 && inFlight === 0 && resolveDraining) {
+      const resolve = resolveDraining;
+      resolveDraining = null;
+      drainingPromise = null;
+      resolve();
+    }
+  };
+
+  const runQueue = () => {
+    while (inFlight < concurrency && queue.length > 0) {
+      const invoice = queue.shift();
+      if (!invoice) {
+        continue;
+      }
+      inFlight += 1;
+
+      void (async () => {
+        try {
+          const result = await markSettled(
+            { invoice },
+            {
+              tipIntentRepo: options.tipIntentRepo,
+              ledgerRepo: options.ledgerRepo,
+            },
+          );
+          logger.info("settlement.subscription.processed", {
+            invoice,
+            requestId: `settlement:${invoice}`,
+            credited: result.credited,
+            idempotencyKey: result.idempotencyKey,
+          });
+        } catch (error) {
+          logger.error("settlement.subscription.process_failed", {
+            invoice,
+            requestId: `settlement:${invoice}`,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        } finally {
+          inFlight -= 1;
+          activeInvoices.delete(invoice);
+          markRecent(invoice);
+          notifyIfDrained();
+          runQueue();
+        }
+      })();
+    }
+  };
+
+  const enqueue = (invoice: string) => {
+    if (closing) {
+      logger.error("settlement.subscription.ignored_during_shutdown", {
+        invoice,
+        requestId: `settlement:${invoice}`,
+      });
+      return;
+    }
+
+    if (activeInvoices.has(invoice) || recentInvoices.has(invoice)) {
+      deduped += 1;
+      logger.info("settlement.subscription.deduped", {
+        invoice,
+        requestId: `settlement:${invoice}`,
+        dedupedTotal: deduped,
+      });
+      return;
+    }
+
+    if (inFlight >= concurrency && queue.length >= maxPendingEvents) {
+      overflowDropped += 1;
+      const info: QueueOverflowInfo = {
+        invoice,
+        queueLength: queue.length,
+        inFlight,
+        droppedTotal: overflowDropped,
+        policy: "drop_new",
+      };
+      options.onQueueOverflow?.(info);
+      logger.error("settlement.subscription.queue_overflow", {
+        ...info,
+        requestId: `settlement:${invoice}`,
+        fallback: "polling",
+      });
+      return;
+    }
+
+    queue.push(invoice);
+    activeInvoices.add(invoice);
+    runQueue();
+  };
+
   const subscription = await options.adapter.subscribeSettlements({
     onSettled: async (invoice) => {
-      try {
-        const result = await markSettled(
-          { invoice },
-          {
-            tipIntentRepo: options.tipIntentRepo,
-            ledgerRepo: options.ledgerRepo,
-          },
-        );
-        logger.info("[worker] settlement subscription event", {
-          invoice,
-          credited: result.credited,
-          idempotencyKey: result.idempotencyKey,
-        });
-      } catch (error) {
-        logger.error("[worker] settlement subscription invoice handling failed", {
-          invoice,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      enqueue(invoice);
     },
     onError: (error) => {
-      logger.error("[worker] settlement subscription stream failed", error);
+      logger.error("settlement.subscription.stream_failed", { error });
     },
   });
 
   return {
     async close() {
+      closing = true;
       try {
         await subscription.close();
       } catch (error) {
-        logger.error("[worker] settlement subscription shutdown failed", error);
+        logger.error("settlement.subscription.shutdown_failed", { error });
       }
+
+      if (queue.length > 0 || inFlight > 0) {
+        await createDrainingPromise();
+      }
+      notifyIfDrained();
+
+      logger.info("settlement.subscription.shutdown_summary", {
+        droppedOverflowEvents: overflowDropped,
+        dedupedEvents: deduped,
+        queueLength: queue.length,
+        inFlight,
+      });
     },
   };
 }

--- a/fiber-link-service/apps/worker/src/worker-runtime.test.ts
+++ b/fiber-link-service/apps/worker/src/worker-runtime.test.ts
@@ -171,7 +171,7 @@ describe("createWorkerRuntime", () => {
     ticks[0]?.();
     await Promise.resolve();
 
-    expect(warnings).toContain("[worker] previous worker cycle still running; skipping tick");
+    expect(warnings).toContain("worker.cycle.overlap");
 
     deferred.resolve();
     await runtime.shutdown("manual");


### PR DESCRIPTION
## Summary
- implement a bounded settlement subscription queue with configurable concurrency, burst dedupe, overflow drop policy, and shutdown drain guarantees
- add centralized worker env config parsing/validation and switch entry bootstrap to consume fully typed config (including subscription queue knobs)
- normalize worker structured logging contract (component/event/severity + correlation keys), add snapshot-style log contract tests, and remove unsafe admin dashboard router casts with type-alignment tests
- update settlement recovery runbook with subscription overflow/fallback operational notes

## Test Plan
- [x] cd fiber-link-service/apps/worker && bun run test --run
- [x] cd fiber-link-service/apps/admin && bun run test --run

Closes #173
Closes #177