### PR TITLE
fix: normalize fractional CKB rebalance amounts

### DIFF
--- a/fiber-link-service/packages/fiber-adapter/src/fiber-adapter.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/fiber-adapter.test.ts
@@ -343,7 +343,7 @@ describe("fiber adapter", () => {
     expect(executeCkbOnchainWithdrawal).not.toHaveBeenCalled();
   });
 
-  it("ensureChainLiquidity starts a rebalance request and returns pending status", async () => {
+  it("ensureChainLiquidity encodes fractional CKB rebalance amounts as shannons hex", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -358,7 +358,7 @@ describe("fiber adapter", () => {
       requestId: "liq-1",
       asset: "CKB",
       network: "AGGRON4",
-      requiredAmount: "100",
+      requiredAmount: "85.00016356",
       sourceKind: "FIBER_TO_CKB_CHAIN",
     });
 
@@ -373,7 +373,7 @@ describe("fiber adapter", () => {
     );
     expect(fetchSpy.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
-        body: expect.stringContaining("\"request_id\":\"liq-1\""),
+        body: expect.stringContaining("\"required_amount\":\"0x1faa3f4e4\""),
       }),
     );
   });

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/normalize.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/normalize.ts
@@ -43,6 +43,30 @@ export function toHexQuantity(value: string): string {
   return `0x${BigInt(value).toString(16)}`;
 }
 
+const SHANNONS_PER_CKB = 100_000_000n;
+
+export function ckbDecimalToHexQuantity(value: string): string {
+  const trimmed = value.trim();
+  if (!/^\d+(?:\.\d+)?$/.test(trimmed)) {
+    throw new Error(`invalid CKB amount: ${value}`);
+  }
+
+  const [integerPartRaw, fractionPartRaw = ""] = trimmed.split(".");
+  if (fractionPartRaw.length > 8) {
+    throw new Error(`CKB amount supports at most 8 decimal places, received: ${value}`);
+  }
+
+  const integerPart = BigInt(integerPartRaw);
+  const fractionPart = fractionPartRaw.padEnd(8, "0");
+  const fractionValue = fractionPart ? BigInt(fractionPart) : 0n;
+  const shannons = integerPart * SHANNONS_PER_CKB + fractionValue;
+  if (shannons <= 0n) {
+    throw new Error(`CKB amount must be greater than 0, received: ${value}`);
+  }
+
+  return `0x${shannons.toString(16)}`;
+}
+
 export function pickStringCandidate(value: unknown): string | null {
   if (typeof value === "string" && value.trim()) {
     return value.trim();

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.test.ts
@@ -65,6 +65,32 @@ describe("rebalance-ops local CKB liquidity fallback", () => {
     expect(mod.hasLocalChainLiquiditySweepSupport()).toBe(true);
   });
 
+  it("encodes fractional CKB rebalance amounts as shannons hex before calling Fiber RPC", async () => {
+    rpcCallMock.mockResolvedValueOnce({ status: "pending", started: true });
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    const result = await ensureChainLiquidity("http://fnn:8227", {
+      requestId: "liq-fractional-rpc",
+      asset: "CKB",
+      network: "AGGRON4",
+      requiredAmount: "85.00016356",
+      sourceKind: "FIBER_TO_CKB_CHAIN",
+    });
+
+    expect(result).toEqual({
+      state: "PENDING",
+      started: true,
+    });
+    expect(rpcCallMock).toHaveBeenCalledWith(
+      "http://fnn:8227",
+      "rebalance_to_ckb_chain",
+      expect.objectContaining({
+        request_id: "liq-fractional-rpc",
+        required_amount: "0x1faa3f4e4",
+      }),
+    );
+  });
+
   it("falls back to a local sweep into the hot wallet when rebalance rpc is unsupported", async () => {
     process.env.FIBER_LIQUIDITY_CKB_SOURCE_PRIVATE_KEY =
       "0x2222222222222222222222222222222222222222222222222222222222222222";
@@ -80,7 +106,7 @@ describe("rebalance-ops local CKB liquidity fallback", () => {
       requestId: "liq-1",
       asset: "CKB",
       network: "AGGRON4",
-      requiredAmount: "62",
+      requiredAmount: "61.5",
       sourceKind: "FIBER_TO_CKB_CHAIN",
     });
 
@@ -93,7 +119,7 @@ describe("rebalance-ops local CKB liquidity fallback", () => {
     });
     expect(resolveHotWalletAddressMock).toHaveBeenCalledWith("AGGRON4");
     expect(executeTransferMock).toHaveBeenCalledWith({
-      amount: "62",
+      amount: "61.5",
       destination: { kind: "CKB_ADDRESS", address: "ckt1qhotwallet" },
       network: "AGGRON4",
       privateKey: "0x2222222222222222222222222222222222222222222222222222222222222222",

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.ts
@@ -5,7 +5,7 @@ import {
   normalizeCkbPrivateKey,
   resolveHotWalletAddress,
 } from "../ckb-onchain-withdrawal";
-import { toHexQuantity } from "./normalize";
+import { ckbDecimalToHexQuantity, toHexQuantity } from "./normalize";
 import type {
   CkbNetwork,
   EnsureChainLiquidityArgs,
@@ -226,6 +226,13 @@ async function getLocalChainLiquidityStatus(args: GetRebalanceStatusArgs): Promi
   return toStatusResult(tracking);
 }
 
+function toRebalanceRequiredAmountHex(args: EnsureChainLiquidityArgs): string {
+  if (args.asset === "CKB") {
+    return ckbDecimalToHexQuantity(args.requiredAmount);
+  }
+  return toHexQuantity(args.requiredAmount);
+}
+
 export async function ensureChainLiquidity(
   endpoint: string,
   args: EnsureChainLiquidityArgs,
@@ -240,7 +247,7 @@ export async function ensureChainLiquidity(
       request_id: args.requestId,
       asset: args.asset,
       network: args.network,
-      required_amount: toHexQuantity(args.requiredAmount),
+      required_amount: toRebalanceRequiredAmountHex(args),
       source_kind: args.sourceKind,
     })) as Record<string, unknown> | undefined;
     return parseEnsureChainLiquidityResult(result);


### PR DESCRIPTION
## Summary
- normalize fractional CKB liquidity rebalance amounts into shannons hex before calling `rebalance_to_ckb_chain`
- keep the local `LOCAL_CKB_SWEEP` fallback using decimal CKB amounts for on-chain transfer helpers
- add regression coverage for fractional CKB direct-rebalance RPC payloads and unsupported-RPC local sweep fallback

## Context
During live validation of PR #334 on the `qk4848...` stack, the canary liquidity request `f9a6fcdf-7219-41ff-917b-dd1f3b916a13` exposed a remaining bug:

- `requestedRebalanceAmount` / `requiredAmount` is represented as decimal CKB (for example `85.00016356`)
- `rebalance-ops.ts` was feeding that string into `toHexQuantity()` before the Fiber RPC call
- that helper only accepts integer decimal strings / existing hex quantities, so the automatic path could die with `invalid amount` before it ever decided between direct RPC and local sweep fallback

This patch fixes that conversion boundary.

## Test Plan
- `bunx vitest --run packages/fiber-adapter/src/rpc-adapter/rebalance-ops.test.ts packages/fiber-adapter/src/fiber-adapter.test.ts apps/worker/src/liquidity-batch.test.ts`
- `git diff --check`

Closes #337
