### PR TITLE
feat(notifications): notification center foundation

### DIFF
--- a/fiber-link-service/packages/db/src/schema.test.ts
+++ b/fiber-link-service/packages/db/src/schema.test.ts
@@ -1,17 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { assetEnum, invoiceStateEnum, ledgerEntries, tipIntents, withdrawalStateEnum, withdrawals } from "./schema";
+import {
+  assetEnum,
+  invoiceStateEnum,
+  ledgerEntries,
+  notificationChannelKindEnum,
+  notificationChannels,
+  notificationEventEnum,
+  notificationRules,
+  tipIntents,
+  withdrawalStateEnum,
+  withdrawals,
+} from "./schema";
 
 describe("schema", () => {
   it("exports core tables", () => {
     expect(tipIntents).toBeDefined();
     expect(ledgerEntries).toBeDefined();
     expect(withdrawals).toBeDefined();
+    expect(notificationChannels).toBeDefined();
+    expect(notificationRules).toBeDefined();
   });
 
   it("pins asset and invoice lifecycle enums to supported states", () => {
     expect(assetEnum.enumValues).toEqual(["CKB", "USDI"]);
     expect(invoiceStateEnum.enumValues).toEqual(["UNPAID", "SETTLED", "FAILED"]);
     expect(withdrawalStateEnum.enumValues).toEqual(["PENDING", "PROCESSING", "RETRY_PENDING", "COMPLETED", "FAILED"]);
+    expect(notificationChannelKindEnum.enumValues).toEqual(["WEBHOOK"]);
+    expect(notificationEventEnum.enumValues).toEqual([
+      "WITHDRAWAL_RETRY_PENDING",
+      "WITHDRAWAL_FAILED",
+      "WITHDRAWAL_COMPLETED",
+    ]);
   });
 
   it("keeps idempotency and lifecycle columns explicitly modeled", () => {
@@ -20,5 +39,9 @@ describe("schema", () => {
     expect(ledgerEntries.idempotencyKey.name).toBe("idempotency_key");
     expect(withdrawals.state.name).toBe("state");
     expect(withdrawals.nextRetryAt.name).toBe("next_retry_at");
+    expect(notificationChannels.kind.name).toBe("kind");
+    expect(notificationChannels.enabled.name).toBe("enabled");
+    expect(notificationRules.event.name).toBe("event");
+    expect(notificationRules.channelId.name).toBe("channel_id");
   });
 });

--- a/fiber-link-service/packages/notifications/package.json
+++ b/fiber-link-service/packages/notifications/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fiber-link/notifications",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@fiber-link/db": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/fiber-link-service/packages/notifications/src/dispatcher.test.ts
+++ b/fiber-link-service/packages/notifications/src/dispatcher.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNotificationDispatcher } from "./dispatcher";
+import { createInMemoryNotificationRepo } from "./notification-repo";
+
+describe("createNotificationDispatcher", () => {
+  const repo = createInMemoryNotificationRepo();
+
+  beforeEach(() => {
+    repo.__resetForTests?.();
+  });
+
+  it("dispatches withdrawal event to matched channel handlers", async () => {
+    const firstChannel = await repo.createChannel({
+      appId: "app-1",
+      name: "first",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/first",
+    });
+    const secondChannel = await repo.createChannel({
+      appId: "app-1",
+      name: "second",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/second",
+    });
+
+    await repo.createRule({
+      appId: "app-1",
+      channelId: firstChannel.id,
+      event: "WITHDRAWAL_COMPLETED",
+    });
+    await repo.createRule({
+      appId: "app-1",
+      channelId: secondChannel.id,
+      event: "WITHDRAWAL_COMPLETED",
+    });
+
+    const webhookHandler = vi.fn(async () => {
+      return;
+    });
+    const dispatcher = createNotificationDispatcher({
+      repo,
+      handlers: { WEBHOOK: webhookHandler },
+    });
+
+    const summary = await dispatcher.dispatchWithdrawalEvent({
+      type: "WITHDRAWAL_COMPLETED",
+      occurredAt: new Date("2026-02-07T13:00:00.000Z"),
+      appId: "app-1",
+      userId: "user-1",
+      withdrawalId: "wd-1",
+      asset: "USDI",
+      amount: "12.5",
+      txHash: "0xabc",
+    });
+
+    expect(summary).toEqual({ matched: 2, attempted: 2, delivered: 2, failed: 0 });
+    expect(webhookHandler).toHaveBeenCalledTimes(2);
+  });
+
+  it("isolates handler failures and reports failed attempts", async () => {
+    const channel = await repo.createChannel({
+      appId: "app-1",
+      name: "only",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/fail",
+    });
+    await repo.createRule({
+      appId: "app-1",
+      channelId: channel.id,
+      event: "WITHDRAWAL_FAILED",
+    });
+
+    const onDispatchError = vi.fn();
+    const dispatcher = createNotificationDispatcher({
+      repo,
+      handlers: {
+        WEBHOOK: vi.fn(async () => {
+          throw new Error("network down");
+        }),
+      },
+      onDispatchError,
+    });
+
+    const summary = await dispatcher.dispatchWithdrawalEvent({
+      type: "WITHDRAWAL_FAILED",
+      occurredAt: new Date("2026-02-07T13:10:00.000Z"),
+      appId: "app-1",
+      userId: "user-1",
+      withdrawalId: "wd-2",
+      asset: "USDI",
+      amount: "5",
+      retryCount: 3,
+      error: "exhausted retries",
+    });
+
+    expect(summary).toEqual({ matched: 1, attempted: 1, delivered: 0, failed: 1 });
+    expect(onDispatchError).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty summary when no rules match", async () => {
+    const webhookHandler = vi.fn(async () => {
+      return;
+    });
+    const dispatcher = createNotificationDispatcher({
+      repo,
+      handlers: { WEBHOOK: webhookHandler },
+    });
+
+    const summary = await dispatcher.dispatchWithdrawalEvent({
+      type: "WITHDRAWAL_RETRY_PENDING",
+      occurredAt: new Date("2026-02-07T13:20:00.000Z"),
+      appId: "app-empty",
+      userId: "user-1",
+      withdrawalId: "wd-empty",
+      asset: "USDI",
+      amount: "2",
+      retryCount: 1,
+      nextRetryAt: new Date("2026-02-07T13:21:00.000Z"),
+      error: "temporary node error",
+    });
+
+    expect(summary).toEqual({ matched: 0, attempted: 0, delivered: 0, failed: 0 });
+    expect(webhookHandler).not.toHaveBeenCalled();
+  });
+});

--- a/fiber-link-service/packages/notifications/src/dispatcher.ts
+++ b/fiber-link-service/packages/notifications/src/dispatcher.ts
@@ -1,0 +1,84 @@
+import type { NotificationChannelKind } from "@fiber-link/db";
+import type { WithdrawalNotificationEvent } from "./notification-events";
+import type { NotificationDispatchTarget, NotificationRepo } from "./notification-repo";
+
+export type NotificationDispatchInput = {
+  target: NotificationDispatchTarget;
+  event: WithdrawalNotificationEvent;
+};
+
+export type NotificationChannelHandler = (input: NotificationDispatchInput) => Promise<void>;
+
+export type NotificationDispatchSummary = {
+  matched: number;
+  attempted: number;
+  delivered: number;
+  failed: number;
+};
+
+export type NotificationDispatcher = {
+  dispatchWithdrawalEvent(event: WithdrawalNotificationEvent): Promise<NotificationDispatchSummary>;
+};
+
+export type CreateNotificationDispatcherOptions = {
+  repo: Pick<NotificationRepo, "listDispatchTargets">;
+  handlers?: Partial<Record<NotificationChannelKind, NotificationChannelHandler>>;
+  onDispatchError?: (input: NotificationDispatchInput & { error: unknown }) => void;
+};
+
+const NOOP_CHANNEL_HANDLER: NotificationChannelHandler = async () => {
+  return;
+};
+
+const DEFAULT_CHANNEL_HANDLERS: Record<NotificationChannelKind, NotificationChannelHandler> = {
+  WEBHOOK: NOOP_CHANNEL_HANDLER,
+};
+
+export function createNoopNotificationDispatcher(): NotificationDispatcher {
+  return {
+    async dispatchWithdrawalEvent() {
+      return {
+        matched: 0,
+        attempted: 0,
+        delivered: 0,
+        failed: 0,
+      };
+    },
+  };
+}
+
+export function createNotificationDispatcher(options: CreateNotificationDispatcherOptions): NotificationDispatcher {
+  const channelHandlers: Record<NotificationChannelKind, NotificationChannelHandler> = {
+    ...DEFAULT_CHANNEL_HANDLERS,
+    ...(options.handlers ?? {}),
+  };
+
+  return {
+    async dispatchWithdrawalEvent(event) {
+      const targets = await options.repo.listDispatchTargets(event.appId, event.type);
+      let delivered = 0;
+      let failed = 0;
+
+      for (const target of targets) {
+        try {
+          await channelHandlers[target.kind]({ target, event });
+          delivered += 1;
+        } catch (error) {
+          failed += 1;
+          try {
+            options.onDispatchError?.({ target, event, error });
+          } catch {
+            // Notifications are best-effort; secondary observer failures should not fan out.
+          }
+        }
+      }
+
+      return {
+        matched: targets.length,
+        attempted: targets.length,
+        delivered,
+        failed,
+      };
+    },
+  };
+}

--- a/fiber-link-service/packages/notifications/src/index.ts
+++ b/fiber-link-service/packages/notifications/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./notification-events";
+export * from "./notification-repo";
+export * from "./dispatcher";

--- a/fiber-link-service/packages/notifications/src/notification-events.ts
+++ b/fiber-link-service/packages/notifications/src/notification-events.ts
@@ -1,0 +1,34 @@
+import type { Asset } from "@fiber-link/db";
+
+export type WithdrawalNotificationEventBase = {
+  type: "WITHDRAWAL_RETRY_PENDING" | "WITHDRAWAL_FAILED" | "WITHDRAWAL_COMPLETED";
+  occurredAt: Date;
+  appId: string;
+  userId: string;
+  withdrawalId: string;
+  asset: Asset;
+  amount: string;
+};
+
+export type WithdrawalRetryPendingNotificationEvent = WithdrawalNotificationEventBase & {
+  type: "WITHDRAWAL_RETRY_PENDING";
+  retryCount: number;
+  nextRetryAt: Date;
+  error: string;
+};
+
+export type WithdrawalFailedNotificationEvent = WithdrawalNotificationEventBase & {
+  type: "WITHDRAWAL_FAILED";
+  retryCount: number;
+  error: string;
+};
+
+export type WithdrawalCompletedNotificationEvent = WithdrawalNotificationEventBase & {
+  type: "WITHDRAWAL_COMPLETED";
+  txHash: string;
+};
+
+export type WithdrawalNotificationEvent =
+  | WithdrawalRetryPendingNotificationEvent
+  | WithdrawalFailedNotificationEvent
+  | WithdrawalCompletedNotificationEvent;

--- a/fiber-link-service/packages/notifications/src/notification-repo.test.ts
+++ b/fiber-link-service/packages/notifications/src/notification-repo.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createInMemoryNotificationRepo } from "./notification-repo";
+
+describe("createInMemoryNotificationRepo", () => {
+  const repo = createInMemoryNotificationRepo();
+
+  beforeEach(() => {
+    repo.__resetForTests?.();
+  });
+
+  it("resolves active dispatch targets for app + event", async () => {
+    const channel = await repo.createChannel({
+      appId: "app-1",
+      name: "primary-webhook",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/withdrawals",
+      secret: "top-secret",
+    });
+
+    await repo.createRule({
+      appId: "app-1",
+      channelId: channel.id,
+      event: "WITHDRAWAL_COMPLETED",
+    });
+
+    const targets = await repo.listDispatchTargets("app-1", "WITHDRAWAL_COMPLETED");
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({
+      appId: "app-1",
+      event: "WITHDRAWAL_COMPLETED",
+      channelId: channel.id,
+      channelName: "primary-webhook",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/withdrawals",
+      secret: "top-secret",
+    });
+  });
+
+  it("skips disabled channels and disabled rules", async () => {
+    const enabledChannel = await repo.createChannel({
+      appId: "app-1",
+      name: "enabled-channel",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/enabled",
+    });
+    const disabledChannel = await repo.createChannel({
+      appId: "app-1",
+      name: "disabled-channel",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/disabled",
+      enabled: false,
+    });
+
+    await repo.createRule({
+      appId: "app-1",
+      channelId: enabledChannel.id,
+      event: "WITHDRAWAL_FAILED",
+      enabled: false,
+    });
+    await repo.createRule({
+      appId: "app-1",
+      channelId: disabledChannel.id,
+      event: "WITHDRAWAL_FAILED",
+    });
+
+    const targets = await repo.listDispatchTargets("app-1", "WITHDRAWAL_FAILED");
+    expect(targets).toEqual([]);
+  });
+
+  it("rejects rule creation when channel does not exist in app scope", async () => {
+    const channel = await repo.createChannel({
+      appId: "app-1",
+      name: "app1-channel",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/app1",
+    });
+
+    await expect(
+      repo.createRule({
+        appId: "app-2",
+        channelId: channel.id,
+        event: "WITHDRAWAL_RETRY_PENDING",
+      }),
+    ).rejects.toThrow("notification channel not found");
+  });
+});

