### PR TITLE
docs: reconcile superseded/diverged docs with canonical index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@
 - `docs/current-architecture.md` — canonical source-of-truth index for architecture, current status, and historical redirects.
 - `docs/plans/2026-02-21-issue-32-epic-closeout.md` — latest closeout mapping for epic `#32`.
 - `docs/plans/2026-02-17-issue-32-epic-execution-status-tracker.md` — superseded historical status snapshot retained for traceability.
+- `docs/plans/2026-02-03-fiber-link-mvp-design.md` — historical early design snapshot; use canonical links at the top of the file.
+- `docs/plans/2026-02-03-fiber-link-mvp-plan.md` — historical implementation draft; use canonical links at the top of the file.
 
 ## Plugin testing
 

--- a/docs/current-architecture.md
+++ b/docs/current-architecture.md
@@ -1,6 +1,6 @@
 # Current Architecture (Canonical Index)
 
-Last updated: 2026-02-21
+Last updated: 2026-02-22
 
 This file is the source-of-truth index for architecture, operational boundaries, and active
 implementation references.
@@ -40,6 +40,15 @@ implementation references.
 These docs remain for historical traceability but should not be treated as current implementation
 guidance.
 
+- `docs/plans/2026-02-03-fiber-link-mvp-design.md`
+  - Status: diverged early-design snapshot.
+  - Canonical replacement: `docs/01-scope-mvp.md` and `docs/02-architecture.md`.
+  - Canonical index: `docs/current-architecture.md`.
+- `docs/plans/2026-02-03-fiber-link-mvp-plan.md`
+  - Status: superseded implementation draft.
+  - Canonical replacement: `docs/06-development-progress.md` and
+    `docs/plans/2026-02-21-issue-32-epic-closeout.md`.
+  - Canonical index: `docs/current-architecture.md`.
 - `docs/plans/2026-02-17-issue-32-epic-execution-status-tracker.md`
   - Status: superseded historical snapshot.
   - Canonical replacement: `docs/plans/2026-02-21-issue-32-epic-closeout.md`.
@@ -47,5 +56,5 @@ guidance.
 
 ## Freshness Snapshot
 
-- Historical/superseded docs tracked with explicit redirect: 1
+- Historical/superseded docs tracked with explicit redirect: 3
 - Planning placeholder marker count in `docs/`: 0

--- a/docs/plans/2026-02-03-fiber-link-mvp-design.md
+++ b/docs/plans/2026-02-03-fiber-link-mvp-design.md
@@ -1,6 +1,13 @@
 # Fiber Link MVP Design
 
 **Date:** 2026-02-03
+**Status:** Historical design snapshot (superseded)
+
+Canonical references:
+- `docs/current-architecture.md` (canonical index)
+- `docs/01-scope-mvp.md` (product scope baseline)
+- `docs/02-architecture.md` (current architecture and boundaries)
+- `docs/06-development-progress.md` (implementation status)
 
 ## Goal
 Deliver an end-to-end tipping and withdrawal flow for Discourse communities on CKB Fiber, with a custodial hub, internal ledger, and on-chain UDT withdrawals.

--- a/docs/plans/2026-02-03-fiber-link-mvp-plan.md
+++ b/docs/plans/2026-02-03-fiber-link-mvp-plan.md
@@ -1,5 +1,11 @@
 # Fiber Link MVP Implementation Plan
 
+Status: Historical implementation draft (superseded).
+Canonical references:
+- `docs/current-architecture.md` (canonical index)
+- `docs/06-development-progress.md` (current implementation status)
+- `docs/plans/2026-02-21-issue-32-epic-closeout.md` (latest epic closeout mapping)
+
 **Goal:** Build an MVP that enables Discourse tipping via CKB Fiber with a custodial hub, internal ledger, and batched UDT withdrawals, plus an Admin Web console.
 
 **Architecture:** Split into two repos. `fiber-link-service` hosts a Fastify JSON-RPC API for the Discourse plugin, a Next.js Admin Web (tRPC), a Drizzle/Postgres data layer, a Fiber Adapter wrapper, and background workers for settlement/reconciliation/withdrawals. Admin Web uses role-based access with **super admin + community admin**. `fiber-link-discourse-plugin` delivers the UI, polling, and HMAC-authenticated RPC calls.


### PR DESCRIPTION
## Summary
- add explicit historical/superseded status and canonical redirects to legacy MVP design/plan docs
- expand docs/current-architecture.md historical section to include all three tracked superseded/diverged docs
- sync docs/README.md roadmap section to reduce contributor ambiguity

## Validation
- docs-only change; verified links and counts via local diff review

Closes #211