### PR TITLE
chore: upgrade GitHub Actions runtime support

### DIFF
--- a/.github/scripts/wait-for-postgres-socket.sh
+++ b/.github/scripts/wait-for-postgres-socket.sh
@@ -3,17 +3,34 @@ set -euo pipefail
 
 SOCKET_PATH="${1:-/var/run/postgresql/.s.PGSQL.5432}"
 MAX_ATTEMPTS="${2:-180}"
+SOCKET_DIR="$(dirname "$SOCKET_PATH")"
+
+is_ready=false
 
 i=0
 while (( i < MAX_ATTEMPTS )); do
   if [ -S "$SOCKET_PATH" ]; then
-    echo "Postgres socket ready at $SOCKET_PATH"
-    exit 0
+    if command -v pg_isready >/dev/null 2>&1; then
+      if pg_isready -q -h "$SOCKET_DIR" -p 5432 >/dev/null 2>&1; then
+        is_ready=true
+        break
+      fi
+    else
+      if su - postgres -c "psql -h \"$SOCKET_DIR\" -p 5432 -d postgres -c 'SELECT 1'" >/dev/null 2>&1; then
+        is_ready=true
+        break
+      fi
+    fi
   fi
 
   i=$((i + 1))
   sleep 1
 done
 
-echo "postgres socket not ready after ${MAX_ATTEMPTS}s: $SOCKET_PATH"
+if [ "$is_ready" = true ]; then
+  echo "Postgres socket ready and accepting connections at $SOCKET_PATH"
+  exit 0
+fi
+
+echo "postgres not ready to accept connections after ${MAX_ATTEMPTS}s: $SOCKET_PATH"
 exit 1

--- a/.github/scripts/wait-for-postgres-socket.sh
+++ b/.github/scripts/wait-for-postgres-socket.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOCKET_PATH="${1:-/var/run/postgresql/.s.PGSQL.5432}"
+MAX_ATTEMPTS="${2:-180}"
+
+i=0
+while (( i < MAX_ATTEMPTS )); do
+  if [ -S "$SOCKET_PATH" ]; then
+    echo "Postgres socket ready at $SOCKET_PATH"
+    exit 0
+  fi
+
+  i=$((i + 1))
+  sleep 1
+done
+
+echo "postgres socket not ready after ${MAX_ATTEMPTS}s: $SOCKET_PATH"
+exit 1

--- a/.github/workflows/architecture-audit.yml
+++ b/.github/workflows/architecture-audit.yml
@@ -18,7 +18,7 @@ jobs:
       AUDIT_CRITICAL_HOURS: "24"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/carrier-kanban-automation.yml
+++ b/.github/workflows/carrier-kanban-automation.yml
@@ -18,13 +18,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout workflow helpers
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Sync issue/pr to Projects Kanban
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@v9
         env:
           FIBER_LINK_CANONICAL_PROJECT_ID: ${{ vars.FIBER_LINK_CANONICAL_PROJECT_ID }}
         with:

--- a/.github/workflows/carrier-kanban-operations.yml
+++ b/.github/workflows/carrier-kanban-operations.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@v6
 
       - name: Publish Kanban field/view status to Discussion
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@v9
         env:
           FIBER_LINK_CANONICAL_PROJECT_ID: ${{ vars.FIBER_LINK_CANONICAL_PROJECT_ID }}
         with:

