### PR TITLE
feat(observability): audit timeline foundation

### DIFF
--- a/fiber-link-service/apps/rpc/src/methods/tip.ts
+++ b/fiber-link-service/apps/rpc/src/methods/tip.ts
@@ -2,8 +2,10 @@ import { createAdapter, createAdapterProvider } from "@fiber-link/fiber-adapter"
 import {
   createDbClient,
   createDbLedgerRepo,
+  createDbTipIntentEventRepo,
   createDbTipIntentRepo,
   type LedgerRepo,
+  type TipIntentEventRepo,
   type TipIntentRepo,
 } from "@fiber-link/db";
 import type { InvoiceState } from "@fiber-link/fiber-adapter";
@@ -11,6 +13,7 @@ import type { InvoiceState } from "@fiber-link/fiber-adapter";
 let defaultTipIntentRepo: TipIntentRepo | null | undefined;
 let defaultLedgerRepo: LedgerRepo | null | undefined;
 let defaultAdapter: ReturnType<typeof createAdapterProvider> | null | undefined;
+let defaultTipIntentEventRepo: TipIntentEventRepo | null | undefined;
 
 function isInvoiceStateConflictError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
@@ -56,6 +59,21 @@ function getDefaultLedgerRepo(): LedgerRepo {
   return defaultLedgerRepo;
 }
 
