### PR TITLE
ci: harden PR coverage comment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,8 @@ jobs:
           run_pkg() {
             local pkg="$1"
             local name="$2"
-            local report_dir="../../coverage-reports/$name"
+            local report_dir="coverage-reports/$name"
+            local pkg_report_dir="../../$report_dir"
             local status_file="$report_dir/.status"
 
             mkdir -p "$report_dir"
@@ -101,7 +102,7 @@ jobs:
               return 0
             fi
 
-            if (cd "$pkg" && bunx vitest run --silent --coverage.enabled --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reportsDirectory="$report_dir"); then
+            if (cd "$pkg" && bunx vitest run --silent --coverage.enabled --coverage.provider=v8 --coverage.reporter=json-summary --coverage.reportsDirectory="$pkg_report_dir"); then
               echo "ok" > "$status_file"
               return 0
             fi


### PR DESCRIPTION
## Summary
- Fixes a YAML syntax regression in .github/workflows/ci.yml that prevented PR coverage workflow from running.
- Restores PR-triggered coverage reporting behavior for opened/reopened/synchronize events.
- Makes coverage job more robust and faster with safer base-coverage checkout and caching.

## Validation Notes
- Focused on workflow correctness and stability; no app code changes.

## Changes
- Restrict PR trigger to explicit pull_request event types (opened/synchronize/reopened).
- Add workflow-level concurrency with cancel-in-progress to avoid duplicate runs on frequent pushes.
- Add Bun cache layers for service and coverage jobs.
- Rewrite base-branch coverage collection with isolated temp worktree and robust path handling.
- Fix multiline/printf YAML breakage in comment upsert script.
- Add timeout and better checkout settings for PR context consistency.