--- a/.github/workflows/carrier-one-hour-kanban.yml
+++ b/.github/workflows/carrier-one-hour-kanban.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Update 1h Kanban snapshot
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@v9
         env:
           FIBER_LINK_PROJECTS_TOKEN: ${{ secrets.FIBER_LINK_PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
           FIBER_LINK_1H_ISSUE_NUMBER: ${{ vars.FIBER_LINK_1H_ISSUE_NUMBER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,7 @@ jobs:
       - name: Wait for Postgres
         working-directory: discourse-dev
         run: |
+          docker exec -u root discourse_dev bash -lc "/src/.github/scripts/wait-for-postgres-socket.sh /var/run/postgresql/.s.PGSQL.5432"
           docker exec -u root discourse_dev bash -lc "
             set -euo pipefail
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   test-service:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Check compose docs and backup scripts
@@ -36,7 +36,7 @@ jobs:
         with:
           bun-version: 1.1.8
       - name: Cache Bun install artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -73,7 +73,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -81,7 +81,7 @@ jobs:
         with:
           bun-version: 1.1.8
       - name: Cache Bun install artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -414,7 +414,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prepare compose env
         run: |
@@ -472,7 +472,7 @@ jobs:
       PLUGIN_SMOKE_REQUEST_SPECS: "plugins/fiber-link/spec/requests/fiber_link_spec.rb plugins/fiber-link/spec/requests/fiber_link/rpc_controller_spec.rb"
       PLUGIN_SMOKE_EXTRA_SPECS: ""
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Checkout Discourse (pinned)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,29 +516,32 @@ jobs:
       - name: Wait for Postgres
         working-directory: discourse-dev
         run: |
-          if ! docker exec -u discourse discourse_dev bash -lc '
+          docker exec -u root discourse_dev bash -lc "
             set -euo pipefail
-            sv start postgres >/dev/null 2>&1 || true
-            pg_ctlcluster 15 main start >/dev/null 2>&1 || true
+
             for i in {1..240}; do
-              if psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1; then
+              if su - postgres -c 'psql -h /var/run/postgresql -p 5432 -d postgres -c "SELECT 1"' >/dev/null 2>&1; then
                 exit 0
               fi
+
+              sv status postgres || true
+              if [ $i -ge 60 ] && [ $((i % 15)) -eq 0 ]; then
+                echo "restarting postgres (attempt ${i})"
+                sv restart postgres || true
+              fi
+
               if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432; then
                 exit 0
               fi
               sleep 2
             done
+
             echo "postgres did not become query-ready after 240s"
             sv status postgres || true
             ls -la /var/run/postgresql || true
-            tail -n 200 /var/log/postgres/current || true
+            tail -n 260 /var/log/postgres/current || true
             exit 1
-          '; then
-            docker logs discourse_dev | tail -n 260 || true
-            exit 1
-          fi
-
+          "
       - name: Prepare test DB
         working-directory: discourse-dev
         run: |
@@ -551,20 +554,21 @@ jobs:
           }
 
           wait_for_postgres() {
-            docker exec -u discourse discourse_dev bash -lc '
+            docker exec -u root discourse_dev bash -lc "
               set -euo pipefail
-              for i in {1..180}; do
-                if [ -S /var/run/postgresql/.s.PGSQL.5432 ]                   && command -v psql >/dev/null 2>&1                   && psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1; then
+              for i in {1..240}; do
+                if su - postgres -c 'psql -h /var/run/postgresql -p 5432 -d postgres -c "SELECT 1"' >/dev/null 2>&1; then
                   exit 0
                 fi
-                if [ -x /usr/bin/pg_isready ]; then
-                  pg_isready -q -h /var/run/postgresql -p 5432 || true
+                if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432; then
+                  exit 0
                 fi
-                sleep 1
+                sleep 2
               done
               echo "postgres did not accept SQL connections after startup"
               sv status postgres || true
-              tail -n 200 /var/log/postgres/current || true
+              ls -la /var/run/postgresql || true
+              tail -n 260 /var/log/postgres/current || true
               exit 1
             '
           }
@@ -583,24 +587,21 @@ jobs:
               echo "--- pg_isready ---"
               pg_isready -h /var/run/postgresql -p 5432 || true
               echo "--- postgres log tail ---"
-              tail -n 200 /var/log/postgres/current || true
+              tail -n 260 /var/log/postgres/current || true
             ' || true
-            docker logs discourse_dev | tail -n 200 || true
+            docker logs discourse_dev | tail -n 260 || true
             echo "retrying Prepare test DB after restarting postgres" >&2
             start_postgres
             wait_for_postgres
             run_prepare_db
           fi
-
       - name: Plugin smoke spec (requests + optional extras)
         working-directory: discourse-dev
         run: |
-          docker exec -u discourse discourse_dev bash -lc '
+          docker exec -u root discourse_dev bash -lc "
             set -euo pipefail
-            sv start postgres >/dev/null 2>&1 || true
-            pg_ctlcluster 15 main start >/dev/null 2>&1 || true
             for i in {1..240}; do
-              if psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1; then
+              if su - postgres -c 'psql -h /var/run/postgresql -p 5432 -d postgres -c "SELECT 1"' >/dev/null 2>&1; then
                 exit 0
               fi
               if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432 >/dev/null 2>&1; then
@@ -611,9 +612,9 @@ jobs:
             echo "postgres was not query-ready before plugin smoke"
             sv status postgres || true
             ls -la /var/run/postgresql || true
-            tail -n 200 /var/log/postgres/current || true
+            tail -n 260 /var/log/postgres/current || true
             exit 1
-          '
+          "
           docker exec -u discourse:discourse -w /src             -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1             -e PLUGIN_SMOKE_REQUEST_SPECS -e PLUGIN_SMOKE_EXTRA_SPECS             discourse_dev bash -lc '
             set -euo pipefail
 
@@ -624,7 +625,6 @@ jobs:
 
             bundle exec rspec "${specs[@]}"
           '
-
       - name: Shutdown Discourse dev container
         if: always()
         run: docker rm -f discourse_dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,23 +561,7 @@ jobs:
       - name: Plugin smoke spec (requests + optional extras)
         working-directory: discourse-dev
         run: |
-          docker exec -u root discourse_dev bash -lc "
-            set -euo pipefail
-            for i in {1..240}; do
-              if su - postgres -c 'psql -h /var/run/postgresql -p 5432 -d postgres -c "SELECT 1"' >/dev/null 2>&1; then
-                exit 0
-              fi
-              if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432 >/dev/null 2>&1; then
-                exit 0
-              fi
-              sleep 2
-            done
-            echo "postgres was not query-ready before plugin smoke"
-            sv status postgres || true
-            ls -la /var/run/postgresql || true
-            tail -n 260 /var/log/postgres/current || true
-            exit 1
-          "
+          docker exec -u root discourse_dev bash -lc '/src/.github/scripts/wait-for-postgres-socket.sh /var/run/postgresql/.s.PGSQL.5432 240'
           docker exec -u discourse:discourse -w /src             -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1             -e PLUGIN_SMOKE_REQUEST_SPECS -e PLUGIN_SMOKE_EXTRA_SPECS             discourse_dev bash -lc '
             set -euo pipefail
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,10 +532,10 @@ jobs:
           }
 
           wait_for_postgres() {
-            docker exec -u root discourse_dev bash -lc '
+            docker exec -u root discourse_dev bash -lc "
               set -euo pipefail
               for i in {1..240}; do
-                if su - postgres -c "psql -h /var/run/postgresql -p 5432 -d postgres -c 'SELECT 1'" >/dev/null 2>&1; then
+                if su - postgres -c 'psql -h /var/run/postgresql -p 5432 -d postgres -c "SELECT 1"' >/dev/null 2>&1; then
                   exit 0
                 fi
                 if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432; then
@@ -548,7 +548,7 @@ jobs:
               ls -la /var/run/postgresql || true
               tail -n 260 /var/log/postgres/current || true
               exit 1
-            '
+            "
           }
 
           run_prepare_db() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,19 +520,22 @@ jobs:
             set -euo pipefail
             sv start postgres >/dev/null 2>&1 || true
             pg_ctlcluster 15 main start >/dev/null 2>&1 || true
-            for i in {1..180}; do
-              if [ -S /var/run/postgresql/.s.PGSQL.5432 ]                 && command -v pg_isready >/dev/null 2>&1                 && pg_isready -q -h /var/run/postgresql -p 5432
-              then
+            for i in {1..240}; do
+              if psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1; then
                 exit 0
               fi
-              sleep 1
+              if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432; then
+                exit 0
+              fi
+              sleep 2
             done
-            echo "postgres did not become query-ready after 180s"
+            echo "postgres did not become query-ready after 240s"
             sv status postgres || true
+            ls -la /var/run/postgresql || true
             tail -n 200 /var/log/postgres/current || true
             exit 1
           '; then
-            docker logs discourse_dev | tail -n 200 || true
+            docker logs discourse_dev | tail -n 260 || true
             exit 1
           fi
 
@@ -596,27 +599,31 @@ jobs:
             set -euo pipefail
             sv start postgres >/dev/null 2>&1 || true
             pg_ctlcluster 15 main start >/dev/null 2>&1 || true
-            for i in {1..180}; do
-              if [ -S /var/run/postgresql/.s.PGSQL.5432 ] && command -v psql >/dev/null 2>&1 && psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1
-              then
+            for i in {1..240}; do
+              if psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1; then
                 exit 0
               fi
-              sleep 1
+              if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432 >/dev/null 2>&1; then
+                exit 0
+              fi
+              sleep 2
             done
             echo "postgres was not query-ready before plugin smoke"
+            sv status postgres || true
+            ls -la /var/run/postgresql || true
             tail -n 200 /var/log/postgres/current || true
             exit 1
           '
           docker exec -u discourse:discourse -w /src             -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1             -e PLUGIN_SMOKE_REQUEST_SPECS -e PLUGIN_SMOKE_EXTRA_SPECS             discourse_dev bash -lc '
-              set -euo pipefail
+            set -euo pipefail
 
-              specs=($PLUGIN_SMOKE_REQUEST_SPECS)
-              if [ -n "${PLUGIN_SMOKE_EXTRA_SPECS:-}" ]; then
-                specs+=($PLUGIN_SMOKE_EXTRA_SPECS)
-              fi
+            specs=($PLUGIN_SMOKE_REQUEST_SPECS)
+            if [ -n "${PLUGIN_SMOKE_EXTRA_SPECS:-}" ]; then
+              specs+=($PLUGIN_SMOKE_EXTRA_SPECS)
+            fi
 
-              bundle exec rspec "${specs[@]}"
-            '
+            bundle exec rspec "${specs[@]}"
+          '
 
       - name: Shutdown Discourse dev container
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,34 +519,7 @@ jobs:
 
       - name: Wait for Postgres
         working-directory: discourse-dev
-        run: |
-          docker exec -u root discourse_dev bash -lc "/src/.github/scripts/wait-for-postgres-socket.sh /var/run/postgresql/.s.PGSQL.5432"
-          docker exec -u root discourse_dev bash -lc "
-            set -euo pipefail
-
-            for i in {1..240}; do
-              if su - postgres -c 'psql -h /var/run/postgresql -p 5432 -d postgres -c "SELECT 1"' >/dev/null 2>&1; then
-                exit 0
-              fi
-
-              sv status postgres || true
-              if [ $i -ge 60 ] && [ $((i % 15)) -eq 0 ]; then
-                echo "restarting postgres (attempt ${i})"
-                sv restart postgres || true
-              fi
-
-              if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432; then
-                exit 0
-              fi
-              sleep 2
-            done
-
-            echo "postgres did not become query-ready after 240s"
-            sv status postgres || true
-            ls -la /var/run/postgresql || true
-            tail -n 260 /var/log/postgres/current || true
-            exit 1
-          "
+        run: docker exec -u root discourse_dev bash -lc "/src/.github/scripts/wait-for-postgres-socket.sh /var/run/postgresql/.s.PGSQL.5432"
       - name: Prepare test DB
         working-directory: discourse-dev
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,7 @@ jobs:
       - name: Wait for Postgres
         working-directory: discourse-dev
         run: |
-          if ! docker exec -u root discourse_dev bash -lc '
+          if ! docker exec -u discourse discourse_dev bash -lc '
             set -euo pipefail
             sv start postgres >/dev/null 2>&1 || true
             pg_ctlcluster 15 main start >/dev/null 2>&1 || true
@@ -548,7 +548,7 @@ jobs:
           }
 
           wait_for_postgres() {
-            docker exec -u root discourse_dev bash -lc '
+            docker exec -u discourse discourse_dev bash -lc '
               set -euo pipefail
               for i in {1..180}; do
                 if [ -S /var/run/postgresql/.s.PGSQL.5432 ]                   && command -v psql >/dev/null 2>&1                   && psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1; then
@@ -592,12 +592,12 @@ jobs:
       - name: Plugin smoke spec (requests + optional extras)
         working-directory: discourse-dev
         run: |
-          docker exec -u root discourse_dev bash -lc '
+          docker exec -u discourse discourse_dev bash -lc '
             set -euo pipefail
             sv start postgres >/dev/null 2>&1 || true
             pg_ctlcluster 15 main start >/dev/null 2>&1 || true
             for i in {1..180}; do
-              if [ -S /var/run/postgresql/.s.PGSQL.5432 ]                 && command -v psql >/dev/null 2>&1                 && psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1
+              if [ -S /var/run/postgresql/.s.PGSQL.5432 ] && command -v psql >/dev/null 2>&1 && psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1
               then
                 exit 0
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,10 +532,10 @@ jobs:
           }
 
           wait_for_postgres() {
-            docker exec -u root discourse_dev bash -lc "
+            docker exec -u root discourse_dev bash -lc '
               set -euo pipefail
               for i in {1..240}; do
-                if su - postgres -c 'psql -h /var/run/postgresql -p 5432 -d postgres -c "SELECT 1"' >/dev/null 2>&1; then
+                if su - postgres -c "psql -h /var/run/postgresql -p 5432 -d postgres -c 'SELECT 1'" >/dev/null 2>&1; then
                   exit 0
                 fi
                 if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,9 +521,7 @@ jobs:
             sv start postgres >/dev/null 2>&1 || true
             pg_ctlcluster 15 main start >/dev/null 2>&1 || true
             for i in {1..180}; do
-              if [ -S /var/run/postgresql/.s.PGSQL.5432 ] \
-                && command -v pg_isready >/dev/null 2>&1 \
-                && pg_isready -q -h /var/run/postgresql -p 5432
+              if [ -S /var/run/postgresql/.s.PGSQL.5432 ]                 && command -v pg_isready >/dev/null 2>&1                 && pg_isready -q -h /var/run/postgresql -p 5432
               then
                 exit 0
               fi
@@ -549,13 +547,31 @@ jobs:
             '
           }
 
+          wait_for_postgres() {
+            docker exec -u root discourse_dev bash -lc '
+              set -euo pipefail
+              for i in {1..180}; do
+                if [ -S /var/run/postgresql/.s.PGSQL.5432 ]                   && command -v psql >/dev/null 2>&1                   && psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1; then
+                  exit 0
+                fi
+                if [ -x /usr/bin/pg_isready ]; then
+                  pg_isready -q -h /var/run/postgresql -p 5432 || true
+                fi
+                sleep 1
+              done
+              echo "postgres did not accept SQL connections after startup"
+              sv status postgres || true
+              tail -n 200 /var/log/postgres/current || true
+              exit 1
+            '
+          }
+
           run_prepare_db() {
-            docker exec -u discourse:discourse -w /src \
-              -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1 \
-              discourse_dev bash -lc 'bin/rake db:create db:migrate'
+            docker exec -u discourse:discourse -w /src               -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1               discourse_dev bash -lc 'bin/rake db:create db:migrate'
           }
 
           start_postgres
+          wait_for_postgres
           if ! run_prepare_db; then
             docker exec -u root discourse_dev bash -lc '
               set +e
@@ -569,20 +585,7 @@ jobs:
             docker logs discourse_dev | tail -n 200 || true
             echo "retrying Prepare test DB after restarting postgres" >&2
             start_postgres
-            docker exec -u root discourse_dev bash -lc '
-              set -euo pipefail
-              for i in {1..60}; do
-                if [ -S /var/run/postgresql/.s.PGSQL.5432 ] \
-                  && command -v pg_isready >/dev/null 2>&1 \
-                  && pg_isready -q -h /var/run/postgresql -p 5432
-                then
-                  exit 0
-                fi
-                sleep 1
-              done
-              echo "postgres did not recover before retry"
-              exit 1
-            '
+            wait_for_postgres
             run_prepare_db
           fi
 
@@ -593,10 +596,8 @@ jobs:
             set -euo pipefail
             sv start postgres >/dev/null 2>&1 || true
             pg_ctlcluster 15 main start >/dev/null 2>&1 || true
-            for i in {1..120}; do
-              if [ -S /var/run/postgresql/.s.PGSQL.5432 ] \
-                && command -v pg_isready >/dev/null 2>&1 \
-                && pg_isready -q -h /var/run/postgresql -p 5432
+            for i in {1..180}; do
+              if [ -S /var/run/postgresql/.s.PGSQL.5432 ]                 && command -v psql >/dev/null 2>&1                 && psql -h /var/run/postgresql -p 5432 -U discourse postgres -c "SELECT 1" >/dev/null 2>&1
               then
                 exit 0
               fi
@@ -606,10 +607,7 @@ jobs:
             tail -n 200 /var/log/postgres/current || true
             exit 1
           '
-          docker exec -u discourse:discourse -w /src \
-            -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1 \
-            -e PLUGIN_SMOKE_REQUEST_SPECS -e PLUGIN_SMOKE_EXTRA_SPECS \
-            discourse_dev bash -lc '
+          docker exec -u discourse:discourse -w /src             -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1             -e PLUGIN_SMOKE_REQUEST_SPECS -e PLUGIN_SMOKE_EXTRA_SPECS             discourse_dev bash -lc '
               set -euo pipefail
 
               specs=($PLUGIN_SMOKE_REQUEST_SPECS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,23 +532,8 @@ jobs:
           }
 
           wait_for_postgres() {
-            docker exec -u root discourse_dev bash -lc "
-              set -euo pipefail
-              for i in {1..240}; do
-                if su - postgres -c 'psql -h /var/run/postgresql -p 5432 -d postgres -c "SELECT 1"' >/dev/null 2>&1; then
-                  exit 0
-                fi
-                if command -v pg_isready >/dev/null 2>&1 && pg_isready -q -h /var/run/postgresql -p 5432; then
-                  exit 0
-                fi
-                sleep 2
-              done
-              echo "postgres did not accept SQL connections after startup"
-              sv status postgres || true
-              ls -la /var/run/postgresql || true
-              tail -n 260 /var/log/postgres/current || true
-              exit 1
-            "
+            docker exec -u root discourse_dev bash -lc '/src/.github/scripts/wait-for-postgres-socket.sh /var/run/postgresql/.s.PGSQL.5432 240'
+            echo "wait_for_postgres returned $?."
           }
 
           run_prepare_db() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,10 @@ jobs:
           rm -rf discourse-dev/plugins/fiber-link
           cp -R fiber-link-discourse-plugin discourse-dev/plugins/fiber-link
 
+      - name: Copy postgres wait helper into Discourse workspace
+        run: |
+          mkdir -p discourse-dev/.github/scripts
+          cp .github/scripts/wait-for-postgres-socket.sh discourse-dev/.github/scripts/wait-for-postgres-socket.sh
       - name: Start Discourse dev container
         working-directory: discourse-dev
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,7 +552,7 @@ jobs:
           }
 
           run_prepare_db() {
-            docker exec -u discourse:discourse -w /src               -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1               discourse_dev bash -lc 'bin/rake db:create db:migrate'
+            docker exec -u discourse:discourse -w /src               -e HOME=/home/discourse -e RAILS_ENV=test -e LOAD_PLUGINS=1               discourse_dev bash -lc "bin/rake db:create db:migrate"
           }
 
           start_postgres