+function getDefaultTipIntentEventRepo(): TipIntentEventRepo | null {
+  if (defaultTipIntentEventRepo !== undefined) {
+    return defaultTipIntentEventRepo;
+  }
+
+  try {
+    defaultTipIntentEventRepo = createDbTipIntentEventRepo(createDbClient());
+  } catch (error) {
+    console.error("Failed to initialize default TipIntentEventRepo.", error);
+    defaultTipIntentEventRepo = null;
+  }
+
+  return defaultTipIntentEventRepo;
+}
+
 function getDefaultAdapter() {
   if (defaultAdapter !== undefined) {
     return defaultAdapter;
@@ -83,6 +101,7 @@ export type HandleTipStatusInput = {
 type HandleTipStatusOptions = {
   tipIntentRepo?: TipIntentRepo;
   ledgerRepo?: LedgerRepo;
+  tipIntentEventRepo?: TipIntentEventRepo;
   adapter?: {
     getInvoiceStatus: (input: { invoice: string }) => Promise<{ state: InvoiceState }>;
   };
@@ -90,10 +109,35 @@ type HandleTipStatusOptions = {
 
 type HandleTipCreateOptions = {
   tipIntentRepo?: TipIntentRepo;
+  tipIntentEventRepo?: TipIntentEventRepo;
   adapter?: {
     createInvoice: (input: { amount: string; asset: "CKB" | "USDI" }) => Promise<{ invoice: string }>;
   };
 };
+
+function statusStateToTimelineType(state: InvoiceState): "TIP_STATUS_UNPAID_OBSERVED" | "TIP_STATUS_SETTLED" | "TIP_STATUS_FAILED" {
+  if (state === "SETTLED") {
+    return "TIP_STATUS_SETTLED";
+  }
+  if (state === "FAILED") {
+    return "TIP_STATUS_FAILED";
+  }
+  return "TIP_STATUS_UNPAID_OBSERVED";
+}
+
+async function appendTipTimelineEvent(
+  eventRepo: TipIntentEventRepo | null,
+  input: Parameters<TipIntentEventRepo["append"]>[0],
+): Promise<void> {
+  if (!eventRepo) {
+    return;
+  }
+  try {
+    await eventRepo.append(input);
+  } catch (error) {
+    console.error("Failed to append tip intent timeline event.", error);
+  }
+}
 
 export async function handleTipCreate(
   input: HandleTipCreateInput,
@@ -102,7 +146,8 @@ export async function handleTipCreate(
   const adapter = options.adapter ?? getDefaultAdapter();
   const invoice = await adapter.createInvoice({ amount: input.amount, asset: input.asset });
   const repo = options.tipIntentRepo ?? getDefaultTipIntentRepo();
-  await repo.create({
+  const eventRepo = options.tipIntentEventRepo ?? getDefaultTipIntentEventRepo();
+  const tipIntent = await repo.create({
     appId: input.appId,
     postId: input.postId,
     fromUserId: input.fromUserId,
@@ -110,6 +155,18 @@ export async function handleTipCreate(
     asset: input.asset,
     amount: input.amount,
     invoice: invoice.invoice,
+  });
+  await appendTipTimelineEvent(eventRepo, {
+    tipIntentId: tipIntent.id,
+    invoice: tipIntent.invoice,
+    source: "TIP_CREATE",
+    type: "TIP_CREATED",
+    previousInvoiceState: null,
+    nextInvoiceState: tipIntent.invoiceState,
+    metadata: {
+      appId: tipIntent.appId,
+      postId: tipIntent.postId,
+    },
   });
   return { invoice: invoice.invoice };
 }
@@ -120,10 +177,23 @@ export async function handleTipStatus(
 ) {
   const tipIntentRepo = options.tipIntentRepo ?? getDefaultTipIntentRepo();
   const ledgerRepo = options.ledgerRepo ?? getDefaultLedgerRepo();
+  const eventRepo = options.tipIntentEventRepo ?? getDefaultTipIntentEventRepo();
   const adapter = options.adapter ?? getDefaultAdapter();
   const tipIntent = await tipIntentRepo.findByInvoiceOrThrow(input.invoice);
 
   if (tipIntent.invoiceState !== "UNPAID") {
+    await appendTipTimelineEvent(eventRepo, {
+      tipIntentId: tipIntent.id,
+      invoice: tipIntent.invoice,
+      source: "TIP_STATUS",
+      type: statusStateToTimelineType(tipIntent.invoiceState),
+      previousInvoiceState: tipIntent.invoiceState,
+      nextInvoiceState: tipIntent.invoiceState,
+      metadata: {
+        observedState: tipIntent.invoiceState,
+        skippedUpstreamCheck: true,
+      },
+    });
     return { state: tipIntent.invoiceState };
   }
 
@@ -137,30 +207,69 @@ export async function handleTipStatus(
       refId: tipIntent.id,
       idempotencyKey: `settlement:tip_intent:${tipIntent.id}`,
     });
+    let nextState: InvoiceState;
     try {
       const settled = await tipIntentRepo.updateInvoiceState(input.invoice, "SETTLED");
-      return { state: settled.invoiceState };
+      nextState = settled.invoiceState;
     } catch (error) {
       if (isInvoiceStateConflictError(error)) {
         const current = await tipIntentRepo.findByInvoiceOrThrow(input.invoice);
-        return { state: current.invoiceState };
+        nextState = current.invoiceState;
+      } else {
+        throw error;
       }
-      throw error;
     }
+    await appendTipTimelineEvent(eventRepo, {
+      tipIntentId: tipIntent.id,
+      invoice: tipIntent.invoice,
+      source: "TIP_STATUS",
+      type: statusStateToTimelineType(nextState),
+      previousInvoiceState: tipIntent.invoiceState,
+      nextInvoiceState: nextState,
+      metadata: {
+        observedState: "SETTLED",
+      },
+    });
+    return { state: nextState };
   }
 
   if (invoiceStatus.state === "FAILED") {
+    let nextState: InvoiceState;
     try {
       const failed = await tipIntentRepo.updateInvoiceState(input.invoice, "FAILED");
-      return { state: failed.invoiceState };
+      nextState = failed.invoiceState;
     } catch (error) {
       if (isInvoiceStateConflictError(error)) {
         const current = await tipIntentRepo.findByInvoiceOrThrow(input.invoice);
-        return { state: current.invoiceState };
+        nextState = current.invoiceState;
+      } else {
+        throw error;
       }
-      throw error;
     }
+    await appendTipTimelineEvent(eventRepo, {
+      tipIntentId: tipIntent.id,
+      invoice: tipIntent.invoice,
+      source: "TIP_STATUS",
+      type: statusStateToTimelineType(nextState),
+      previousInvoiceState: tipIntent.invoiceState,
+      nextInvoiceState: nextState,
+      metadata: {
+        observedState: "FAILED",
+      },
+    });
+    return { state: nextState };
   }
 
+  await appendTipTimelineEvent(eventRepo, {
+    tipIntentId: tipIntent.id,
+    invoice: tipIntent.invoice,
+    source: "TIP_STATUS",
+    type: "TIP_STATUS_UNPAID_OBSERVED",
+    previousInvoiceState: tipIntent.invoiceState,
+    nextInvoiceState: tipIntent.invoiceState,
+    metadata: {
+      observedState: "UNPAID",
+    },
+  });
   return { state: tipIntent.invoiceState };
 }

--- a/fiber-link-service/packages/db/src/index.ts
+++ b/fiber-link-service/packages/db/src/index.ts
@@ -3,5 +3,6 @@ export * from "./client";
 export * from "./idempotency";
 export * from "./withdrawal-repo";
 export * from "./tip-intent-repo";
+export * from "./tip-intent-event-repo";
 export * from "./ledger-repo";
 export * from "./amount";

--- a/fiber-link-service/packages/db/src/schema.test.ts
+++ b/fiber-link-service/packages/db/src/schema.test.ts
@@ -7,6 +7,9 @@ import {
   notificationChannels,
   notificationEventEnum,
   notificationRules,
+  tipIntentEventSourceEnum,
+  tipIntentEventTypeEnum,
+  tipIntentEvents,
   tipIntents,
   withdrawalStateEnum,
   withdrawals,
@@ -15,6 +18,7 @@ import {
 describe("schema", () => {
   it("exports core tables", () => {
     expect(tipIntents).toBeDefined();
+    expect(tipIntentEvents).toBeDefined();
     expect(ledgerEntries).toBeDefined();
     expect(withdrawals).toBeDefined();
     expect(notificationChannels).toBeDefined();
@@ -24,6 +28,22 @@ describe("schema", () => {
   it("pins asset and invoice lifecycle enums to supported states", () => {
     expect(assetEnum.enumValues).toEqual(["CKB", "USDI"]);
     expect(invoiceStateEnum.enumValues).toEqual(["UNPAID", "SETTLED", "FAILED"]);
+    expect(tipIntentEventSourceEnum.enumValues).toEqual(["TIP_CREATE", "TIP_STATUS", "SETTLEMENT_DISCOVERY"]);
+    expect(tipIntentEventTypeEnum.enumValues).toEqual([
+      "TIP_CREATED",
+      "TIP_STATUS_UNPAID_OBSERVED",
+      "TIP_STATUS_SETTLED",
+      "TIP_STATUS_FAILED",
+      "SETTLEMENT_NO_CHANGE",
+      "SETTLEMENT_SETTLED_CREDIT_APPLIED",
+      "SETTLEMENT_SETTLED_DUPLICATE",
+      "SETTLEMENT_FAILED_UPSTREAM_REPORTED",
+      "SETTLEMENT_RETRY_SCHEDULED",
+      "SETTLEMENT_FAILED_PENDING_TIMEOUT",
+      "SETTLEMENT_FAILED_CONTRACT_MISMATCH",
+      "SETTLEMENT_FAILED_RETRY_EXHAUSTED",
+      "SETTLEMENT_FAILED_TERMINAL_ERROR",
+    ]);
     expect(withdrawalStateEnum.enumValues).toEqual(["PENDING", "PROCESSING", "RETRY_PENDING", "COMPLETED", "FAILED"]);
     expect(notificationChannelKindEnum.enumValues).toEqual(["WEBHOOK"]);
     expect(notificationEventEnum.enumValues).toEqual([
@@ -36,6 +56,8 @@ describe("schema", () => {
   it("keeps idempotency and lifecycle columns explicitly modeled", () => {
     expect(tipIntents.invoice.name).toBe("invoice");
     expect(tipIntents.invoiceState.name).toBe("invoice_state");
+    expect(tipIntentEvents.type.name).toBe("type");
+    expect(tipIntentEvents.tipIntentId.name).toBe("tip_intent_id");
     expect(ledgerEntries.idempotencyKey.name).toBe("idempotency_key");
     expect(withdrawals.state.name).toBe("state");
     expect(withdrawals.nextRetryAt.name).toBe("next_retry_at");

--- a/fiber-link-service/packages/db/src/schema.ts
+++ b/fiber-link-service/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { boolean, index, integer, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { boolean, index, integer, jsonb, numeric, pgEnum, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 
 export const userRoleEnum = pgEnum("user_role", ["SUPER_ADMIN", "COMMUNITY_ADMIN"]);
 export type UserRole = (typeof userRoleEnum.enumValues)[number];
@@ -10,6 +10,30 @@ export const invoiceStateEnum = pgEnum("invoice_state", ["UNPAID", "SETTLED", "F
 export type InvoiceState = (typeof invoiceStateEnum.enumValues)[number];
 
 export const ledgerEntryTypeEnum = pgEnum("ledger_entry_type", ["credit", "debit"]);
+
+export const tipIntentEventSourceEnum = pgEnum("tip_intent_event_source", [
+  "TIP_CREATE",
+  "TIP_STATUS",
+  "SETTLEMENT_DISCOVERY",
+]);
+export type TipIntentEventSource = (typeof tipIntentEventSourceEnum.enumValues)[number];
+
+export const tipIntentEventTypeEnum = pgEnum("tip_intent_event_type", [
+  "TIP_CREATED",
+  "TIP_STATUS_UNPAID_OBSERVED",
+  "TIP_STATUS_SETTLED",
+  "TIP_STATUS_FAILED",
+  "SETTLEMENT_NO_CHANGE",
+  "SETTLEMENT_SETTLED_CREDIT_APPLIED",
+  "SETTLEMENT_SETTLED_DUPLICATE",
+  "SETTLEMENT_FAILED_UPSTREAM_REPORTED",
+  "SETTLEMENT_RETRY_SCHEDULED",
+  "SETTLEMENT_FAILED_PENDING_TIMEOUT",
+  "SETTLEMENT_FAILED_CONTRACT_MISMATCH",
+  "SETTLEMENT_FAILED_RETRY_EXHAUSTED",
+  "SETTLEMENT_FAILED_TERMINAL_ERROR",
+]);
+export type TipIntentEventType = (typeof tipIntentEventTypeEnum.enumValues)[number];
 
 export const withdrawalStateEnum = pgEnum("withdrawal_state", [
   "PENDING",
@@ -92,6 +116,28 @@ export const tipIntents = pgTable(
       table.createdAt,
       table.id,
     ),
+  }),
+);
+
+export const tipIntentEvents = pgTable(
+  "tip_intent_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    tipIntentId: uuid("tip_intent_id")
+      .notNull()
+      .references(() => tipIntents.id),
+    invoice: text("invoice").notNull(),
+    source: tipIntentEventSourceEnum("source").notNull(),
+    type: tipIntentEventTypeEnum("type").notNull(),
+    previousInvoiceState: invoiceStateEnum("previous_invoice_state"),
+    nextInvoiceState: invoiceStateEnum("next_invoice_state"),
+    metadata: jsonb("metadata").$type<Record<string, unknown> | null>(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    byTipIntentCreatedAt: index("tip_intent_events_tip_intent_created_at_idx").on(table.tipIntentId, table.createdAt, table.id),
+    byInvoiceCreatedAt: index("tip_intent_events_invoice_created_at_idx").on(table.invoice, table.createdAt, table.id),
+    bySourceCreatedAt: index("tip_intent_events_source_created_at_idx").on(table.source, table.createdAt, table.id),
   }),
 );
 

--- a/fiber-link-service/packages/db/src/tip-intent-event-repo.test.ts
+++ b/fiber-link-service/packages/db/src/tip-intent-event-repo.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DbClient } from "./client";
+import { createDbTipIntentEventRepo, createInMemoryTipIntentEventRepo } from "./tip-intent-event-repo";
+
+function createRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "evt-1",
+    tipIntentId: "tip-1",
+    invoice: "inv-1",
+    source: "TIP_STATUS",
+    type: "TIP_STATUS_UNPAID_OBSERVED",
+    previousInvoiceState: "UNPAID",
+    nextInvoiceState: "UNPAID",
+    metadata: {
+      observedState: "UNPAID",
+    },
+    createdAt: new Date("2026-02-21T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("tipIntentEventRepo (db)", () => {
+  it("appends and lists timeline events for a tip intent", async () => {
+    const insertReturning = vi.fn(async () => [createRow({ type: "TIP_CREATED", source: "TIP_CREATE" })]);
+    const insertValues = vi.fn(() => ({ returning: insertReturning }));
+    const insert = vi.fn(() => ({ values: insertValues }));
+
+    const selectLimit = vi.fn(async () => [createRow()]);
+    const selectOrderBy = vi.fn(() => ({ limit: selectLimit }));
+    const selectWhere = vi.fn(() => ({ orderBy: selectOrderBy }));
+    const selectFrom = vi.fn(() => ({ where: selectWhere }));
+    const select = vi.fn(() => ({ from: selectFrom }));
+
+    const db = { insert, select } as unknown as DbClient;
+    const repo = createDbTipIntentEventRepo(db);
+
+    const appended = await repo.append({
+      tipIntentId: "tip-1",
+      invoice: "inv-1",
+      source: "TIP_CREATE",
+      type: "TIP_CREATED",
+      previousInvoiceState: null,
+      nextInvoiceState: "UNPAID",
+      metadata: { phase: "create" },
+      createdAt: new Date("2026-02-21T00:00:00.000Z"),
+    });
+
+    expect(appended.type).toBe("TIP_CREATED");
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tipIntentId: "tip-1",
+        source: "TIP_CREATE",
+        type: "TIP_CREATED",
+      }),
+    );
+
+    const listed = await repo.listByTipIntentId("tip-1", { limit: 10 });
+    expect(selectLimit).toHaveBeenCalledWith(10);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      tipIntentId: "tip-1",
+      type: "TIP_STATUS_UNPAID_OBSERVED",
+      metadata: { observedState: "UNPAID" },
+    });
+  });
+});
+
+describe("tipIntentEventRepo (in-memory)", () => {
+  const repo = createInMemoryTipIntentEventRepo();
+
+  beforeEach(() => {
+    repo.__resetForTests?.();
+  });
+
+  it("stores append-only events ordered by createdAt", async () => {
+    await repo.append({
+      tipIntentId: "tip-1",
+      invoice: "inv-1",
+      source: "TIP_CREATE",
+      type: "TIP_CREATED",
+      previousInvoiceState: null,
+      nextInvoiceState: "UNPAID",
+      metadata: { position: "first" },
+      createdAt: new Date("2026-02-21T00:00:00.000Z"),
+    });
+    await repo.append({
+      tipIntentId: "tip-1",
+      invoice: "inv-1",
+      source: "TIP_STATUS",
+      type: "TIP_STATUS_SETTLED",
+      previousInvoiceState: "UNPAID",
+      nextInvoiceState: "SETTLED",
+      metadata: { position: "second" },
+      createdAt: new Date("2026-02-21T00:00:01.000Z"),
+    });
+
+    const listed = await repo.listByTipIntentId("tip-1");
+    expect(listed.map((event) => event.type)).toEqual(["TIP_CREATED", "TIP_STATUS_SETTLED"]);
+  });
+
+  it("returns cloned metadata so tests cannot mutate stored events", async () => {
+    await repo.append({
+      tipIntentId: "tip-1",
+      invoice: "inv-1",
+      source: "TIP_STATUS",
+      type: "TIP_STATUS_UNPAID_OBSERVED",
+      previousInvoiceState: "UNPAID",
+      nextInvoiceState: "UNPAID",
+      metadata: { observedState: "UNPAID" },
+    });
+
+    const listed = await repo.listByTipIntentId("tip-1");
+    (listed[0]?.metadata as Record<string, unknown>).observedState = "MUTATED";
+
+    const listedAgain = await repo.listByTipIntentId("tip-1");
+    expect((listedAgain[0]?.metadata as Record<string, unknown>).observedState).toBe("UNPAID");
+  });
+});

--- a/fiber-link-service/packages/db/src/tip-intent-event-repo.ts
+++ b/fiber-link-service/packages/db/src/tip-intent-event-repo.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "crypto";
+import { asc, eq } from "drizzle-orm";
+import type { DbClient } from "./client";
+import { tipIntentEvents, type InvoiceState, type TipIntentEventSource, type TipIntentEventType } from "./schema";
+
+export type TipIntentEventMetadata = Record<string, unknown>;
+
+export type AppendTipIntentEventInput = {
+  tipIntentId: string;
+  invoice: string;
+  source: TipIntentEventSource;
+  type: TipIntentEventType;
+  previousInvoiceState?: InvoiceState | null;
+  nextInvoiceState?: InvoiceState | null;
+  metadata?: TipIntentEventMetadata | null;
+  createdAt?: Date;
+};
+
+export type TipIntentEventRecord = {
+  id: string;
+  tipIntentId: string;
+  invoice: string;
+  source: TipIntentEventSource;
+  type: TipIntentEventType;
+  previousInvoiceState: InvoiceState | null;
+  nextInvoiceState: InvoiceState | null;
+  metadata: TipIntentEventMetadata | null;
+  createdAt: Date;
+};
+
+export type TipIntentEventListOptions = {
+  limit?: number;
+};
+
+export type TipIntentEventRepo = {
+  append(input: AppendTipIntentEventInput): Promise<TipIntentEventRecord>;
+  listByTipIntentId(tipIntentId: string, options?: TipIntentEventListOptions): Promise<TipIntentEventRecord[]>;
+  __listForTests?: () => TipIntentEventRecord[];
+  __resetForTests?: () => void;
+};
+
+type TipIntentEventRow = typeof tipIntentEvents.$inferSelect;
+
+function normalizeMetadata(metadata: unknown): TipIntentEventMetadata | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+  return metadata as TipIntentEventMetadata;
+}
+
+function cloneMetadata(metadata: TipIntentEventMetadata | null): TipIntentEventMetadata | null {
+  if (!metadata) {
+    return null;
+  }
+  return JSON.parse(JSON.stringify(metadata)) as TipIntentEventMetadata;
+}
+
+function toRecord(row: TipIntentEventRow): TipIntentEventRecord {
+  return {
+    id: row.id,
+    tipIntentId: row.tipIntentId,
+    invoice: row.invoice,
+    source: row.source as TipIntentEventSource,
+    type: row.type as TipIntentEventType,
+    previousInvoiceState: (row.previousInvoiceState as InvoiceState | null) ?? null,
+    nextInvoiceState: (row.nextInvoiceState as InvoiceState | null) ?? null,
+    metadata: normalizeMetadata(row.metadata),
+    createdAt: row.createdAt,
+  };
+}
+
+export function createDbTipIntentEventRepo(db: DbClient): TipIntentEventRepo {
+  return {
+    async append(input) {
+      const createdAt = input.createdAt ?? new Date();
+      const [row] = await db
+        .insert(tipIntentEvents)
+        .values({
+          tipIntentId: input.tipIntentId,
+          invoice: input.invoice,
+          source: input.source,
+          type: input.type,
+          previousInvoiceState: input.previousInvoiceState ?? null,
+          nextInvoiceState: input.nextInvoiceState ?? null,
+          metadata: input.metadata ?? null,
+          createdAt,
+        })
+        .returning();
+      return toRecord(row);
+    },
+
+    async listByTipIntentId(tipIntentId, options = {}) {
+      let query = db
+        .select()
+        .from(tipIntentEvents)
+        .where(eq(tipIntentEvents.tipIntentId, tipIntentId))
+        .orderBy(asc(tipIntentEvents.createdAt), asc(tipIntentEvents.id));
+      if (options.limit && options.limit > 0) {
+        query = query.limit(options.limit);
+      }
+      const rows = await query;
+      return rows.map(toRecord);
+    },
+  };
+}
+
+export function createInMemoryTipIntentEventRepo(): TipIntentEventRepo {
+  const records: TipIntentEventRecord[] = [];
+
+  function clone(record: TipIntentEventRecord): TipIntentEventRecord {
+    return {
+      ...record,
+      metadata: cloneMetadata(record.metadata),
+      createdAt: new Date(record.createdAt),
+    };
+  }
+
+  return {
+    async append(input) {
+      const record: TipIntentEventRecord = {
+        id: randomUUID(),
+        tipIntentId: input.tipIntentId,
+        invoice: input.invoice,
+        source: input.source,
+        type: input.type,
+        previousInvoiceState: input.previousInvoiceState ?? null,
+        nextInvoiceState: input.nextInvoiceState ?? null,
+        metadata: cloneMetadata(input.metadata ?? null),
+        createdAt: input.createdAt ? new Date(input.createdAt) : new Date(),
+      };
+      records.push(record);
+      return clone(record);
+    },
+
+    async listByTipIntentId(tipIntentId, options = {}) {
+      let items = records.filter((record) => record.tipIntentId === tipIntentId);
+      items = items.sort((left, right) => {
+        const createdAtDiff = left.createdAt.getTime() - right.createdAt.getTime();
+        if (createdAtDiff !== 0) {
+          return createdAtDiff;
+        }
+        return left.id.localeCompare(right.id);
+      });
+      if (options.limit && options.limit > 0) {
+        items = items.slice(0, options.limit);
+      }
+      return items.map(clone);
+    },
+
+    __listForTests() {
+      return records.map(clone);
+    },
+
+    __resetForTests() {
+      records.length = 0;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add tip intent timeline event schema and repository support
- persist timeline/audit events from tip method flows
- wire settlement discovery to record replayable timeline diagnostics

## Testing
- `bun run test -- --run src/tip-intent-event-repo.test.ts src/schema.test.ts` (packages/db)
- `bun run test -- --run src/methods/tip.test.ts` (apps/rpc)
- `bun run test -- --run src/settlement-discovery.test.ts` (apps/worker)

Closes #218
