### PR TITLE
fix: normalize fractional CKB rebalance amounts (review fixes for #338)

### DIFF
--- a/fiber-link-service/packages/fiber-adapter/src/ckb-onchain-withdrawal.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/ckb-onchain-withdrawal.ts
@@ -1,7 +1,6 @@
 import { BI, Indexer, RPC, commons, config, hd, helpers } from "@ckb-lumos/lumos";
 import type { Asset, CkbNetwork, ExecuteWithdrawalArgs, WithdrawalExecutionKind } from "./types";
-
-const SHANNONS_PER_CKB = 100_000_000n;
+import { SHANNONS_PER_CKB, parseCkbDecimalToShannons } from "./rpc-adapter/normalize";
 const DEFAULT_FEE_RATE_SHANNONS_PER_KB = 1_000n;
 const DEFAULT_TESTNET_CKB_RPC_URL = "https://testnet.ckbapp.dev/";
 
@@ -27,28 +26,15 @@ export function normalizeErrorMessage(error: unknown): string {
 }
 
 function parseCkbAmountToShannons(amount: string): bigint {
-  const trimmed = amount.trim();
-  if (!/^\d+(?:\.\d+)?$/.test(trimmed)) {
-    throw new WithdrawalExecutionError(`invalid CKB amount: ${amount}`, "permanent");
-  }
-
-  const [intPartRaw, fracPartRaw = ""] = trimmed.split(".");
-  if (fracPartRaw.length > 8) {
+  try {
+    return parseCkbDecimalToShannons(amount);
+  } catch (error) {
     throw new WithdrawalExecutionError(
-      `CKB amount supports at most 8 decimal places, received: ${amount}`,
+      error instanceof Error ? error.message : String(error),
       "permanent",
+      { cause: error instanceof Error ? error : undefined },
     );
   }
-
-  const intPart = BigInt(intPartRaw);
-  const fracPart = fracPartRaw.padEnd(8, "0");
-  const fracValue = fracPart ? BigInt(fracPart) : 0n;
-  const shannons = intPart * SHANNONS_PER_CKB + fracValue;
-
-  if (shannons <= 0n) {
-    throw new WithdrawalExecutionError(`withdrawal amount must be greater than 0, received: ${amount}`, "permanent");
-  }
-  return shannons;
 }
 
 function parseOptionalBigIntEnv(name: string): bigint | null {

--- a/fiber-link-service/packages/fiber-adapter/src/fiber-adapter.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/fiber-adapter.test.ts
@@ -343,7 +343,7 @@ describe("fiber adapter", () => {
     expect(executeCkbOnchainWithdrawal).not.toHaveBeenCalled();
   });
 
-  it("ensureChainLiquidity starts a rebalance request and returns pending status", async () => {
+  it("ensureChainLiquidity encodes fractional CKB rebalance amounts as shannons hex", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -358,7 +358,7 @@ describe("fiber adapter", () => {
       requestId: "liq-1",
       asset: "CKB",
       network: "AGGRON4",
-      requiredAmount: "100",
+      requiredAmount: "85.00016356",
       sourceKind: "FIBER_TO_CKB_CHAIN",
     });
 
@@ -368,12 +368,7 @@ describe("fiber adapter", () => {
     });
     expect(fetchSpy.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
-        body: expect.stringContaining("\"method\":\"rebalance_to_ckb_chain\""),
-      }),
-    );
-    expect(fetchSpy.mock.calls[0]?.[1]).toEqual(
-      expect.objectContaining({
-        body: expect.stringContaining("\"request_id\":\"liq-1\""),
+        body: expect.stringContaining("\"required_amount\":\"0x1faa3f4e4\""),
       }),
     );
   });

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/normalize.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/normalize.ts
@@ -43,6 +43,28 @@ export function toHexQuantity(value: string): string {
   return `0x${BigInt(value).toString(16)}`;
 }
 
+export const SHANNONS_PER_CKB = 100_000_000n;
+
+export function parseCkbDecimalToShannons(value: string): bigint {
+  const trimmed = value.trim();
+  if (!/^\d+(?:\.\d+)?$/.test(trimmed)) {
+    throw new Error(`invalid CKB amount: ${value}`);
+  }
+  const [integerPartRaw, fractionPartRaw = ""] = trimmed.split(".");
+  if (fractionPartRaw.length > 8) {
+    throw new Error(`CKB amount supports at most 8 decimal places, received: ${value}`);
+  }
+  const shannons = BigInt(integerPartRaw) * SHANNONS_PER_CKB + BigInt(fractionPartRaw.padEnd(8, "0"));
+  if (shannons <= 0n) {
+    throw new Error(`CKB amount must be greater than 0, received: ${value}`);
+  }
+  return shannons;
+}
+
+export function ckbDecimalToHexQuantity(value: string): string {
+  return `0x${parseCkbDecimalToShannons(value).toString(16)}`;
+}
+
 export function pickStringCandidate(value: unknown): string | null {
   if (typeof value === "string" && value.trim()) {
     return value.trim();

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.test.ts
@@ -65,6 +65,32 @@ describe("rebalance-ops local CKB liquidity fallback", () => {
     expect(mod.hasLocalChainLiquiditySweepSupport()).toBe(true);
   });
 
+  it("encodes fractional CKB rebalance amounts as shannons hex before calling Fiber RPC", async () => {
+    rpcCallMock.mockResolvedValueOnce({ status: "pending", started: true });
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    const result = await ensureChainLiquidity("http://fnn:8227", {
+      requestId: "liq-fractional-rpc",
+      asset: "CKB",
+      network: "AGGRON4",
+      requiredAmount: "85.00016356",
+      sourceKind: "FIBER_TO_CKB_CHAIN",
+    });
+
+    expect(result).toEqual({
+      state: "PENDING",
+      started: true,
+    });
+    expect(rpcCallMock).toHaveBeenCalledWith(
+      "http://fnn:8227",
+      "rebalance_to_ckb_chain",
+      expect.objectContaining({
+        request_id: "liq-fractional-rpc",
+        required_amount: "0x1faa3f4e4",
+      }),
+    );
+  });
+
   it("falls back to a local sweep into the hot wallet when rebalance rpc is unsupported", async () => {
     process.env.FIBER_LIQUIDITY_CKB_SOURCE_PRIVATE_KEY =
       "0x2222222222222222222222222222222222222222222222222222222222222222";
@@ -80,7 +106,7 @@ describe("rebalance-ops local CKB liquidity fallback", () => {
       requestId: "liq-1",
       asset: "CKB",
       network: "AGGRON4",
-      requiredAmount: "62",
+      requiredAmount: "61.5",
       sourceKind: "FIBER_TO_CKB_CHAIN",
     });
 
@@ -93,7 +119,7 @@ describe("rebalance-ops local CKB liquidity fallback", () => {
     });
     expect(resolveHotWalletAddressMock).toHaveBeenCalledWith("AGGRON4");
     expect(executeTransferMock).toHaveBeenCalledWith({
-      amount: "62",
+      amount: "61.5",
       destination: { kind: "CKB_ADDRESS", address: "ckt1qhotwallet" },
       network: "AGGRON4",
       privateKey: "0x2222222222222222222222222222222222222222222222222222222222222222",

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.ts
@@ -5,7 +5,7 @@ import {
   normalizeCkbPrivateKey,
   resolveHotWalletAddress,
 } from "../ckb-onchain-withdrawal";
-import { toHexQuantity } from "./normalize";
+import { ckbDecimalToHexQuantity, toHexQuantity } from "./normalize";
 import type {
   CkbNetwork,
   EnsureChainLiquidityArgs,
@@ -218,6 +218,13 @@ async function getOrRefreshLocalSweepTracking(args: GetRebalanceStatusArgs): Pro
   return pending;
 }
 
+function toRebalanceRequiredAmountHex(args: EnsureChainLiquidityArgs): string {
+  if (args.asset === "CKB") {
+    return ckbDecimalToHexQuantity(args.requiredAmount);
+  }
+  return toHexQuantity(args.requiredAmount);
+}
+
 async function getLocalChainLiquidityStatus(args: GetRebalanceStatusArgs): Promise<GetRebalanceStatusResult | null> {
   const tracking = await getOrRefreshLocalSweepTracking(args);
   if (!tracking) {
@@ -240,7 +247,7 @@ export async function ensureChainLiquidity(
       request_id: args.requestId,
       asset: args.asset,
       network: args.network,
-      required_amount: toHexQuantity(args.requiredAmount),
+      required_amount: toRebalanceRequiredAmountHex(args),
       source_kind: args.sourceKind,
     })) as Record<string, unknown> | undefined;
     return parseEnsureChainLiquidityResult(result);


### PR DESCRIPTION
## Summary

Review-driven improvements on top of PR #338 (`fix/issue-337-fractional-rebalance-amount`).

- Extract `parseCkbDecimalToShannons` and `ckbDecimalToHexQuantity` as shared exports in `normalize.ts`, eliminating the duplicated parsing logic and `SHANNONS_PER_CKB` constant that existed in both `normalize.ts` (new) and `ckb-onchain-withdrawal.ts`
- Fix the redundant ternary (`fractionPart ? BigInt(fractionPart) : 0n`) — after `padEnd(8, "0")` the string is always non-empty, so `BigInt(fractionPart)` is sufficient
- Refactor `parseCkbAmountToShannons` in `ckb-onchain-withdrawal.ts` to delegate to the shared `parseCkbDecimalToShannons`, preserving `WithdrawalExecutionError` wrapping
- Add `toRebalanceRequiredAmountHex` helper in `rebalance-ops.ts` and wire `ckbDecimalToHexQuantity` for CKB amounts before the Fiber RPC call
- Add regression test for fractional CKB direct-RPC path (`85.00016356` → `0x1faa3f4e4`)
- Update local-sweep fallback test to use a fractional amount (`61.5`) to verify the decimal is passed through unchanged to the on-chain transfer helper

## Issues addressed from review

- **Duplication** (Gemini comment on `normalize.ts:68`): single source of truth for CKB decimal → shannons conversion
- **Redundant ternary**: eliminated

Closes #337

https://claude.ai/code/session_01BWEy3TWKE6eusKcpiVVyo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWEy3TWKE6eusKcpiVVyo7)_