--- a/fiber-link-service/packages/notifications/src/notification-repo.ts
+++ b/fiber-link-service/packages/notifications/src/notification-repo.ts
@@ -1,0 +1,286 @@
+import { randomUUID } from "node:crypto";
+import { and, asc, eq } from "drizzle-orm";
+import {
+  notificationChannels,
+  notificationRules,
+  type DbClient,
+  type NotificationChannelKind,
+  type NotificationEvent,
+} from "@fiber-link/db";
+
+export type CreateNotificationChannelInput = {
+  appId: string;
+  name: string;
+  kind: NotificationChannelKind;
+  target: string;
+  secret?: string | null;
+  enabled?: boolean;
+};
+
+export type NotificationChannelRecord = {
+  id: string;
+  appId: string;
+  name: string;
+  kind: NotificationChannelKind;
+  target: string;
+  secret: string | null;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type CreateNotificationRuleInput = {
+  appId: string;
+  channelId: string;
+  event: NotificationEvent;
+  enabled?: boolean;
+};
+
+export type NotificationRuleRecord = {
+  id: string;
+  appId: string;
+  channelId: string;
+  event: NotificationEvent;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type NotificationDispatchTarget = {
+  ruleId: string;
+  channelId: string;
+  appId: string;
+  event: NotificationEvent;
+  channelName: string;
+  kind: NotificationChannelKind;
+  target: string;
+  secret: string | null;
+};
+
+export type NotificationRepo = {
+  createChannel(input: CreateNotificationChannelInput): Promise<NotificationChannelRecord>;
+  createRule(input: CreateNotificationRuleInput): Promise<NotificationRuleRecord>;
+  listDispatchTargets(appId: string, event: NotificationEvent): Promise<NotificationDispatchTarget[]>;
+  __resetForTests?: () => void;
+};
+
+type NotificationChannelRow = typeof notificationChannels.$inferSelect;
+type NotificationRuleRow = typeof notificationRules.$inferSelect;
+
+function toChannelRecord(row: NotificationChannelRow): NotificationChannelRecord {
+  return {
+    id: row.id,
+    appId: row.appId,
+    name: row.name,
+    kind: row.kind as NotificationChannelKind,
+    target: row.target,
+    secret: row.secret,
+    enabled: row.enabled,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function toRuleRecord(row: NotificationRuleRow): NotificationRuleRecord {
+  return {
+    id: row.id,
+    appId: row.appId,
+    channelId: row.channelId,
+    event: row.event as NotificationEvent,
+    enabled: row.enabled,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createDbNotificationRepo(db: DbClient): NotificationRepo {
+  return {
+    async createChannel(input) {
+      const now = new Date();
+      const [row] = await db
+        .insert(notificationChannels)
+        .values({
+          appId: input.appId,
+          name: input.name,
+          kind: input.kind,
+          target: input.target,
+          secret: input.secret ?? null,
+          enabled: input.enabled ?? true,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      return toChannelRecord(row);
+    },
+
+    async createRule(input) {
+      const [channel] = await db
+        .select({ id: notificationChannels.id, appId: notificationChannels.appId })
+        .from(notificationChannels)
+        .where(eq(notificationChannels.id, input.channelId))
+        .limit(1);
+      if (!channel || channel.appId !== input.appId) {
+        throw new Error("notification channel not found");
+      }
+
+      const now = new Date();
+      const [row] = await db
+        .insert(notificationRules)
+        .values({
+          appId: input.appId,
+          channelId: input.channelId,
+          event: input.event,
+          enabled: input.enabled ?? true,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      return toRuleRecord(row);
+    },
+
+    async listDispatchTargets(appId, event) {
+      const rows = await db
+        .select({
+          ruleId: notificationRules.id,
+          channelId: notificationChannels.id,
+          appId: notificationRules.appId,
+          event: notificationRules.event,
+          channelName: notificationChannels.name,
+          kind: notificationChannels.kind,
+          target: notificationChannels.target,
+          secret: notificationChannels.secret,
+        })
+        .from(notificationRules)
+        .innerJoin(
+          notificationChannels,
+          and(
+            eq(notificationChannels.id, notificationRules.channelId),
+            eq(notificationChannels.appId, notificationRules.appId),
+          ),
+        )
+        .where(
+          and(
+            eq(notificationRules.appId, appId),
+            eq(notificationRules.event, event),
+            eq(notificationRules.enabled, true),
+            eq(notificationChannels.enabled, true),
+          ),
+        )
+        .orderBy(asc(notificationRules.createdAt), asc(notificationRules.id));
+
+      return rows.map((row) => ({
+        ruleId: row.ruleId,
+        channelId: row.channelId,
+        appId: row.appId,
+        event: row.event as NotificationEvent,
+        channelName: row.channelName,
+        kind: row.kind as NotificationChannelKind,
+        target: row.target,
+        secret: row.secret,
+      }));
+    },
+  };
+}
+
+export function createInMemoryNotificationRepo(): NotificationRepo {
+  const channels: NotificationChannelRecord[] = [];
+  const rules: NotificationRuleRecord[] = [];
+
+  function cloneChannel(record: NotificationChannelRecord): NotificationChannelRecord {
+    return {
+      ...record,
+      createdAt: new Date(record.createdAt),
+      updatedAt: new Date(record.updatedAt),
+    };
+  }
+
+  function cloneRule(record: NotificationRuleRecord): NotificationRuleRecord {
+    return {
+      ...record,
+      createdAt: new Date(record.createdAt),
+      updatedAt: new Date(record.updatedAt),
+    };
+  }
+
+  return {
+    async createChannel(input) {
+      const duplicate = channels.find((channel) => channel.appId === input.appId && channel.name === input.name);
+      if (duplicate) {
+        throw new Error("duplicate notification channel name");
+      }
+      const now = new Date();
+      const record: NotificationChannelRecord = {
+        id: randomUUID(),
+        appId: input.appId,
+        name: input.name,
+        kind: input.kind,
+        target: input.target,
+        secret: input.secret ?? null,
+        enabled: input.enabled ?? true,
+        createdAt: now,
+        updatedAt: now,
+      };
+      channels.push(record);
+      return cloneChannel(record);
+    },
+
+    async createRule(input) {
+      const channel = channels.find((item) => item.id === input.channelId && item.appId === input.appId);
+      if (!channel) {
+        throw new Error("notification channel not found");
+      }
+      const duplicate = rules.find((rule) => rule.channelId === input.channelId && rule.event === input.event);
+      if (duplicate) {
+        throw new Error("duplicate notification rule");
+      }
+
+      const now = new Date();
+      const record: NotificationRuleRecord = {
+        id: randomUUID(),
+        appId: input.appId,
+        channelId: input.channelId,
+        event: input.event,
+        enabled: input.enabled ?? true,
+        createdAt: now,
+        updatedAt: now,
+      };
+      rules.push(record);
+      return cloneRule(record);
+    },
+
+    async listDispatchTargets(appId, event) {
+      return rules
+        .filter((rule) => rule.appId === appId && rule.event === event && rule.enabled)
+        .sort((left, right) => {
+          const byCreated = left.createdAt.getTime() - right.createdAt.getTime();
+          if (byCreated !== 0) {
+            return byCreated;
+          }
+          return left.id.localeCompare(right.id);
+        })
+        .flatMap((rule) => {
+          const channel = channels.find((item) => item.id === rule.channelId && item.appId === appId);
+          if (!channel || !channel.enabled) {
+            return [];
+          }
+          return [
+            {
+              ruleId: rule.id,
+              channelId: channel.id,
+              appId,
+              event,
+              channelName: channel.name,
+              kind: channel.kind,
+              target: channel.target,
+              secret: channel.secret,
+            },
+          ];
+        });
+    },
+
+    __resetForTests() {
+      channels.length = 0;
+      rules.length = 0;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add notification center foundation models and repositories for withdrawal outcomes
- add notification dispatcher scaffolding for Telegram and Discord channels
- integrate notification dispatch hooks into withdrawal batch handling

## Testing
- `bun test packages/db/src/schema.test.ts`
- `bun test packages/notifications/src/notification-repo.test.ts packages/notifications/src/dispatcher.test.ts`
- `bun test apps/worker/src/withdrawal-batch.test.ts`

Closes #215
