### PR TITLE
feat(dashboard): pipeline board MVP

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-lifecycle-board.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-lifecycle-board.gjs
@@ -1,0 +1,221 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { on } from "@ember/modifier";
+
+const STAGE_VALUES = Object.freeze(["UNPAID", "SETTLED", "FAILED"]);
+const STAGE_FILTER_OPTIONS = Object.freeze(["ALL", ...STAGE_VALUES]);
+
+function toStringOrEmpty(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizeStageCounts(rawCounts) {
+  const countsByStage = { UNPAID: 0, SETTLED: 0, FAILED: 0 };
+  const rows = Array.isArray(rawCounts) ? rawCounts : [];
+
+  for (const row of rows) {
+    if (!row || typeof row !== "object") {
+      continue;
+    }
+    const stage = toStringOrEmpty(row.stage);
+    const rawCount = Number(row.count);
+    if ((stage === "UNPAID" || stage === "SETTLED" || stage === "FAILED") && Number.isFinite(rawCount)) {
+      countsByStage[stage] = Math.max(0, Math.trunc(rawCount));
+    }
+  }
+
+  return STAGE_VALUES.map((stage) => ({ stage, count: countsByStage[stage] }));
+}
+
+function normalizeInvoiceRows(rawRows) {
+  const rows = Array.isArray(rawRows) ? rawRows : [];
+  return rows
+    .filter((row) => row && typeof row === "object")
+    .map((row) => ({
+      invoice: toStringOrEmpty(row.invoice),
+      state: toStringOrEmpty(row.state),
+      amount: toStringOrEmpty(row.amount),
+      asset: toStringOrEmpty(row.asset),
+      fromUserId: toStringOrEmpty(row.fromUserId),
+      toUserId: toStringOrEmpty(row.toUserId),
+      createdAt: toStringOrEmpty(row.createdAt),
+      timelineHref: toStringOrEmpty(row.timelineHref),
+    }))
+    .filter((row) => row.invoice && row.timelineHref);
+}
+
+function toCsvCell(value) {
+  const text = String(value ?? "");
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+function buildCsv(rows) {
+  const header = [
+    "invoice",
+    "stage",
+    "amount",
+    "asset",
+    "from_user_id",
+    "to_user_id",
+    "created_at",
+    "timeline_href",
+  ];
+
+  const lines = [header.map(toCsvCell).join(",")];
+  for (const row of rows) {
+    lines.push(
+      [
+        row.invoice,
+        row.state,
+        row.amount,
+        row.asset,
+        row.fromUserId,
+        row.toUserId,
+        row.createdAt,
+        row.timelineHref,
+      ]
+        .map(toCsvCell)
+        .join(","),
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export default class FiberLinkLifecycleBoard extends Component {
+  @tracked selectedStage = "ALL";
+  @tracked invoiceQuery = "";
+
+  get stageFilterOptions() {
+    return STAGE_FILTER_OPTIONS;
+  }
+
+  get stageCounts() {
+    return normalizeStageCounts(this.args?.board?.stageCounts);
+  }
+
+  get invoiceRows() {
+    return normalizeInvoiceRows(this.args?.board?.invoiceRows);
+  }
+
+  get filteredRows() {
+    const normalizedQuery = this.invoiceQuery.trim().toLowerCase();
+    return this.invoiceRows.filter((row) => {
+      if (this.selectedStage !== "ALL" && row.state !== this.selectedStage) {
+        return false;
+      }
+      if (!normalizedQuery) {
+        return true;
+      }
+      return (
+        row.invoice.toLowerCase().includes(normalizedQuery) ||
+        row.fromUserId.toLowerCase().includes(normalizedQuery) ||
+        row.toUserId.toLowerCase().includes(normalizedQuery)
+      );
+    });
+  }
+
+  get csvHref() {
+    const csv = buildCsv(this.filteredRows);
+    return `data:text/csv;charset=utf-8,${encodeURIComponent(csv)}`;
+  }
+
+  @action
+  updateStageFilter(event) {
+    const value = event?.target?.value;
+    this.selectedStage = STAGE_FILTER_OPTIONS.includes(value) ? value : "ALL";
+  }
+
+  @action
+  updateInvoiceQuery(event) {
+    this.invoiceQuery = toStringOrEmpty(event?.target?.value);
+  }
+
+  @action
+  clearFilters() {
+    this.selectedStage = "ALL";
+    this.invoiceQuery = "";
+  }
+
+  <template>
+    <section class="fiber-link-lifecycle-board">
+      <h4>Lifecycle Pipeline Board</h4>
+      <p>Stage counts and sample invoice rows from the latest dashboard.summary payload.</p>
+
+      <p class="fiber-link-lifecycle-board__stage-counts">
+        {{#each this.stageCounts as |row|}}
+          <span><strong>{{row.stage}}: {{row.count}}</strong></span>
+        {{/each}}
+      </p>
+
+      <div class="fiber-link-lifecycle-board__filters">
+        <label>
+          Lifecycle stage
+          <select
+            value={{this.selectedStage}}
+            aria-label="Lifecycle stage"
+            {{on "change" this.updateStageFilter}}
+          >
+            {{#each this.stageFilterOptions as |stageOption|}}
+              <option value={{stageOption}}>{{stageOption}}</option>
+            {{/each}}
+          </select>
+        </label>
+
+        <label>
+          Search invoice
+          <input
+            type="text"
+            aria-label="Search invoice"
+            value={{this.invoiceQuery}}
+            {{on "input" this.updateInvoiceQuery}}
+          />
+        </label>
+
+        <a href={{this.csvHref}} download="fiber-link-lifecycle-board.csv">Export CSV</a>
+        <button type="button" {{on "click" this.clearFilters}}>Clear</button>
+      </div>
+
+      <table class="fiber-link-lifecycle-board__table">
+        <thead>
+          <tr>
+            <th>invoice</th>
+            <th>stage</th>
+            <th>amount</th>
+            <th>asset</th>
+            <th>from</th>
+            <th>to</th>
+            <th>createdAt</th>
+            <th>timeline</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each this.filteredRows as |row|}}
+            <tr>
+              <td><code>{{row.invoice}}</code></td>
+              <td>{{row.state}}</td>
+              <td>{{row.amount}}</td>
+              <td>{{row.asset}}</td>
+              <td>{{row.fromUserId}}</td>
+              <td>{{row.toUserId}}</td>
+              <td>{{row.createdAt}}</td>
+              <td>
+                <a
+                  href={{row.timelineHref}}
+                  title="Timeline placeholder link for future invoice lifecycle timeline view."
+                >
+                  Timeline
+                </a>
+              </td>
+            </tr>
+          {{else}}
+            <tr>
+              <td colspan="8">No invoice rows for current lifecycle filter.</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    </section>
+  </template>
+}

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
@@ -16,6 +16,19 @@ const WITHDRAWAL_STATE_OPTIONS = Object.freeze([
   "FAILED",
 ]);
 const SETTLEMENT_STATE_OPTIONS = Object.freeze(["ALL", "UNPAID", "SETTLED", "FAILED"]);
+const PIPELINE_STAGE_OPTIONS = Object.freeze(["UNPAID", "SETTLED", "FAILED"]);
+
+function normalizePipelineBoard(rawBoard) {
+  const stageCounts = Array.isArray(rawBoard?.stageCounts)
+    ? rawBoard.stageCounts
+    : PIPELINE_STAGE_OPTIONS.map((stage) => ({ stage, count: 0 }));
+  const invoiceRows = Array.isArray(rawBoard?.invoiceRows) ? rawBoard.invoiceRows : [];
+
+  return {
+    stageCounts,
+    invoiceRows,
+  };
+}
 
 function formatTimestamp(rawValue) {
   if (typeof rawValue !== "string" || !rawValue.trim()) {
@@ -75,6 +88,7 @@ export default class FiberLinkDashboardRoute extends Route {
         withdrawalState: normalizedWithdrawalState,
         settlementState: normalizedSettlementState,
       },
+      adminPipelineBoard: normalizePipelineBoard(),
     });
 
     this._activeModel = model;
@@ -133,6 +147,7 @@ export default class FiberLinkDashboardRoute extends Route {
         adminApps: Array.isArray(result?.admin?.apps) ? result.admin.apps : [],
         adminWithdrawals: Array.isArray(result?.admin?.withdrawals) ? result.admin.withdrawals : [],
         adminSettlements: Array.isArray(result?.admin?.settlements) ? result.admin.settlements : [],
+        adminPipelineBoard: normalizePipelineBoard(result?.admin?.pipelineBoard),
         adminFiltersApplied: result?.admin?.filtersApplied ?? {
           withdrawalState: model.withdrawalStateFilter,
           settlementState: model.settlementStateFilter,

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
@@ -86,6 +86,8 @@
     }}Reset to ALL{{/link-to}})
   </p>
 
+  {{fiber-link-lifecycle-board board=this.model.adminPipelineBoard}}
+
   <h4>Apps</h4>
   <table class="fiber-link-dashboard-admin-apps">
     <thead>

--- a/fiber-link-service/apps/rpc/src/contracts.test.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.test.ts
@@ -81,6 +81,42 @@ describe("rpc contracts", () => {
         generatedAt: "2026-02-16T00:00:00.000Z",
       }).success,
     ).toBe(true);
+
+    expect(
+      DashboardSummaryResultSchema.safeParse({
+        balance: "0",
+        tips: [],
+        admin: {
+          filtersApplied: {
+            withdrawalState: "ALL",
+            settlementState: "ALL",
+          },
+          apps: [],
+          withdrawals: [],
+          settlements: [],
+          pipelineBoard: {
+            stageCounts: [
+              { stage: "UNPAID", count: 2 },
+              { stage: "SETTLED", count: 1 },
+              { stage: "FAILED", count: 0 },
+            ],
+            invoiceRows: [
+              {
+                invoice: "inv-1",
+                state: "UNPAID",
+                amount: "2.5",
+                asset: "CKB",
+                fromUserId: "u1",
+                toUserId: "u2",
+                createdAt: "2026-02-16T00:00:00.000Z",
+                timelineHref: "/fiber-link/timeline/inv-1",
+              },
+            ],
+          },
+        },
+        generatedAt: "2026-02-16T00:00:00.000Z",
+      }).success,
+    ).toBe(true);
   });
 
   it("keeps rpc error code constants stable", () => {

--- a/fiber-link-service/apps/rpc/src/contracts.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.ts
@@ -47,6 +47,7 @@ export const DashboardWithdrawalStateFilterSchema = z.enum([
 ]);
 
 export const DashboardSettlementStateFilterSchema = z.enum(["ALL", "UNPAID", "SETTLED", "FAILED"]);
+const DashboardPipelineStageSchema = z.enum(["UNPAID", "SETTLED", "FAILED"]);
 
 export const DashboardSummaryParamsSchema = z.object({
   userId: z.string().min(1),
@@ -118,6 +119,28 @@ export const DashboardSummaryResultSchema = z.object({
           failureReason: z.string().nullable(),
         }),
       ),
+      pipelineBoard: z
+        .object({
+          stageCounts: z.array(
+            z.object({
+              stage: DashboardPipelineStageSchema,
+              count: z.number().int().min(0),
+            }),
+          ),
+          invoiceRows: z.array(
+            z.object({
+              invoice: z.string().min(1),
+              state: DashboardPipelineStageSchema,
+              amount: z.string().min(1),
+              asset: z.enum(["CKB", "USDI"]),
+              fromUserId: z.string().min(1),
+              toUserId: z.string().min(1),
+              createdAt: z.string().datetime(),
+              timelineHref: z.string().min(1),
+            }),
+          ),
+        })
+        .optional(),
     })
     .optional(),
   generatedAt: z.string().datetime(),

--- a/fiber-link-service/apps/rpc/src/rpc.test.ts
+++ b/fiber-link-service/apps/rpc/src/rpc.test.ts
@@ -504,6 +504,34 @@ describe("json-rpc", () => {
           createdAt: "2026-02-16T00:00:00.000Z",
         },
       ],
+      admin: {
+        filtersApplied: {
+          withdrawalState: "ALL",
+          settlementState: "ALL",
+        },
+        apps: [],
+        withdrawals: [],
+        settlements: [],
+        pipelineBoard: {
+          stageCounts: [
+            { stage: "UNPAID", count: 1 },
+            { stage: "SETTLED", count: 0 },
+            { stage: "FAILED", count: 0 },
+          ],
+          invoiceRows: [
+            {
+              invoice: "inv-1",
+              state: "UNPAID",
+              amount: "1",
+              asset: "CKB",
+              fromUserId: "u1",
+              toUserId: "u2",
+              createdAt: "2026-02-16T00:00:00.000Z",
+              timelineHref: "/fiber-link/timeline/inv-1",
+            },
+          ],
+        },
+      },
       generatedAt: "2026-02-16T00:00:00.000Z",
     });
     try {
@@ -554,6 +582,34 @@ describe("json-rpc", () => {
               createdAt: "2026-02-16T00:00:00.000Z",
             },
           ],
+          admin: {
+            filtersApplied: {
+              withdrawalState: "ALL",
+              settlementState: "ALL",
+            },
+            apps: [],
+            withdrawals: [],
+            settlements: [],
+            pipelineBoard: {
+              stageCounts: [
+                { stage: "UNPAID", count: 1 },
+                { stage: "SETTLED", count: 0 },
+                { stage: "FAILED", count: 0 },
+              ],
+              invoiceRows: [
+                {
+                  invoice: "inv-1",
+                  state: "UNPAID",
+                  amount: "1",
+                  asset: "CKB",
+                  fromUserId: "u1",
+                  toUserId: "u2",
+                  createdAt: "2026-02-16T00:00:00.000Z",
+                  timelineHref: "/fiber-link/timeline/inv-1",
+                },
+              ],
+            },
+          },
           generatedAt: "2026-02-16T00:00:00.000Z",
         },
       });


### PR DESCRIPTION
## Summary
- add a lifecycle board UI component and route wiring in the Discourse plugin dashboard
- extend RPC dashboard contracts/methods for pipeline board data and filtering
- add/update RPC and dashboard tests for the new board behaviors

## Testing
- `bunx vitest run apps/rpc/src/**/*.test.ts`
- `bundle exec rspec plugins/fiber-link/spec/system/fiber_link_dashboard_spec.rb` (blocked locally: missing Discourse test harness/Gemfile in `/tmp/discourse-dev`)

Closes #216