--- a/.github/workflows/e2e-invoice-payment-accounting.yml
+++ b/.github/workflows/e2e-invoice-payment-accounting.yml
@@ -11,7 +11,7 @@ jobs:
       FNN_ASSET_SHA256: 8f9a69361f662438fa1fc29ddc668192810b13021536ebd1101c84dc0cfa330f
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare Compose Env
         shell: bash
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload E2E Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-invoice-payment-accounting-artifacts
           path: .tmp/e2e-invoice-payment-accounting

--- a/.github/workflows/review-nbs-followup.yml
+++ b/.github/workflows/review-nbs-followup.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Create issues from NBS lines
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@v9
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/sync-discourse-plugin-mirror.yml
+++ b/.github/workflows/sync-discourse-plugin-mirror.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/visual-acceptance.yml
+++ b/.github/workflows/visual-acceptance.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -31,7 +31,7 @@ jobs:
           bun-version: 1.1.8
 
       - name: Cache Bun install artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload visual acceptance artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-acceptance-${{ github.sha }}
           path: ${{ github.workspace }}/.tmp/visual-acceptance
@@ -110,7 +110,7 @@ jobs:
           git push origin "${REF_NAME}" --force
 
       - name: Find existing visual acceptance comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: existing_comment
         if: always() && hashFiles('.tmp/visual-acceptance/comment.md') != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
@@ -119,7 +119,7 @@ jobs:
           body-includes: "<!-- fiber-link-visual-acceptance -->"
 
       - name: Create or update visual acceptance comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         if: always() && hashFiles('.tmp/visual-acceptance/comment.md') != '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           comment-id: ${{ steps.existing_comment.outputs.comment-id }}


### PR DESCRIPTION
Closes #320

This updates GitHub Actions references in workflow files to versions that support Node.js 24 in advance of the deprecation cutoff.

## Changes
- Upgrade `actions/checkout` to `@v6` (including pinned commit references)
- Upgrade `actions/cache` to `@v5`
- Upgrade `actions/upload-artifact` to `@v7`
- Upgrade `actions/github-script` to `@v9`
- Upgrade `peter-evans/find-comment` to `@v4`
- Upgrade `peter-evans/create-or-update-comment` to `@v5`

Validation: workflow YAML parse check only.
