### PR TITLE
feat(discourse): refine Fiber Link dashboard and tip UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           ./scripts/run-visual-acceptance-local.test.sh
           ./scripts/render-visual-acceptance-comment.test.sh
           ./scripts/playwright-workflow-flow12.test.sh
+          ./scripts/playwright-workflow-author-withdrawal.test.sh
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.1.8

--- a/docs/plans/2026-04-14-tip-payment-experience-upgrade.md
+++ b/docs/plans/2026-04-14-tip-payment-experience-upgrade.md
@@ -3,12 +3,57 @@
 Goal: turn the Discourse tip payment modal into a product-quality payment surface with clear staged flow, Fiber Link branding, richer payment context, and a polished success state suitable for visual acceptance screenshots.
 
 Scope:
+
 - upgrade the topic/reply tip modal UI in `fiber-link-discourse-plugin`
 - keep current RPC contract (`tip.create`, `tip.status`) working
-- introduce a branded payment experience with Fiber Link logo + link to `https://fiberlink.me/`
+- introduce a branded payment experience with Fiber Link logo + link to `https://www.fiberlink.me`
 - preserve automated system coverage for invoice generation, pending, and settled states
 
+Current interaction direction:
+
+- title the dialog as `Send a tip`, using the same tip icon family as the post-menu tip button
+- present Fiber Link as payment-service attribution via `Powered by Fiber Link` in the dialog footer, with `Fiber Link` as the external link
+- load the official Fiber Link logo from `https://fiberlink.me/brand/fiber-link-logo.png`
+- keep the dialog compact and refined, with a square, centered close control and no header/footer divider lines
+- lead with the large amount and `Tipping @recipient`, then show the forum avatar recipient strip with `Receives <amount>CKB`
+- present context as a two-cell meta row with `Topic` or `Reply context` first and `Network` second
+- separate the summary and Step 1 with clear spacing while avoiding an enclosing card border
+- keep Step 1 focused on amount and optional message with an open layout, no redundant title/caption, soft surfaces, and no gradient color
+- use the current standalone modal direction: off-white surfaces, black primary action, compact mono labels, and restrained status color
+- align the modal header/footer density to the standalone comp by treating their 72px/77px heights as total box height rather than content plus padding
+- keep the step header's right-side stepper as two short horizontal bars: Step 1 highlights the first bar, Step 2 highlights both
+- style quick amounts as equal-width 32px-tall pills with black selected state and transparent inactive state
+- use `Leave a short note` as the optional message placeholder, without extra reaction or markdown helper text below the field
+- select the `Custom` amount chip whenever the typed CKB amount does not match a preset quick amount
+- label the first-step CTA as `Review & Pay`
+- keep the second step visually calm: no progress dots, clear space between `Step 02` and `Pay with Wallet`, and no automatic-status helper copy
+- show the pending state as a compact loading spinner plus `Awaiting payment`; polling remains automatic without a footer `Check status` button
+- decorate the QR card with the standalone comp's top-left and bottom-right black corner marks
+- hide the `Expires in` timer until the RPC result includes real invoice expiration data; keep the timer structure ready for a future dynamic progress bar
+- keep invoice copy as an icon-only control with a centered visible icon on hover: default copy icon, copied check icon, and a 3-second `Copied` title/aria state before reset
+- keep `Open Fiber Wallet` visible but disabled with a semi-transparent, non-clickable appearance for now, and avoid exposing raw invoice/payment details through a `More options` panel
+- do not display fee information in the tip dialog
+
+Dashboard replication direction:
+
+- match the provided Dashboard comp while keeping `/fiber-link` as a normal embedded Discourse page with the standard Discourse chrome visible
+- expose `/fiber-link` from the logged-in user's profile menu as `Fiber Link Dashboard`
+- keep the Dashboard surface transparent so it inherits the Discourse embedded page background instead of painting a separate block
+- keep the hero, summary metrics, withdraw panel, and recent activity table open and border-light rather than card-based
+- keep Dashboard title weights one step lighter than the standalone comp so the embedded page feels calmer inside Discourse
+- expose auto-refresh as a compact dropdown with `10s`, `30s`, and `60s` options
+- keep the live sync label stable during background refreshes to avoid visible flicker
+- keep the withdrawal minimum visible and enforce the current 61 CKB threshold in the UI
+- keep the withdrawal destination error hidden on initial render; disable submit until a destination is present, avoid blue focus rings on withdrawal inputs, and only surface the missing-address validation after a submit attempt
+- provide amount shortcuts for `25%`, `50%`, `75%`, and `Max`, clamped by the minimum withdrawal and available balance
+- show a clear paste failure reminder when clipboard access is unavailable or denied
+- use a toast for successful withdrawal requests instead of inserting a success banner inside the withdraw panel
+- keep the withdrawal action area concise without the extra funds-sent footnote
+- keep the recent-activity search field compact, with the icon and text scaled down with the control
+- hide the `View full ledger` link until a ledger detail workflow is designed
+
 Implementation outline:
+
 1. inspect the existing modal + system spec and keep behavior coverage while changing the presentation
 2. add/expand system expectations first for branded staged UI states
 3. rework the Glimmer modal component into staged states: amount setup, payment request, success

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-auto-refresh-select.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-auto-refresh-select.gjs
@@ -1,0 +1,47 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { on } from "@ember/modifier";
+
+const POLL_INTERVAL_OPTIONS = [10000, 30000, 60000];
+
+export default class FiberLinkAutoRefreshSelect extends Component {
+  get selectedValue() {
+    return Number(this.args.model?.pollIntervalMs || 10000);
+  }
+
+  get isTenSeconds() {
+    return this.selectedValue === 10000;
+  }
+
+  get isThirtySeconds() {
+    return this.selectedValue === 30000;
+  }
+
+  get isSixtySeconds() {
+    return this.selectedValue === 60000;
+  }
+
+  @action
+  updatePollInterval(event) {
+    const nextValue = Number(event?.target?.value);
+    if (!POLL_INTERVAL_OPTIONS.includes(nextValue)) {
+      return;
+    }
+
+    this.args.model?.set("pollIntervalMs", nextValue);
+  }
+
+  <template>
+    <label class="fiber-link-dashboard__refresh-select">
+      <span>Auto-refresh</span>
+      <select
+        aria-label="Auto-refresh interval"
+        {{on "change" this.updatePollInterval}}
+      >
+        <option value="10000" selected={{this.isTenSeconds}}>10s</option>
+        <option value="30000" selected={{this.isThirtySeconds}}>30s</option>
+        <option value="60000" selected={{this.isSixtySeconds}}>60s</option>
+      </select>
+    </label>
+  </template>
+}

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-feed.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-feed.gjs
@@ -1,7 +1,12 @@
 import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { on } from "@ember/modifier";
+import { tracked } from "@glimmer/tracking";
 import formatDate from "discourse/helpers/format-date";
 
 export default class FiberLinkTipFeed extends Component {
+  @tracked activeFilter = "all";
+
   get isLoading() {
     return Boolean(this.args.isLoading);
   }
@@ -22,6 +27,34 @@ export default class FiberLinkTipFeed extends Component {
     return !this.isLoading && !this.errorMessage && this.tips.length === 0;
   }
 
+  get filteredTips() {
+    return this.tips.filter((tip) => this.activeFilter === "all" || tip.directionKey === this.activeFilter);
+  }
+
+  get resultSummary() {
+    const count = this.filteredTips.length;
+    return `Showing ${count} of ${this.tips.length} transactions`;
+  }
+
+  get activeFilterLabel() {
+    if (this.activeFilter === "received") {
+      return "Received";
+    }
+    if (this.activeFilter === "sent") {
+      return "Sent";
+    }
+    if (this.activeFilter === "withdrawn") {
+      return "Withdrawn";
+    }
+    return "All Activity";
+  }
+
+  @action
+  setFilter(event) {
+    const value = event?.target?.value || event?.currentTarget?.dataset?.filter || "all";
+    this.activeFilter = value;
+  }
+
   <template>
     {{#if this.isLoading}}
       <p class="fiber-link-tip-feed-loading">Loading payments...</p>
@@ -34,9 +67,30 @@ export default class FiberLinkTipFeed extends Component {
             You don’t have payments yet.
           </p>
         {{else}}
-          <table class="fiber-link-tip-feed-table">
+          <div class="fiber-link-tip-feed-toolbar">
+            <label class="fiber-link-filter-select-shell">
+              <span class="fiber-link-filter-select-label">Filter</span>
+              <span class="fiber-link-filter-select-wrap">
+                <select
+                  class="fiber-link-filter-select"
+                  aria-label="Activity filter"
+                  value={{this.activeFilter}}
+                  {{on "change" this.setFilter}}
+                >
+                  <option value="all">All Activity</option>
+                  <option value="received">Received</option>
+                  <option value="sent">Sent</option>
+                  <option value="withdrawn">Withdrawn</option>
+                </select>
+                <span class="fiber-link-filter-select-current" aria-hidden="true">{{this.activeFilterLabel}}</span>
+                <span class="fiber-link-filter-select-chevron" aria-hidden="true">⌄</span>
+              </span>
+            </label>
+          </div>
+          <table class="fiber-link-tip-feed-table is-icon-first">
             <thead>
               <tr>
+                <th>Type</th>
                 <th>Amount</th>
                 <th>Status</th>
                 <th>User</th>
@@ -44,14 +98,16 @@ export default class FiberLinkTipFeed extends Component {
               </tr>
             </thead>
             <tbody>
-              {{#each this.tips key="id" as |tip|}}
+              {{#each this.filteredTips key="id" as |tip|}}
                 <tr data-tip-id={{tip.id}}>
+                  <td>
+                    <span class={{tip.directionClassName}} title={{tip.directionLabel}} aria-label={{tip.directionLabel}}>
+                      {{tip.directionIcon}}
+                    </span>
+                  </td>
                   <td>
                     <p class="fiber-link-tip-feed-primary">
                       <strong>{{tip.amount}} {{tip.asset}}</strong>
-                    </p>
-                    <p class="fiber-link-tip-feed-direction-row">
-                      <span class="fiber-link-tip-feed-direction">{{tip.directionLabel}}</span>
                     </p>
                     {{#if tip.message}}
                       <p class="fiber-link-tip-feed-message">{{tip.message}}</p>
@@ -64,6 +120,7 @@ export default class FiberLinkTipFeed extends Component {
               {{/each}}
             </tbody>
           </table>
+          <p class="fiber-link-tip-feed-summary">{{this.resultSummary}}</p>
         {{/if}}
       {{/if}}
     {{/if}}

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-feed.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-feed.gjs
@@ -6,6 +6,7 @@ import formatDate from "discourse/helpers/format-date";
 
 export default class FiberLinkTipFeed extends Component {
   @tracked activeFilter = "all";
+  @tracked searchQuery = "";
 
   get isLoading() {
     return Boolean(this.args.isLoading);
@@ -28,31 +29,63 @@ export default class FiberLinkTipFeed extends Component {
   }
 
   get filteredTips() {
-    return this.tips.filter((tip) => this.activeFilter === "all" || tip.directionKey === this.activeFilter);
+    const query = this.searchQuery.trim().toLowerCase();
+
+    return this.tips.filter((tip) => {
+      const matchesFilter = this.activeFilter === "all" || tip.directionKey === this.activeFilter || tip.statusKey === this.activeFilter;
+      if (!matchesFilter || !query) {
+        return matchesFilter;
+      }
+
+      return [
+        tip.amount,
+        tip.asset,
+        tip.statusLabel,
+        tip.directionLabel,
+        tip.counterpartyUsername,
+        tip.message,
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(query));
+    });
   }
 
   get resultSummary() {
     const count = this.filteredTips.length;
-    return `Showing ${count} of ${this.tips.length} transactions`;
+    return `Showing ${count} of ${this.tips.length} transactions · Last 30 days`;
   }
 
-  get activeFilterLabel() {
-    if (this.activeFilter === "received") {
-      return "Received";
+  countForFilter(value) {
+    if (value === "all") {
+      return this.tips.length;
     }
-    if (this.activeFilter === "sent") {
-      return "Sent";
-    }
-    if (this.activeFilter === "withdrawn") {
-      return "Withdrawn";
-    }
-    return "All Activity";
+
+    return this.tips.filter((tip) => tip.directionKey === value || tip.statusKey === value).length;
+  }
+
+  get filterOptions() {
+    return [
+      { value: "all", label: "All" },
+      { value: "received", label: "Received" },
+      { value: "sent", label: "Sent" },
+      { value: "pending", label: "Pending" },
+      { value: "failed", label: "Failed" },
+    ].map((option) => ({
+      ...option,
+      className: option.value === this.activeFilter ? "fiber-link-filter-chip is-active" : "fiber-link-filter-chip",
+      count: this.countForFilter(option.value),
+    }));
   }
 
   @action
   setFilter(event) {
     const value = event?.target?.value || event?.currentTarget?.dataset?.filter || "all";
     this.activeFilter = value;
+  }
+
+  @action
+  onSearchInput(event) {
+    this.searchQuery = event?.target?.value ?? "";
   }
 
   <template>
@@ -67,31 +100,56 @@ export default class FiberLinkTipFeed extends Component {
             You don’t have payments yet.
           </p>
         {{else}}
-          <div class="fiber-link-tip-feed-toolbar">
-            <label class="fiber-link-filter-select-shell">
-              <span class="fiber-link-filter-select-label">Filter</span>
-              <span class="fiber-link-filter-select-wrap">
-                <select
-                  class="fiber-link-filter-select"
-                  aria-label="Activity filter"
-                  value={{this.activeFilter}}
-                  {{on "change" this.setFilter}}
-                >
-                  <option value="all">All Activity</option>
-                  <option value="received">Received</option>
-                  <option value="sent">Sent</option>
-                  <option value="withdrawn">Withdrawn</option>
-                </select>
-                <span class="fiber-link-filter-select-current" aria-hidden="true">{{this.activeFilterLabel}}</span>
-                <span class="fiber-link-filter-select-chevron" aria-hidden="true">⌄</span>
-              </span>
+          <div class="fiber-link-tip-feed-header">
+            <div>
+              <div class="fiber-link-dashboard__section-kicker">
+                <strong>02</strong>
+                <span>RECENT ACTIVITY</span>
+              </div>
+              <h3>All <span>transactions.</span></h3>
+              <p>
+                Settlement history across Discourse — received tips, sent
+                payments, and withdrawals.
+              </p>
+            </div>
+            <label class="fiber-link-tip-feed-search">
+              <svg
+                class="fiber-link-tip-feed-search__icon"
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+              >
+                <circle cx="11" cy="11" r="8"></circle>
+                <path d="m21 21-4.35-4.35"></path>
+              </svg>
+              <input
+                aria-label="Search activity"
+                placeholder="Search user..."
+                type="search"
+                value={{this.searchQuery}}
+                {{on "input" this.onSearchInput}}
+              />
             </label>
           </div>
-          <table class="fiber-link-tip-feed-table is-icon-first">
+
+          <div class="fiber-link-filter-group" aria-label="Activity filters">
+            {{#each this.filterOptions as |option|}}
+              <button
+                type="button"
+                class={{option.className}}
+                data-filter={{option.value}}
+                {{on "click" this.setFilter}}
+              >
+                <span>{{option.label}}</span>
+                <strong>{{option.count}}</strong>
+              </button>
+            {{/each}}
+          </div>
+
+          <table class="fiber-link-tip-feed-table">
             <thead>
               <tr>
-                <th>Type</th>
                 <th>Amount</th>
+                <th>Type</th>
                 <th>Status</th>
                 <th>User</th>
                 <th>Time</th>
@@ -101,20 +159,36 @@ export default class FiberLinkTipFeed extends Component {
               {{#each this.filteredTips key="id" as |tip|}}
                 <tr data-tip-id={{tip.id}}>
                   <td>
-                    <span class={{tip.directionClassName}} title={{tip.directionLabel}} aria-label={{tip.directionLabel}}>
-                      {{tip.directionIcon}}
+                    <p class={{tip.amountClassName}}>
+                      <strong>{{tip.amountPrefix}} {{tip.amount}}</strong>
+                      <span>{{tip.asset}}</span>
+                    </p>
+                  </td>
+                  <td>
+                    <span class="fiber-link-tip-feed-type">
+                      <span class={{tip.directionClassName}} title={{tip.directionLabel}} aria-label={{tip.directionLabel}}>
+                        {{tip.directionIcon}}
+                      </span>
+                      <span>{{tip.directionLabel}}</span>
                     </span>
                   </td>
                   <td>
-                    <p class="fiber-link-tip-feed-primary">
-                      <strong>{{tip.amount}} {{tip.asset}}</strong>
-                    </p>
-                    {{#if tip.message}}
-                      <p class="fiber-link-tip-feed-message">{{tip.message}}</p>
-                    {{/if}}
+                    <span class="fiber-link-tip-feed-status">
+                      <span class={{tip.statusDotClassName}} aria-hidden="true"></span>
+                      <span class={{tip.statusTextClassName}}>{{tip.statusLabel}}</span>
+                    </span>
                   </td>
-                  <td><span class={{tip.statusClassName}}>{{tip.statusLabel}}</span></td>
-                  <td>@{{tip.counterpartyUsername}}</td>
+                  <td>
+                    <span class="fiber-link-tip-feed-user">
+                      <span class="fiber-link-tip-feed-avatar" aria-hidden="true">{{tip.avatarInitials}}</span>
+                      <span>
+                        <strong>@{{tip.counterpartyUsername}}</strong>
+                        {{#if tip.message}}
+                          <p class="fiber-link-tip-feed-message">{{tip.message}}</p>
+                        {{/if}}
+                      </span>
+                    </span>
+                  </td>
                   <td title={{tip.absoluteTimeLabel}}>{{formatDate tip.createdAt}}</td>
                 </tr>
               {{/each}}

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-modal.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-modal.js
@@ -2,6 +2,6 @@ import Component from "@glimmer/component";
 
 export default class FiberLinkTipModal extends Component {
   get title() {
-    return "Pay with Fiber";
+    return "Tip";
   }
 }

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
@@ -64,12 +64,12 @@ export default class FiberLinkWithdrawalPanel extends Component {
     return normalizeValue(this.quote?.lockedBalance) || normalizeValue(this.args.lockedBalance) || "0";
   }
 
-  get networkFee() {
-    return normalizeValue(this.quote?.networkFee) || "0";
-  }
-
   get receiveAmount() {
     return normalizeValue(this.quote?.receiveAmount) || normalizeValue(this.amount) || "0";
+  }
+
+  get networkFee() {
+    return normalizeValue(this.quote?.networkFee) || "0";
   }
 
   get amountErrorMessage() {
@@ -302,7 +302,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
         </div>
         <div class="fiber-link-dashboard__withdrawal-summary-item">
           <span>Network fee</span>
-          <strong>{{this.networkFee}} CKB</strong>
+          <strong>{{this.networkFee}} {{this.asset}}</strong>
         </div>
         <div class="fiber-link-dashboard__withdrawal-summary-item is-highlighted">
           <span>You receive</span>

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { on } from "@ember/modifier";
+import { service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import { registerDestructor } from "@ember/destroyable";
 import DButton from "discourse/components/d-button";
@@ -34,16 +35,19 @@ function getWithdrawalResultPresentation(state) {
 }
 
 export default class FiberLinkWithdrawalPanel extends Component {
+  @service toasts;
+
   @tracked amount = "61";
   @tracked destinationAddress = "";
   @tracked isSubmitting = false;
   @tracked isQuoteLoading = false;
   @tracked errorMessage = null;
-  @tracked successMessage = null;
   @tracked quoteErrorMessage = null;
+  @tracked pasteErrorMessage = null;
   @tracked quote = null;
   @tracked requestedId = null;
   @tracked requestedState = null;
+  @tracked hasSubmitted = false;
 
   _quoteTimer = null;
 
@@ -86,20 +90,28 @@ export default class FiberLinkWithdrawalPanel extends Component {
       return `Amount must be at least ${MIN_WITHDRAW_AMOUNT} CKB.`;
     }
 
+    if (Number(value) > this.availableBalanceNumber) {
+      return "Amount exceeds available balance.";
+    }
+
     return null;
   }
 
   get addressErrorMessage() {
     const value = normalizeValue(this.destinationAddress);
     if (!value) {
-      return "Enter a CKB withdrawal address.";
+      return "Enter a valid CKB withdrawal address.";
     }
 
     if (!ADDRESS_PATTERN.test(value)) {
-      return "Address must start with ckt1 or ckb1.";
+      return "Enter a valid CKB withdrawal address.";
     }
 
     return null;
+  }
+
+  get isDestinationBlank() {
+    return !normalizeValue(this.destinationAddress);
   }
 
   get destination() {
@@ -115,7 +127,15 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   get addressValidationMessage() {
+    if (this.pasteErrorMessage) {
+      return this.pasteErrorMessage;
+    }
+
     if (this.addressErrorMessage) {
+      if (this.isDestinationBlank && !this.hasSubmitted) {
+        return null;
+      }
+
       return this.addressErrorMessage;
     }
 
@@ -127,6 +147,10 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   get addressValidationClass() {
+    if (this.pasteErrorMessage) {
+      return "fiber-link-dashboard__withdrawal-validation is-error";
+    }
+
     if (this.addressErrorMessage || this.quote?.destinationValid === false) {
       return "fiber-link-dashboard__withdrawal-validation is-error";
     }
@@ -137,25 +161,45 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   get isSubmitDisabled() {
-    return (
+    return Boolean(
       this.isSubmitting ||
-      this.isQuoteLoading ||
-      !!this.amountErrorMessage ||
-      !!this.addressErrorMessage ||
-      this.quote?.destinationValid === false
+        this.isQuoteLoading ||
+        this.amountErrorMessage ||
+        this.addressErrorMessage ||
+        !this.destination,
     );
   }
 
   get submitLabel() {
-    return this.isSubmitting ? "Requesting..." : "Request Withdrawal";
+    return this.isSubmitting ? "Requesting..." : "Request withdrawal →";
   }
 
   get minimumWithdrawalAmount() {
     return MIN_WITHDRAW_AMOUNT;
   }
 
+  get availableBalanceNumber() {
+    const value = Number(this.availableBalance);
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  get maxWithdrawalAmountLabel() {
+    return this._formatAmount(this.availableBalanceNumber);
+  }
+
   get requestedResultPresentation() {
     return getWithdrawalResultPresentation(this.requestedState);
+  }
+
+  get successToastMessage() {
+    const detail = this.requestedResultPresentation.detail;
+    if (detail) {
+      return detail;
+    }
+
+    return this.requestedId
+      ? `Requested withdrawal ${this.requestedId}`
+      : "Withdrawal request submitted.";
   }
 
   _clearQuoteTimer() {
@@ -184,6 +228,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
   onAmountInput(event) {
     this.amount = event?.target?.value ?? "";
     this.errorMessage = null;
+    this.hasSubmitted = false;
     this._scheduleQuoteRefresh();
   }
 
@@ -191,7 +236,45 @@ export default class FiberLinkWithdrawalPanel extends Component {
   onAddressInput(event) {
     this.destinationAddress = event?.target?.value ?? "";
     this.errorMessage = null;
+    this.pasteErrorMessage = null;
+    this.hasSubmitted = false;
     this._scheduleQuoteRefresh();
+  }
+
+  @action
+  setQuickAmount(event) {
+    const quickAmount = event?.currentTarget?.dataset?.quickAmount;
+    const availableBalance = this.availableBalanceNumber;
+    let nextAmount = availableBalance;
+
+    if (quickAmount !== "max") {
+      nextAmount = availableBalance * Number(quickAmount || 0);
+      nextAmount = Math.max(nextAmount, this.minimumWithdrawalAmount);
+      nextAmount = Math.min(nextAmount, availableBalance);
+    }
+
+    this.amount = this._formatAmount(nextAmount);
+    this.errorMessage = null;
+    this.hasSubmitted = false;
+    this._scheduleQuoteRefresh();
+  }
+
+  @action
+  async pasteDestination() {
+    this.pasteErrorMessage = null;
+    this.errorMessage = null;
+
+    try {
+      if (!navigator.clipboard?.readText) {
+        throw new Error("Clipboard unavailable");
+      }
+
+      this.destinationAddress = await navigator.clipboard.readText();
+      this.hasSubmitted = false;
+      this._scheduleQuoteRefresh();
+    } catch (_error) {
+      this.pasteErrorMessage = "Clipboard access failed. Paste manually.";
+    }
   }
 
   @action
@@ -218,14 +301,25 @@ export default class FiberLinkWithdrawalPanel extends Component {
 
   @action
   async submit() {
-    if (this.isSubmitDisabled || !this.destination) {
-      this.errorMessage = this.amountErrorMessage || this.addressErrorMessage || this.quoteErrorMessage;
+    this.hasSubmitted = true;
+
+    if (
+      this.isSubmitDisabled ||
+      this.amountErrorMessage ||
+      this.addressErrorMessage ||
+      !this.destination ||
+      this.quote?.destinationValid === false
+    ) {
+      this.errorMessage =
+        this.amountErrorMessage ||
+        this.addressErrorMessage ||
+        this.quoteErrorMessage ||
+        "Enter a valid CKB withdrawal address.";
       return;
     }
 
     this.isSubmitting = true;
     this.errorMessage = null;
-    this.successMessage = null;
 
     try {
       const result = await requestWithdrawal({
@@ -236,9 +330,10 @@ export default class FiberLinkWithdrawalPanel extends Component {
 
       this.requestedId = result?.id ?? null;
       this.requestedState = result?.state ?? null;
-      this.successMessage = this.requestedId
-        ? `Requested withdrawal ${this.requestedId}`
-        : "Withdrawal request submitted.";
+      this.toasts.success({
+        duration: "short",
+        data: { message: this.successToastMessage },
+      });
 
       if (typeof this.args.onRequested === "function") {
         this.args.onRequested(result);
@@ -250,45 +345,34 @@ export default class FiberLinkWithdrawalPanel extends Component {
     }
   }
 
+  _formatAmount(value) {
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+      return "0";
+    }
+
+    return numericValue.toFixed(8).replace(/\.?0+$/, "");
+  }
+
   <template>
     <section class="fiber-link-dashboard__withdrawal">
-      <div class="fiber-link-dashboard__withdrawal-header">
-        <div>
-          <h3>Withdraw</h3>
-          <p>Move your settled CKB balance to a wallet you control.</p>
-        </div>
-        <div class="fiber-link-dashboard__withdrawal-badge">
-          <span>Minimum</span>
-          <strong>{{this.minimumWithdrawalAmount}} CKB</strong>
-        </div>
+      <div class="fiber-link-dashboard__section-kicker">
+        <strong>01</strong>
+        <span>WITHDRAW</span>
+      </div>
+
+      <div class="fiber-link-dashboard__withdrawal-heading">
+        <h3>Move your <span>settled</span> CKB.</h3>
+        <p>
+          Send funds from your Fiber Link balance to a wallet you control.
+          Minimum withdrawal is {{this.minimumWithdrawalAmount}} CKB.
+        </p>
       </div>
 
       {{#if this.errorMessage}}
         <p class="fiber-link-tip-alert is-error" data-fiber-link-withdrawal-result="error">
           {{this.errorMessage}}
         </p>
-      {{/if}}
-
-      {{#if this.successMessage}}
-        <div
-          class={{this.requestedResultPresentation.alertClass}}
-          data-fiber-link-withdrawal-result="success"
-        >
-          <p class="fiber-link-dashboard__withdrawal-success">{{this.successMessage}}</p>
-          {{#if this.requestedResultPresentation.detail}}
-            <p class="fiber-link-dashboard__withdrawal-note">
-              {{this.requestedResultPresentation.detail}}
-            </p>
-          {{/if}}
-          {{#if this.requestedState}}
-            <span
-              class={{this.requestedResultPresentation.badgeClass}}
-              data-fiber-link-withdrawal-result="state"
-            >
-              {{this.requestedResultPresentation.badgeLabel}}
-            </span>
-          {{/if}}
-        </div>
       {{/if}}
 
       <div class="fiber-link-dashboard__withdrawal-summary-grid">
@@ -300,10 +384,6 @@ export default class FiberLinkWithdrawalPanel extends Component {
           <span>Locked</span>
           <strong>{{this.lockedBalance}} {{this.asset}}</strong>
         </div>
-        <div class="fiber-link-dashboard__withdrawal-summary-item">
-          <span>Network fee</span>
-          <strong>{{this.networkFee}} {{this.asset}}</strong>
-        </div>
         <div class="fiber-link-dashboard__withdrawal-summary-item is-highlighted">
           <span>You receive</span>
           <strong>{{this.receiveAmount}} {{this.asset}}</strong>
@@ -312,37 +392,59 @@ export default class FiberLinkWithdrawalPanel extends Component {
 
       <div class="fiber-link-dashboard__withdrawal-form">
         <label class="fiber-link-tip-field">
-          <span class="fiber-link-tip-label">Amount</span>
-          <input
-            class="fiber-link-tip-input fiber-link-dashboard__withdrawal-input"
-            data-fiber-link-withdrawal-input="amount"
-            inputmode="decimal"
-            min={{this.minimumWithdrawalAmount}}
-            type="text"
-            value={{this.amount}}
-            {{on "input" this.onAmountInput}}
-          />
+          <span class="fiber-link-dashboard__field-row">
+            <span class="fiber-link-tip-label">Amount</span>
+            <span>Network fee {{this.networkFee}} {{this.asset}}</span>
+          </span>
+          <span class="fiber-link-dashboard__amount-input-wrap">
+            <input
+              class="fiber-link-tip-input fiber-link-dashboard__withdrawal-input is-amount"
+              data-fiber-link-withdrawal-input="amount"
+              inputmode="decimal"
+              min={{this.minimumWithdrawalAmount}}
+              type="text"
+              value={{this.amount}}
+              {{on "input" this.onAmountInput}}
+            />
+            <span>{{this.asset}}</span>
+          </span>
+          <span class="fiber-link-dashboard__quick-amounts" aria-label="Withdrawal amount shortcuts">
+            <button type="button" data-quick-amount="0.25" {{on "click" this.setQuickAmount}}>25%</button>
+            <button type="button" data-quick-amount="0.5" {{on "click" this.setQuickAmount}}>50%</button>
+            <button type="button" data-quick-amount="0.75" {{on "click" this.setQuickAmount}}>75%</button>
+            <button type="button" data-quick-amount="max" {{on "click" this.setQuickAmount}}>Max · {{this.maxWithdrawalAmountLabel}}</button>
+          </span>
           {{#if this.amountErrorMessage}}
             <p class="fiber-link-tip-input-error">{{this.amountErrorMessage}}</p>
           {{/if}}
         </label>
 
-        <label class="fiber-link-tip-field">
-          <span class="fiber-link-tip-label">Destination Address</span>
+        <div class="fiber-link-tip-field">
+          <span class="fiber-link-dashboard__field-row">
+            <span class="fiber-link-tip-label">Destination Address</span>
+            <button
+              class="fiber-link-dashboard__paste-button"
+              type="button"
+              {{on "click" this.pasteDestination}}
+            >
+              Paste
+            </button>
+          </span>
           <input
             class="fiber-link-tip-input fiber-link-dashboard__withdrawal-input is-address"
+            aria-label="Destination Address"
             data-fiber-link-withdrawal-input="address"
-            placeholder="paste address"
+            placeholder="ckb1q..."
             spellcheck="false"
             type="text"
             value={{this.destinationAddress}}
             {{on "input" this.onAddressInput}}
           />
-        </label>
 
-        {{#if this.addressValidationMessage}}
-          <p class={{this.addressValidationClass}}>{{this.addressValidationMessage}}</p>
-        {{/if}}
+          {{#if this.addressValidationMessage}}
+            <p class={{this.addressValidationClass}}>{{this.addressValidationMessage}}</p>
+          {{/if}}
+        </div>
 
         {{#if this.quoteErrorMessage}}
           <p class="fiber-link-tip-input-error">{{this.quoteErrorMessage}}</p>
@@ -356,7 +458,6 @@ export default class FiberLinkWithdrawalPanel extends Component {
           @action={{this.submit}}
           @disabled={{this.isSubmitDisabled}}
           @translatedLabel={{this.submitLabel}}
-          @icon="arrow-up-right-from-square"
         />
         {{#if this.requestedId}}
           <p class="fiber-link-dashboard__withdrawal-meta">

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
@@ -713,7 +713,13 @@ export default class FiberLinkTipModal extends Component {
 
                 <div class="fiber-link-tip-invoice-line">
                   <span>Invoice</span>
-                  <strong>{{this.invoicePreview}}</strong>
+                  <strong
+                    data-fiber-link-tip-modal="invoice-value"
+                    data-fiber-link-invoice={{this.invoice}}
+                    title={{this.invoice}}
+                  >
+                    {{this.invoicePreview}}
+                  </strong>
                   <DButton
                     class="fiber-link-tip-copy-button"
                     data-fiber-link-tip-modal="copy-invoice"

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
@@ -6,14 +6,18 @@ import { on } from "@ember/modifier";
 import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
 import DModalCancel from "discourse/components/d-modal-cancel";
+import { avatarUrl } from "discourse/lib/avatar-utils";
+import { clipboardCopy } from "discourse/lib/utilities";
 
 import { createTip, getTipStatus } from "../../services/fiber-link-api";
 
 const AMOUNT_PATTERN = /^(?:\d+)(?:\.\d{1,8})?$/;
+const COPY_FEEDBACK_TIMEOUT_MS = 3000;
 const TIP_STATUS_AUTO_POLL_INTERVAL_MS = 1000;
-const FIBER_LINK_HOMEPAGE_URL = "https://fiberlink.me/";
+const FIBER_LINK_HOMEPAGE_URL = "https://www.fiberlink.me";
 const FIBER_LINK_LOGO_URL = "https://fiberlink.me/brand/fiber-link-logo.png";
-const QUICK_AMOUNTS = ["5", "10", "31", "50"];
+const MAX_MESSAGE_LENGTH = 120;
+const QUICK_AMOUNTS = ["1", "5", "10"];
 
 function normalizeMessage(value) {
   if (typeof value !== "string") {
@@ -89,11 +93,6 @@ function mapStatusErrorToMessage(error) {
   return message || "Failed to check status.";
 }
 
-function buildWalletHref(invoice) {
-  const value = normalizeMessage(invoice);
-  return value ? `fiber://invoice/${value}` : null;
-}
-
 export default class FiberLinkTipModal extends Component {
   @tracked amount = "1";
   @tracked message = "";
@@ -106,15 +105,17 @@ export default class FiberLinkTipModal extends Component {
   @tracked isGenerating = false;
   @tracked isChecking = false;
   @tracked errorMessage;
-  @tracked copyFeedback;
-  @tracked autoPollMessage;
-  @tracked showAdvanced = false;
+  @tracked copyState = "idle";
 
   _pollTimer = null;
+  _copyFeedbackTimer = null;
 
   constructor(owner, args) {
     super(owner, args);
-    registerDestructor(this, () => this._clearStatusPollTimer());
+    registerDestructor(this, () => {
+      this._clearStatusPollTimer();
+      this._clearCopyFeedbackTimer();
+    });
   }
 
   get postId() {
@@ -140,14 +141,45 @@ export default class FiberLinkTipModal extends Component {
     return value || "post author";
   }
 
+  get targetAvatarUrl() {
+    const template = normalizeMessage(this.args?.model?.targetAvatarTemplate);
+    return template ? avatarUrl(template, "large") : null;
+  }
+
+  get targetInitial() {
+    return this.targetUsername.slice(0, 1).toUpperCase();
+  }
+
   get topicTitle() {
     const value = normalizeMessage(this.args?.model?.topicTitle);
     return value || "Community post";
   }
 
+  get postNumber() {
+    const rawValue = this.args?.model?.postNumber;
+    const parsed = Number(rawValue);
+    return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : null;
+  }
+
   get postSummary() {
     const value = normalizeMessage(this.args?.model?.postSummary);
-    return value || "Support this contributor directly from the conversation.";
+    return value || (this.postNumber ? `Reply #${this.postNumber}` : "Reply");
+  }
+
+  get isReplyContext() {
+    return this.args?.model?.isReplyContext === true;
+  }
+
+  get contextLabel() {
+    return this.isReplyContext ? "Reply:" : "Topic:";
+  }
+
+  get contextSectionLabel() {
+    return this.isReplyContext ? "Reply context" : "Topic";
+  }
+
+  get contextTitle() {
+    return this.isReplyContext ? this.postSummary : this.topicTitle;
   }
 
   get brandHomepageUrl() {
@@ -158,16 +190,72 @@ export default class FiberLinkTipModal extends Component {
     return FIBER_LINK_LOGO_URL;
   }
 
-  get trimmedMessage() {
-    return normalizeMessage(this.message);
+  get modalTitle() {
+    return "Send a tip";
   }
 
-  get hasMessage() {
-    return !!this.trimmedMessage;
+  get stepNumberLabel() {
+    if (this.isPayStep) {
+      return "Step 02";
+    }
+    if (this.isConfirmedStep) {
+      return "Step 02";
+    }
+    return "Step 01";
   }
 
-  get quickAmounts() {
-    return QUICK_AMOUNTS;
+  get stepContextLabel() {
+    if (this.isPayStep) {
+      return "of 02 · Pay with wallet";
+    }
+    if (this.isConfirmedStep) {
+      return "of 02 · Complete";
+    }
+    return "of 02 · Amount";
+  }
+
+  get invoicePreview() {
+    const value = normalizeMessage(this.invoice);
+    if (!value) {
+      return "";
+    }
+    if (value.length <= 28) {
+      return value;
+    }
+    return `${value.slice(0, 18)}…${value.slice(-6)}`;
+  }
+
+  get quickAmountItems() {
+    const amount = normalizeMessage(this.amount);
+    return QUICK_AMOUNTS.map((value) => ({
+      value,
+      className: value === amount ? "fiber-link-tip-chip is-selected" : "fiber-link-tip-chip",
+      isSelected: value === amount,
+      ariaPressed: value === amount ? "true" : "false",
+    }));
+  }
+
+  get isCustomAmountSelected() {
+    const amount = normalizeMessage(this.amount);
+    return amount !== "" && !QUICK_AMOUNTS.includes(amount);
+  }
+
+  get customAmountClassName() {
+    return this.isCustomAmountSelected
+      ? "fiber-link-tip-chip is-selected"
+      : "fiber-link-tip-chip";
+  }
+
+  get customAmountAriaPressed() {
+    return this.isCustomAmountSelected ? "true" : "false";
+  }
+
+  get maxMessageLength() {
+    return MAX_MESSAGE_LENGTH;
+  }
+
+  get messageCharacterCount() {
+    return this.message.length;
   }
 
   get isSelfTip() {
@@ -193,31 +281,6 @@ export default class FiberLinkTipModal extends Component {
     return normalizeMessage(this.amount) || "0";
   }
 
-  get payTitle() {
-    return `Pay ${this.displayAmount} CKB`;
-  }
-
-  get paySubtitle() {
-    return `to @${this.targetUsername}`;
-  }
-
-  get statusDescription() {
-    switch (this.statusState) {
-      case "SETTLED":
-        return `${this.displayAmount} CKB has been sent to @${this.targetUsername}.`;
-      case "PROCESSING":
-        return "Payment detected. We’re confirming it on the network.";
-      case "DETECTED":
-        return "Payment detected. Confirmation should follow shortly.";
-      case "FAILED":
-        return "The payment could not be completed. Please try again.";
-      case "EXPIRED":
-        return "This payment request expired. Generate a new one to continue.";
-      default:
-        return "Scan with Fiber Wallet. This window updates automatically after payment.";
-    }
-  }
-
   get isGenerateInvoiceDisabled() {
     return (
       this.isGenerating ||
@@ -230,24 +293,30 @@ export default class FiberLinkTipModal extends Component {
     );
   }
 
-  get isCheckStatusDisabled() {
-    return !this.invoice || this.isChecking || this.isGenerating;
-  }
-
-  get checkStatusLabel() {
-    return this.isChecking ? "Checking..." : "Check status";
-  }
-
   get generateButtonLabel() {
-    return this.isGenerating ? "Preparing payment..." : "Continue to Payment";
+    return this.isGenerating ? "Preparing payment..." : "Review & Pay";
   }
 
   get shouldShowInvoiceQr() {
     return typeof this.invoiceQrDataUrl === "string" && this.invoiceQrDataUrl.trim().startsWith("data:image/");
   }
 
-  get walletHref() {
-    return buildWalletHref(this.invoice);
+  get shouldShowInvoiceTimer() {
+    return false;
+  }
+
+  get copyButtonIcon() {
+    return this.copyState === "copied" ? "check" : "copy";
+  }
+
+  get copyButtonLabel() {
+    if (this.copyState === "copied") {
+      return "Copied";
+    }
+    if (this.copyState === "failed") {
+      return "Copy failed";
+    }
+    return "Copy invoice";
   }
 
   get isGenerateStep() {
@@ -262,15 +331,32 @@ export default class FiberLinkTipModal extends Component {
     return this.currentStep === "confirmed";
   }
 
-  get moreOptionsLabel() {
-    return this.showAdvanced ? "Hide payment details" : "More options";
-  }
-
   _clearStatusPollTimer() {
     if (this._pollTimer) {
       clearTimeout(this._pollTimer);
       this._pollTimer = null;
     }
+  }
+
+  _clearCopyFeedbackTimer() {
+    if (this._copyFeedbackTimer) {
+      clearTimeout(this._copyFeedbackTimer);
+      this._copyFeedbackTimer = null;
+    }
+  }
+
+  _resetCopyState() {
+    this._clearCopyFeedbackTimer();
+    this.copyState = "idle";
+  }
+
+  _setTemporaryCopyState(state) {
+    this._clearCopyFeedbackTimer();
+    this.copyState = state;
+    this._copyFeedbackTimer = setTimeout(() => {
+      this._copyFeedbackTimer = null;
+      this.copyState = "idle";
+    }, COPY_FEEDBACK_TIMEOUT_MS);
   }
 
   _scheduleStatusPoll() {
@@ -288,8 +374,7 @@ export default class FiberLinkTipModal extends Component {
   @action
   onAmountInput(event) {
     this.amount = event?.target?.value ?? "";
-    this.copyFeedback = null;
-    this.autoPollMessage = null;
+    this._resetCopyState();
   }
 
   @action
@@ -304,13 +389,7 @@ export default class FiberLinkTipModal extends Component {
       return;
     }
     this.amount = value;
-    this.copyFeedback = null;
-    this.autoPollMessage = null;
-  }
-
-  @action
-  toggleAdvanced() {
-    this.showAdvanced = !this.showAdvanced;
+    this._resetCopyState();
   }
 
   @action
@@ -322,8 +401,7 @@ export default class FiberLinkTipModal extends Component {
     }
 
     this.errorMessage = null;
-    this.copyFeedback = null;
-    this.autoPollMessage = null;
+    this._resetCopyState();
     this._clearStatusPollTimer();
 
     if (this.isSelfTip) {
@@ -363,8 +441,6 @@ export default class FiberLinkTipModal extends Component {
       this.statusState = "UNPAID";
       this.statusLabel = mapTipStateToLabel("UNPAID");
       this.statusClass = mapTipStateToClass("UNPAID");
-      this.autoPollMessage = "Status updates automatically";
-      this.showAdvanced = false;
       scheduleAutoPoll = true;
     } catch (e) {
       this.errorMessage = mapCreateTipErrorToMessage(e);
@@ -389,7 +465,6 @@ export default class FiberLinkTipModal extends Component {
       this.errorMessage = null;
       this._clearStatusPollTimer();
     }
-    this.copyFeedback = null;
     this.isChecking = true;
 
     try {
@@ -401,21 +476,16 @@ export default class FiberLinkTipModal extends Component {
 
       if (state === "SETTLED") {
         this.currentStep = "confirmed";
-        this.showAdvanced = false;
-        this.autoPollMessage = null;
         this._clearStatusPollTimer();
       } else if (state === "UNPAID" || state === "DETECTED" || state === "PROCESSING") {
         this.currentStep = "pay";
-        this.autoPollMessage = "Status updates automatically";
         scheduleAutoPoll = true;
       } else {
         this.currentStep = "pay";
-        this.autoPollMessage = null;
         this._clearStatusPollTimer();
       }
     } catch (e) {
       if (isAutoPoll && isTransientNetworkError(normalizeMessage(e?.message))) {
-        this.autoPollMessage = "Status updates automatically";
         scheduleAutoPoll = true;
       } else {
         this.errorMessage = mapStatusErrorToMessage(e);
@@ -434,40 +504,71 @@ export default class FiberLinkTipModal extends Component {
       return;
     }
 
-    this.copyFeedback = null;
+    this._resetCopyState();
 
     try {
-      if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
-        throw new Error("Clipboard API unavailable");
-      }
-      await navigator.clipboard.writeText(this.invoice);
-      this.copyFeedback = "Copied invoice";
+      await clipboardCopy(this.invoice);
+      this._setTemporaryCopyState("copied");
     } catch (_error) {
-      this.copyFeedback = "Copy failed";
+      this._setTemporaryCopyState("failed");
     }
   }
 
   <template>
-    <DModal @closeModal={{@closeModal}} @title="Pay with Fiber" class="fiber-link-tip-modal">
+    <DModal @closeModal={{@closeModal}} @title={{this.modalTitle}} class="fiber-link-tip-modal">
       <:body>
-        <div class="fiber-link-tip-modal__content fiber-link-tip-modal__content--checkout">
-          <header class="fiber-link-tip-modal__hero">
-            <p class="fiber-link-tip-modal__eyebrow">Native CKB tip</p>
-            <h2>{{this.payTitle}}</h2>
-            <p class="fiber-link-tip-modal__hero-subtitle">{{this.paySubtitle}}</p>
-          </header>
+        <div class="fiber-link-tip-modal__content">
+          <header class="fiber-link-tip-modal__header">
+            <section class="fiber-link-tip-modal__hero">
+              <h2>
+                <span>{{this.displayAmount}}</span>
+                <em>CKB</em>
+              </h2>
+              <div class="fiber-link-tip-modal__hero-sub">
+                <span>Tipping</span>
+                <span class="fiber-link-tip-modal__hero-handle">@{{this.targetUsername}}</span>
+              </div>
+            </section>
 
-          <ol class="fiber-link-tip-stepper" aria-label="Tip payment progress">
-            <li class={{if this.isGenerateStep "is-active" (if this.invoice "is-complete" "")}}>
-              <span>Configure</span>
-            </li>
-            <li class={{if this.isPayStep "is-active" (if this.isConfirmedStep "is-complete" "")}}>
-              <span>Pay</span>
-            </li>
-            <li class={{if this.isConfirmedStep "is-active" ""}}>
-              <span>Confirm</span>
-            </li>
-          </ol>
+            <div class="fiber-link-tip-modal__recipient-strip" data-fiber-link-tip-modal="recipient">
+              <div class="fiber-link-tip-modal__recipient-identity">
+                {{#if this.targetAvatarUrl}}
+                  <img
+                    class="fiber-link-tip-modal__recipient-avatar"
+                    data-fiber-link-tip-modal="recipient-avatar"
+                    src={{this.targetAvatarUrl}}
+                    alt=""
+                  />
+                {{else}}
+                  <span
+                    class="fiber-link-tip-modal__recipient-avatar fiber-link-tip-modal__recipient-avatar--fallback"
+                    aria-hidden="true"
+                  >
+                    {{this.targetInitial}}
+                  </span>
+                {{/if}}
+                <div class="fiber-link-tip-modal__recipient-copy">
+                  <strong>@{{this.targetUsername}}</strong>
+                  <span>Recipient · verified 2d ago</span>
+                </div>
+              </div>
+              <p class="fiber-link-tip-modal__receive-note">
+                <span>Receives</span>
+                <strong>{{this.displayAmount}}<small>CKB</small></strong>
+              </p>
+            </div>
+
+            <div class="fiber-link-tip-modal__meta" data-fiber-link-tip-modal="summary">
+              <div class="fiber-link-tip-modal__meta-cell">
+                <span>{{this.contextSectionLabel}}</span>
+                <strong title={{this.contextTitle}}>{{this.contextTitle}}</strong>
+              </div>
+              <div class="fiber-link-tip-modal__meta-cell">
+                <span>Network</span>
+                <strong>Fiber Link · Mainnet</strong>
+              </div>
+            </div>
+          </header>
 
           {{#if this.errorMessage}}
             <p class="fiber-link-tip-alert is-error">{{this.errorMessage}}</p>
@@ -477,257 +578,241 @@ export default class FiberLinkTipModal extends Component {
             <p class="fiber-link-tip-alert is-warning">You can’t tip your own post.</p>
           {{/if}}
 
-          <div class="fiber-link-tip-modal__grid">
-            <aside class="fiber-link-tip-summary" data-fiber-link-tip-modal="summary">
-              <div class="fiber-link-tip-summary__header">
-                <p class="fiber-link-tip-summary__eyebrow">Payment summary</p>
-                <a
-                  href={{this.brandHomepageUrl}}
-                  class="fiber-link-tip-summary__brand"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-fiber-link-tip-modal="brand-link"
-                >
-                  <img
-                    src={{this.brandLogoUrl}}
-                    alt="Fiber Link"
-                    class="fiber-link-tip-summary__logo"
-                    data-fiber-link-tip-modal="brand-logo"
-                  />
-                  <span>Fiber Link</span>
-                </a>
+          {{#if this.isGenerateStep}}
+            <section class="fiber-link-tip-step-card" data-fiber-link-tip-modal-step="generate">
+              <div class="fiber-link-tip-step-card__header">
+                <span class="fiber-link-tip-step-card__eyebrow">
+                  <strong>{{this.stepNumberLabel}}</strong>
+                  <span>{{this.stepContextLabel}}</span>
+                  <span class="fiber-link-tip-step-card__line" aria-hidden="true"></span>
+                  <span
+                    class="fiber-link-tip-step-card__progress"
+                    data-fiber-link-tip-modal="stepper"
+                    aria-hidden="true"
+                  >
+                    <span class="is-active"></span>
+                    <span></span>
+                  </span>
+                </span>
               </div>
 
-              <dl class="fiber-link-tip-summary__list">
-                <div>
-                  <dt>Recipient</dt>
-                  <dd>@{{this.targetUsername}}</dd>
-                </div>
-                <div>
-                  <dt>Amount</dt>
-                  <dd>{{this.displayAmount}} CKB</dd>
-                </div>
-                <div>
-                  <dt>Network</dt>
-                  <dd>Fiber Link</dd>
-                </div>
-                <div>
-                  <dt>Topic</dt>
-                  <dd title={{this.topicTitle}}>{{this.topicTitle}}</dd>
-                </div>
-                {{#if this.hasMessage}}
-                  <div>
-                    <dt>Message</dt>
-                    <dd>{{this.trimmedMessage}}</dd>
+              <div class="fiber-link-tip-form">
+                <label class="fiber-link-tip-field">
+                  <span class="fiber-link-tip-field-row">
+                    <span class="fiber-link-tip-label">Amount</span>
+                    <span class="fiber-link-tip-field-hint">≈ $0.42 USD</span>
+                  </span>
+                  <div class="fiber-link-tip-input-group">
+                    <input
+                      class="fiber-link-tip-input fiber-link-tip-input--amount"
+                      aria-label="Amount"
+                      inputmode="decimal"
+                      name="fiber-link-tip-amount"
+                      value={{this.amount}}
+                      {{on "input" this.onAmountInput}}
+                    />
+                    <span class="fiber-link-tip-input-suffix">CKB</span>
                   </div>
-                {{/if}}
-              </dl>
+                </label>
 
-              <p class="fiber-link-tip-summary__meta">Powered by Fiber Link • wallet-ready payment requests</p>
-            </aside>
-
-            <div class="fiber-link-tip-modal__main">
-              {{#if this.isGenerateStep}}
-                <section class="fiber-link-tip-panel" data-fiber-link-tip-modal-step="generate">
-                  <div class="fiber-link-tip-panel__header">
-                    <h3>Send tip</h3>
-                    <p>Confirm the amount, add an optional note, then continue to payment.</p>
-                  </div>
-
-                  <div class="fiber-link-tip-form">
-                    <label class="fiber-link-tip-field">
-                      <span class="fiber-link-tip-label">Amount</span>
-                      <div class="fiber-link-tip-input-group">
-                        <input
-                          class="fiber-link-tip-input fiber-link-tip-input--amount"
-                          inputmode="decimal"
-                          value={{this.amount}}
-                          {{on "input" this.onAmountInput}}
-                        />
-                        <span class="fiber-link-tip-input-suffix">CKB</span>
-                      </div>
-                    </label>
-
-                    <div class="fiber-link-tip-quick-amounts" aria-label="Quick amounts">
-                      {{#each this.quickAmounts as |quickAmount|}}
-                        <button
-                          type="button"
-                          class="fiber-link-tip-chip"
-                          data-quick-amount={{quickAmount}}
-                          {{on "click" this.onQuickAmountClick}}
-                        >
-                          {{quickAmount}}
-                        </button>
-                      {{/each}}
-                    </div>
-
-                    {{#if this.amountErrorMessage}}
-                      <p class="fiber-link-tip-input-error">{{this.amountErrorMessage}}</p>
-                    {{/if}}
-
-                    <label class="fiber-link-tip-field">
-                      <span class="fiber-link-tip-label">Message <span class="fiber-link-tip-label__optional">optional</span></span>
-                      <textarea
-                        class="fiber-link-tip-input fiber-link-tip-textarea"
-                        aria-label="Message (optional)"
-                        rows="2"
-                        placeholder="Say thanks to the creator"
-                        value={{this.message}}
-                        {{on "input" this.onMessageInput}}
-                      ></textarea>
-                    </label>
-                  </div>
-                </section>
-              {{/if}}
-
-              {{#if this.isPayStep}}
-                <section class="fiber-link-tip-panel fiber-link-tip-panel--pay" data-fiber-link-tip-modal-step="pay">
-                  <div class="fiber-link-tip-panel__header">
-                    <h3>{{this.statusLabel}}</h3>
-                    <p>{{this.statusDescription}}</p>
-                  </div>
-
-                  <div class="fiber-link-tip-status-row fiber-link-tip-status-row--panel">
-                    <span class={{this.statusClass}}>{{this.statusLabel}}</span>
-                    <p class="fiber-link-tip-status-copy">{{this.autoPollMessage}}</p>
-                  </div>
-
-                  {{#if this.invoice}}
-                    {{#if this.shouldShowInvoiceQr}}
-                      <div class="fiber-link-tip-invoice-visual fiber-link-tip-invoice-visual--hero">
-                        <img
-                          class="fiber-link-tip-invoice-qr"
-                          data-fiber-link-tip-modal="invoice-qr"
-                          src={{this.invoiceQrDataUrl}}
-                          alt="Invoice QR code"
-                        />
-                      </div>
-                    {{else}}
-                      <div class="fiber-link-tip-invoice-visual fiber-link-tip-invoice-visual--placeholder">
-                        <p class="fiber-link-tip-step-card__placeholder">
-                          QR preview unavailable. Open Fiber Wallet or copy the invoice below.
-                        </p>
-                      </div>
-                    {{/if}}
-
-                    <p class="fiber-link-tip-pay-hint">Scan with Fiber Wallet. Already paid? Wait a few seconds for confirmation.</p>
-
-                    <div class="fiber-link-tip-panel__actions">
-                      <DButton @translatedLabel="Copy Invoice" @action={{this.copyInvoice}} />
-                      {{#if this.copyFeedback}}
-                        <span class="fiber-link-tip-copy-feedback">{{this.copyFeedback}}</span>
-                      {{/if}}
-                    </div>
-
+                <div class="fiber-link-tip-quick-amounts" aria-label="Quick amounts">
+                  {{#each this.quickAmountItems as |quickAmount|}}
                     <button
                       type="button"
-                      class="btn-link fiber-link-tip-advanced-toggle"
-                      {{on "click" this.toggleAdvanced}}
+                      class={{quickAmount.className}}
+                      data-quick-amount={{quickAmount.value}}
+                      aria-pressed={{quickAmount.ariaPressed}}
+                      {{on "click" this.onQuickAmountClick}}
                     >
-                      {{this.moreOptionsLabel}}
+                      {{quickAmount.value}} CKB
                     </button>
+                  {{/each}}
+                  <button
+                    type="button"
+                    class={{this.customAmountClassName}}
+                    aria-pressed={{this.customAmountAriaPressed}}
+                  >
+                    Custom
+                  </button>
+                </div>
 
-                    {{#if this.showAdvanced}}
-                      <div class="fiber-link-tip-advanced-panel">
-                        <p class="fiber-link-tip-invoice-label">Payment details</p>
-                        <code class="fiber-link-tip-invoice" title={{this.invoice}}>{{this.invoice}}</code>
-                        <div class="fiber-link-tip-advanced-panel__actions">
-                          {{#if this.walletHref}}
-                            <a
-                              class="btn fiber-link-tip-wallet-link"
-                              data-fiber-link-tip-modal="wallet-link-secondary"
-                              href={{this.walletHref}}
-                            >
-                              Open wallet deep link
-                            </a>
-                          {{/if}}
-                          <DButton
-                            class="fiber-link-tip-advanced-action"
-                            @action={{this.checkStatus}}
-                            @translatedLabel={{this.checkStatusLabel}}
-                            @disabled={{this.isCheckStatusDisabled}}
-                          />
-                        </div>
-                      </div>
-                    {{/if}}
-                  {{/if}}
-                </section>
-              {{/if}}
+                {{#if this.amountErrorMessage}}
+                  <p class="fiber-link-tip-input-error">{{this.amountErrorMessage}}</p>
+                {{/if}}
 
-              {{#if this.isConfirmedStep}}
-                <section class="fiber-link-tip-panel fiber-link-tip-panel--confirmed" data-fiber-link-tip-modal-step="confirmed">
-                  <div class="fiber-link-tip-success-mark" aria-hidden="true">
-                    <span>✓</span>
+                <label class="fiber-link-tip-field">
+                  <span class="fiber-link-tip-field-row">
+                    <span class="fiber-link-tip-label">Tip message</span>
+                    <span class="fiber-link-tip-field-hint">Optional · {{this.messageCharacterCount}} / {{this.maxMessageLength}}</span>
+                  </span>
+                  <span class="fiber-link-tip-textarea-wrap">
+                    <textarea
+                      class="fiber-link-tip-input fiber-link-tip-textarea"
+                      aria-label="Message (optional)"
+                      maxlength={{this.maxMessageLength}}
+                      name="fiber-link-tip-message"
+                      rows="3"
+                      placeholder="Leave a short note"
+                      value={{this.message}}
+                      {{on "input" this.onMessageInput}}
+                    ></textarea>
+                  </span>
+                </label>
+
+              </div>
+            </section>
+          {{/if}}
+
+          {{#if this.isPayStep}}
+            <section class="fiber-link-tip-step-card fiber-link-tip-step-card--pay" data-fiber-link-tip-modal-step="pay">
+              <div class="fiber-link-tip-step-card__header">
+                <span class="fiber-link-tip-step-card__eyebrow">
+                  <strong>{{this.stepNumberLabel}}</strong>
+                  <span>{{this.stepContextLabel}}</span>
+                  <span class="fiber-link-tip-step-card__line" aria-hidden="true"></span>
+                  <span
+                    class="fiber-link-tip-step-card__progress"
+                    data-fiber-link-tip-modal="stepper"
+                    aria-hidden="true"
+                  >
+                    <span class="is-active"></span>
+                    <span class="is-active"></span>
+                  </span>
+                </span>
+              </div>
+
+              {{#if this.invoice}}
+                {{#if this.shouldShowInvoiceQr}}
+                  <div class="fiber-link-tip-invoice-visual">
+                    <img
+                      class="fiber-link-tip-invoice-qr"
+                      data-fiber-link-tip-modal="invoice-qr"
+                      src={{this.invoiceQrDataUrl}}
+                      alt="Invoice QR code"
+                    />
                   </div>
-                  <div class="fiber-link-tip-panel__header fiber-link-tip-panel__header--centered">
-                    <h3>Payment complete</h3>
-                    <p>{{this.displayAmount}} CKB sent to @{{this.targetUsername}}.</p>
+                {{else}}
+                  <div class="fiber-link-tip-invoice-visual fiber-link-tip-invoice-visual--placeholder">
+                    <p class="fiber-link-tip-step-card__placeholder">
+                      QR preview unavailable. Open Fiber Wallet or copy the invoice below.
+                    </p>
                   </div>
-                  <div class="fiber-link-tip-status-row fiber-link-tip-status-row--success">
-                    <span class={{this.statusClass}}>{{this.statusLabel}}</span>
+                {{/if}}
+
+                <div class="fiber-link-tip-status-row">
+                  <span class="fiber-link-tip-status-line">
+                    <span
+                      class="fiber-link-tip-status-spinner"
+                      data-fiber-link-tip-modal="status-spinner"
+                      aria-hidden="true"
+                    ></span>
+                    <span>{{this.statusLabel}}</span>
+                    <small>· listening on Fiber Link</small>
+                  </span>
+                </div>
+
+                <div class="fiber-link-tip-invoice-line">
+                  <span>Invoice</span>
+                  <strong>{{this.invoicePreview}}</strong>
+                  <DButton
+                    class="fiber-link-tip-copy-button"
+                    data-fiber-link-tip-modal="copy-invoice"
+                    @action={{this.copyInvoice}}
+                    @icon={{this.copyButtonIcon}}
+                    @translatedAriaLabel={{this.copyButtonLabel}}
+                    @translatedTitle={{this.copyButtonLabel}}
+                  />
+                </div>
+
+                {{#if this.shouldShowInvoiceTimer}}
+                  <div class="fiber-link-tip-timer">
+                    <span>Expires in</span>
+                    <span class="fiber-link-tip-timer__track" aria-hidden="true"></span>
+                    <strong>09:24</strong>
                   </div>
-                  <div class="fiber-link-tip-confirmed-summary">
-                    <p><strong>Network:</strong> Fiber Link</p>
-                    {{#if this.hasMessage}}
-                      <p><strong>Message:</strong> {{this.trimmedMessage}}</p>
-                    {{/if}}
-                  </div>
-                </section>
+                {{/if}}
               {{/if}}
-            </div>
-          </div>
+            </section>
+          {{/if}}
+
+          {{#if this.isConfirmedStep}}
+            <section class="fiber-link-tip-step-card fiber-link-tip-step-card--confirmed" data-fiber-link-tip-modal-step="confirmed">
+              <div class="fiber-link-tip-success-mark" aria-hidden="true">
+                <span>✓</span>
+              </div>
+              <div class="fiber-link-tip-step-card__header is-centered">
+                <h3>Payment complete</h3>
+                <p class="fiber-link-tip-step-card__caption">{{this.displayAmount}} CKB sent to @{{this.targetUsername}}.</p>
+              </div>
+              <div class="fiber-link-tip-status-row">
+                <span class={{this.statusClass}}>{{this.statusLabel}}</span>
+              </div>
+            </section>
+          {{/if}}
         </div>
       </:body>
 
       <:footer>
         <div class="fiber-link-tip-footer">
-          <div class="fiber-link-tip-footer__secondary">
-            {{#if this.isConfirmedStep}}
-              <a
-                href={{this.brandHomepageUrl}}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="btn"
-              >
-                View Fiber Link
-              </a>
-            {{else}}
-              <DModalCancel @close={{@closeModal}} />
-            {{/if}}
+          <div class="fiber-link-tip-modal__powered-by">
+            <img
+              src={{this.brandLogoUrl}}
+              alt=""
+              class="fiber-link-tip-modal__brand-logo"
+              data-fiber-link-tip-modal="brand-logo"
+            />
+            <span>Powered by</span>
+            <a
+              href={{this.brandHomepageUrl}}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-fiber-link-tip-modal="brand-link"
+            >
+              <strong>Fiber Link</strong>
+            </a>
           </div>
 
-          <div class="fiber-link-tip-footer__primary">
-            {{#if this.isGenerateStep}}
-              <DButton
-                class="btn-primary"
-                @action={{this.generateInvoice}}
-                @disabled={{this.isGenerateInvoiceDisabled}}
-                @translatedLabel={{this.generateButtonLabel}}
-              />
-            {{/if}}
-
-            {{#if this.isPayStep}}
-              {{#if this.walletHref}}
+          <div class="fiber-link-tip-footer__actions">
+            <div class="fiber-link-tip-footer__secondary">
+              {{#if this.isConfirmedStep}}
                 <a
-                  class="btn btn-primary fiber-link-tip-wallet-link fiber-link-tip-wallet-link--primary"
-                  data-fiber-link-tip-modal="wallet-link"
-                  href={{this.walletHref}}
+                  href={{this.brandHomepageUrl}}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="btn"
                 >
-                  Open Fiber Wallet
+                  View Fiber Link
                 </a>
               {{else}}
+                <DModalCancel @close={{@closeModal}} />
+              {{/if}}
+            </div>
+
+            <div class="fiber-link-tip-footer__primary">
+              {{#if this.isGenerateStep}}
                 <DButton
                   class="btn-primary"
-                  @action={{this.checkStatus}}
-                  @disabled={{this.isCheckStatusDisabled}}
-                  @translatedLabel={{this.checkStatusLabel}}
+                  @action={{this.generateInvoice}}
+                  @disabled={{this.isGenerateInvoiceDisabled}}
+                  @translatedLabel={{this.generateButtonLabel}}
                 />
               {{/if}}
-            {{/if}}
 
-            {{#if this.isConfirmedStep}}
-              <DButton class="btn-primary" @action={{@closeModal}} @translatedLabel="Done" />
-            {{/if}}
+              {{#if this.isPayStep}}
+                <button
+                  type="button"
+                  class="btn-primary fiber-link-tip-wallet-link"
+                  data-fiber-link-tip-modal="wallet-button"
+                  disabled
+                >
+                  Open Fiber Wallet →
+                </button>
+              {{/if}}
+
+              {{#if this.isConfirmedStep}}
+                <DButton class="btn-primary" @action={{@closeModal}} @translatedLabel="Done" />
+              {{/if}}
+            </div>
           </div>
         </div>
       </:footer>

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
@@ -21,6 +21,16 @@ export default class FiberLinkTipPostMenuButton extends Component {
     return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : null;
   }
 
+  get postNumber() {
+    const rawPostNumber = this.post?.post_number ?? this.post?.postNumber;
+    const parsed = Number(rawPostNumber);
+    return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : null;
+  }
+
+  get isReplyContext() {
+    return Number(this.postNumber) > 1;
+  }
+
   get targetUserId() {
     const rawUserId = this.post?.user_id ?? this.post?.userId ?? this.post?.user?.id;
     const parsed = Number(rawUserId);
@@ -33,6 +43,14 @@ export default class FiberLinkTipPostMenuButton extends Component {
       return username.trim();
     }
     return "post author";
+  }
+
+  get targetAvatarTemplate() {
+    const template = this.post?.avatar_template ?? this.post?.user?.avatar_template;
+    if (typeof template === "string" && template.trim()) {
+      return template.trim();
+    }
+    return null;
   }
 
   get topicTitle() {
@@ -90,8 +108,11 @@ export default class FiberLinkTipPostMenuButton extends Component {
         fromUserId: this.currentUserId,
         targetUserId: this.targetUserId,
         targetUsername: this.targetUsername,
+        targetAvatarTemplate: this.targetAvatarTemplate,
+        postNumber: this.postNumber,
         topicTitle: this.topicTitle,
         postSummary: this.postSummary,
+        isReplyContext: this.isReplyContext,
         isSelfTip: this.isSelfTip,
       },
     });

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
@@ -1,11 +1,13 @@
 import getURL from "discourse-common/lib/get-url";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { i18n } from "discourse-i18n";
 import FiberLinkTipPostMenuButton from "../components/post-menu/fiber-link-tip-post-menu-button";
 import { configureFiberLinkApi } from "../services/fiber-link-api";
 
 export const FIBER_LINK_BOOT_EVENT = "fiber-link:bootstrapped";
 export const FIBER_LINK_RUNTIME_KEY = "__fiberLinkRuntime";
-const FIBER_LINK_RPC_PATH = "/fiber-link/rpc";
+const FIBER_LINK_DASHBOARD_PATH = "/fiber-link";
+const FIBER_LINK_RPC_PATH = `${FIBER_LINK_DASHBOARD_PATH}/rpc`;
 
 function buildRuntimeConfig() {
   return {
@@ -34,6 +36,13 @@ export default {
     runtime.tipButtonPlacement = "post-menu";
 
     withPluginApi((api) => {
+      api.addQuickAccessProfileItem({
+        className: "fiber-link-user-menu-dashboard",
+        icon: "gift",
+        href: getURL(FIBER_LINK_DASHBOARD_PATH),
+        content: i18n("fiber_link.dashboard.user_menu_link"),
+      });
+
       api.registerValueTransformer(
         "post-menu-buttons",
         ({ value: dag, context: { firstButtonKey, lastHiddenButtonKey } }) => {

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/lib/fiber-link-tip-context.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/lib/fiber-link-tip-context.js
@@ -31,7 +31,9 @@ export function buildTipTopicTitle(post) {
 }
 
 export function buildTipPostSummary(post) {
-  const text = stripMarkup(post?.excerpt ?? post?.cooked_excerpt ?? post?.blurb ?? post?.raw ?? "");
+  const text = stripMarkup(
+    post?.excerpt ?? post?.cooked_excerpt ?? post?.blurb ?? post?.raw ?? post?.cooked ?? "",
+  );
   if (!text) {
     return DEFAULT_POST_SUMMARY;
   }

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
@@ -3,8 +3,9 @@ import EmberObject from "@ember/object";
 
 import { getDashboardSummary } from "../services/fiber-link-api";
 
-const POLL_INTERVAL_MS = 10000;
+const DEFAULT_POLL_INTERVAL_MS = 10000;
 const DASHBOARD_LIMIT = 20;
+const ALLOWED_POLL_INTERVALS = [10000, 30000, 60000];
 
 function formatIsoTimestamp(rawValue) {
   if (typeof rawValue !== "string" || !rawValue.trim()) {
@@ -25,6 +26,8 @@ function mapTipStateToPresentation(state) {
       key: "completed",
       label: "Completed",
       className: "fiber-link-status-badge is-success",
+      dotClassName: "fiber-link-tip-feed-status-dot is-completed",
+      textClassName: "fiber-link-tip-feed-status-text is-completed",
     };
   }
   if (state === "FAILED") {
@@ -32,12 +35,16 @@ function mapTipStateToPresentation(state) {
       key: "failed",
       label: "Failed",
       className: "fiber-link-status-badge is-danger",
+      dotClassName: "fiber-link-tip-feed-status-dot is-failed",
+      textClassName: "fiber-link-tip-feed-status-text is-failed",
     };
   }
   return {
     key: "pending",
     label: "Pending",
     className: "fiber-link-status-badge is-info",
+    dotClassName: "fiber-link-tip-feed-status-dot is-pending",
+    textClassName: "fiber-link-tip-feed-status-text is-pending",
   };
 }
 
@@ -48,6 +55,8 @@ function mapDirectionPresentation(direction) {
       label: "Withdrawn",
       icon: "↗",
       className: "fiber-link-direction-icon is-withdrawn",
+      amountPrefix: "-",
+      amountClassName: "fiber-link-tip-feed-amount is-negative",
     };
   }
 
@@ -57,6 +66,8 @@ function mapDirectionPresentation(direction) {
       label: "Sent",
       icon: "↑",
       className: "fiber-link-direction-icon is-sent",
+      amountPrefix: "-",
+      amountClassName: "fiber-link-tip-feed-amount is-negative",
     };
   }
 
@@ -65,11 +76,33 @@ function mapDirectionPresentation(direction) {
     label: "Received",
     icon: "↓",
     className: "fiber-link-direction-icon is-received",
+    amountPrefix: "+",
+    amountClassName: "fiber-link-tip-feed-amount is-positive",
   };
 }
 
 function buildTipFeedSignature(tips) {
   return JSON.stringify(Array.isArray(tips) ? tips : []);
+}
+
+function buildAvatarInitials(username) {
+  const value = typeof username === "string" ? username.trim() : "";
+  if (!value) {
+    return "U";
+  }
+
+  return value
+    .replace(/^@/, "")
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("") || value.slice(0, 2).toUpperCase();
+}
+
+function formatCountCaption(count, singular, plural = `${singular}s`) {
+  const normalizedCount = Number(count || 0);
+  return `${normalizedCount} ${normalizedCount === 1 ? singular : plural}`;
 }
 
 function normalizeTips(tips) {
@@ -78,6 +111,13 @@ function normalizeTips(tips) {
     const status = mapTipStateToPresentation(tip?.state);
     const direction = mapDirectionPresentation(tip?.direction);
     const absoluteTime = formatIsoTimestamp(tip?.createdAt);
+    const counterpartyUsername =
+      typeof tip?.counterpartyUsername === "string" && tip.counterpartyUsername.trim()
+        ? tip.counterpartyUsername.trim()
+        : typeof tip?.counterpartyUserId === "string"
+          ? tip.counterpartyUserId
+          : "unknown";
+
     return {
       id: typeof tip?.id === "string" ? tip.id : "unknown",
       amount: typeof tip?.amount === "string" ? tip.amount : "0",
@@ -90,12 +130,12 @@ function normalizeTips(tips) {
       directionLabel: direction.label,
       directionIcon: direction.icon,
       directionClassName: direction.className,
-      counterpartyUsername:
-        typeof tip?.counterpartyUsername === "string" && tip.counterpartyUsername.trim()
-          ? tip.counterpartyUsername.trim()
-          : typeof tip?.counterpartyUserId === "string"
-            ? tip.counterpartyUserId
-            : "unknown",
+      amountPrefix: direction.amountPrefix,
+      amountClassName: direction.amountClassName,
+      statusDotClassName: status.dotClassName,
+      statusTextClassName: status.textClassName,
+      counterpartyUsername,
+      avatarInitials: buildAvatarInitials(counterpartyUsername),
       absoluteTimeLabel: absoluteTime,
       message: typeof tip?.message === "string" && tip.message.trim() ? tip.message.trim() : null,
     };
@@ -122,8 +162,12 @@ export default class FiberLinkDashboardRoute extends Route {
       pendingCount: 0,
       completedCount: 0,
       failedCount: 0,
+      pendingCaption: "0 invoices awaiting settlement",
+      completedCaption: "Successful payments · 30d",
+      failedCaption: "Requires attention",
       generatedAt: null,
       refreshedAt: null,
+      pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
       tipFeedItems: [],
     });
 
@@ -148,12 +192,9 @@ export default class FiberLinkDashboardRoute extends Route {
 
     this._clearPollTimer();
 
-    const isInitialLoad = Boolean(model.isInitialLoading);
-    model.setProperties({
-      summaryErrorMessage: null,
-      feedErrorMessage: null,
-      isRefreshing: !isInitialLoad,
-    });
+    if (model.isInitialLoading) {
+      model.set("isRefreshing", false);
+    }
 
     try {
       const result = await getDashboardSummary({
@@ -168,19 +209,32 @@ export default class FiberLinkDashboardRoute extends Route {
       const generatedAt = formatIsoTimestamp(result?.generatedAt) || new Date().toISOString();
       const normalizedTips = normalizeTips(result?.tips);
       const nextTipFeedSignature = buildTipFeedSignature(normalizedTips);
+      const pendingCount = Number(result?.stats?.pendingCount ?? 0);
+      const completedCount = Number(result?.stats?.completedCount ?? 0);
+      const failedCount = Number(result?.stats?.failedCount ?? 0);
 
       const nextProperties = {
         isInitialLoading: false,
         isRefreshing: false,
         summaryErrorMessage: null,
         feedErrorMessage: null,
-        availableBalance: typeof result?.balances?.available === "string" ? result.balances.available : typeof result?.balance === "string" ? result.balance : "0",
-        pendingBalance: typeof result?.balances?.pending === "string" ? result.balances.pending : "0",
-        lockedBalance: typeof result?.balances?.locked === "string" ? result.balances.locked : "0",
+        availableBalance:
+          typeof result?.balances?.available === "string"
+            ? result.balances.available
+            : typeof result?.balance === "string"
+              ? result.balance
+              : "0",
+        pendingBalance:
+          typeof result?.balances?.pending === "string" ? result.balances.pending : "0",
+        lockedBalance:
+          typeof result?.balances?.locked === "string" ? result.balances.locked : "0",
         balanceAsset: result?.balances?.asset === "USDI" ? "USDI" : "CKB",
-        pendingCount: Number(result?.stats?.pendingCount ?? 0),
-        completedCount: Number(result?.stats?.completedCount ?? 0),
-        failedCount: Number(result?.stats?.failedCount ?? 0),
+        pendingCount,
+        completedCount,
+        failedCount,
+        pendingCaption: `${formatCountCaption(pendingCount, "invoice")} awaiting settlement`,
+        completedCaption: "Successful payments · 30d",
+        failedCaption: "Requires attention",
         generatedAt,
         refreshedAt: new Date().toISOString(),
       };
@@ -212,9 +266,15 @@ export default class FiberLinkDashboardRoute extends Route {
 
   _schedulePoll(model) {
     this._clearPollTimer();
+    const pollIntervalMs = ALLOWED_POLL_INTERVALS.includes(
+      Number(model?.pollIntervalMs),
+    )
+      ? Number(model.pollIntervalMs)
+      : DEFAULT_POLL_INTERVAL_MS;
+
     this._pollTimer = setTimeout(() => {
       void this._refreshSummary(model);
-    }, POLL_INTERVAL_MS);
+    }, pollIntervalMs);
   }
 
   _clearPollTimer() {

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
@@ -22,24 +22,50 @@ function formatIsoTimestamp(rawValue) {
 function mapTipStateToPresentation(state) {
   if (state === "SETTLED") {
     return {
-      label: "Payment received",
+      key: "completed",
+      label: "Completed",
       className: "fiber-link-status-badge is-success",
     };
   }
   if (state === "FAILED") {
     return {
+      key: "failed",
       label: "Failed",
       className: "fiber-link-status-badge is-danger",
     };
   }
   return {
-    label: "Awaiting payment",
-    className: "fiber-link-status-badge is-warning",
+    key: "pending",
+    label: "Pending",
+    className: "fiber-link-status-badge is-info",
   };
 }
 
-function mapDirectionLabel(direction) {
-  return direction === "OUT" ? "Outgoing" : "Incoming";
+function mapDirectionPresentation(direction) {
+  if (direction === "WITHDRAWAL" || direction === "WITHDRAWN") {
+    return {
+      key: "withdrawn",
+      label: "Withdrawn",
+      icon: "↗",
+      className: "fiber-link-direction-icon is-withdrawn",
+    };
+  }
+
+  if (direction === "OUT") {
+    return {
+      key: "sent",
+      label: "Sent",
+      icon: "↑",
+      className: "fiber-link-direction-icon is-sent",
+    };
+  }
+
+  return {
+    key: "received",
+    label: "Received",
+    icon: "↓",
+    className: "fiber-link-direction-icon is-received",
+  };
 }
 
 function buildTipFeedSignature(tips) {
@@ -50,6 +76,7 @@ function normalizeTips(tips) {
   const rows = Array.isArray(tips) ? tips : [];
   return rows.map((tip) => {
     const status = mapTipStateToPresentation(tip?.state);
+    const direction = mapDirectionPresentation(tip?.direction);
     const absoluteTime = formatIsoTimestamp(tip?.createdAt);
     return {
       id: typeof tip?.id === "string" ? tip.id : "unknown",
@@ -58,7 +85,11 @@ function normalizeTips(tips) {
       createdAt: typeof tip?.createdAt === "string" ? tip.createdAt : null,
       statusLabel: status.label,
       statusClassName: status.className,
-      directionLabel: mapDirectionLabel(tip?.direction),
+      statusKey: status.key,
+      directionKey: direction.key,
+      directionLabel: direction.label,
+      directionIcon: direction.icon,
+      directionClassName: direction.className,
       counterpartyUsername:
         typeof tip?.counterpartyUsername === "string" && tip.counterpartyUsername.trim()
           ? tip.counterpartyUsername.trim()

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
@@ -1,10 +1,20 @@
 <section class="fiber-link-dashboard">
+  <div class="fiber-link-dashboard__topbar">
+    <div class="fiber-link-dashboard__brand">
+      <span class="fiber-link-dashboard__brand-icon">🔗</span>
+      <strong>Fiber Link</strong>
+    </div>
+    <div class="fiber-link-dashboard__refresh">
+      <span>Auto-refresh</span>
+      <strong>Every 10s</strong>
+    </div>
+  </div>
+
   <header class="fiber-link-dashboard__header">
     <div>
       <h2>Fiber Link Dashboard</h2>
-      <p>Monitor creator payouts, queued payments, and recent activity from Discourse.</p>
+      <p>Monitor your Fiber Link balance, withdrawals, and payment activity from Discourse.</p>
     </div>
-    <p class="fiber-link-dashboard__meta">Auto-refresh every 10s</p>
   </header>
 
   {{#if this.model.summaryErrorMessage}}
@@ -13,9 +23,12 @@
     </p>
   {{/if}}
 
-  <section class="fiber-link-dashboard__metrics">
-    <article class="fiber-link-dashboard__metric-card">
-      <p class="fiber-link-dashboard__metric-label">Balance</p>
+  <section class="fiber-link-dashboard__metrics is-compact" aria-label="Fiber Link summary">
+    <article
+      class="fiber-link-dashboard__metric-card is-balance"
+      title="Tips you’ve received and can withdraw."
+    >
+      <span class="fiber-link-dashboard__metric-icon" aria-hidden="true">💳</span>
       {{#if this.model.isInitialLoading}}
         <p class="fiber-link-dashboard__metric-value">Loading…</p>
       {{else}}
@@ -23,23 +36,25 @@
           {{this.model.availableBalance}} {{this.model.balanceAsset}}
         </p>
       {{/if}}
+      <span class="sr-only">Available Balance: tips you’ve received and can withdraw.</span>
     </article>
 
-    <article class="fiber-link-dashboard__metric-card">
-      <p class="fiber-link-dashboard__metric-label">Pending</p>
-      <p class="fiber-link-dashboard__metric-value">
-        {{this.model.pendingBalance}} {{this.model.balanceAsset}}
-      </p>
+    <article
+      class="fiber-link-dashboard__metric-card is-pending"
+      title="Pending payments awaiting settlement."
+    >
+      <span class="fiber-link-dashboard__metric-icon" aria-hidden="true">⏱</span>
+      <p class="fiber-link-dashboard__metric-value">{{this.model.pendingCount}} Payments</p>
+      <span class="sr-only">Pending Payments</span>
     </article>
 
-    <article class="fiber-link-dashboard__metric-card">
-      <p class="fiber-link-dashboard__metric-label">Completed</p>
-      <p class="fiber-link-dashboard__metric-value">{{this.model.completedCount}}</p>
-    </article>
-
-    <article class="fiber-link-dashboard__metric-card">
-      <p class="fiber-link-dashboard__metric-label">Failed</p>
-      <p class="fiber-link-dashboard__metric-value">{{this.model.failedCount}}</p>
+    <article
+      class="fiber-link-dashboard__metric-card is-completed"
+      title="Completed settled payments."
+    >
+      <span class="fiber-link-dashboard__metric-icon" aria-hidden="true">✓</span>
+      <p class="fiber-link-dashboard__metric-value">{{this.model.completedCount}} Payments</p>
+      <span class="sr-only">Completed Payments</span>
     </article>
   </section>
 
@@ -53,12 +68,12 @@
     <section class="fiber-link-dashboard__activity">
       <div class="fiber-link-dashboard__activity-header">
         <div>
-          <h3>Payments</h3>
+          <h3>Recent Activity</h3>
           <p class="fiber-link-dashboard__subtle">
             {{#if this.model.isRefreshing}}
               Refreshing in background…
             {{else}}
-              Settled and pending creator payments.
+              All recent transactions from Discourse.
             {{/if}}
           </p>
         </div>

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
@@ -1,60 +1,103 @@
 <section class="fiber-link-dashboard">
-  <div class="fiber-link-dashboard__topbar">
-    <div class="fiber-link-dashboard__brand">
-      <span class="fiber-link-dashboard__brand-icon">🔗</span>
-      <strong>Fiber Link</strong>
+  <header class="fiber-link-dashboard__hero">
+    <div class="fiber-link-dashboard__hero-copy">
+      <div class="fiber-link-dashboard__eyebrow">Fiber Link · Creator wallet</div>
+      <h1><span>Fiber Link</span> Dashboard.</h1>
+      <p>
+        Monitor creator payouts, queued payments, and recent settlement
+        activity from Discourse.
+      </p>
     </div>
-    <div class="fiber-link-dashboard__refresh">
-      <span>Auto-refresh</span>
-      <strong>Every 10s</strong>
-    </div>
-  </div>
 
-  <header class="fiber-link-dashboard__header">
-    <div>
-      <h2>Fiber Link Dashboard</h2>
-      <p>Monitor your Fiber Link balance, withdrawals, and payment activity from Discourse.</p>
+    <div class="fiber-link-dashboard__sync">
+      <span class="fiber-link-dashboard__live">
+        <span aria-hidden="true"></span>
+        Live · synced 2s ago
+      </span>
+
+      <FiberLinkAutoRefreshSelect @model={{this.model}} />
     </div>
   </header>
 
   {{#if this.model.summaryErrorMessage}}
     <p class="fiber-link-dashboard__alert is-error">
-      Failed to load dashboard data: {{this.model.summaryErrorMessage}}
+      Failed to load dashboard data:
+      {{this.model.summaryErrorMessage}}
     </p>
   {{/if}}
 
-  <section class="fiber-link-dashboard__metrics is-compact" aria-label="Fiber Link summary">
+  <section
+    class="fiber-link-dashboard__metrics"
+    aria-label="Fiber Link summary"
+  >
     <article
-      class="fiber-link-dashboard__metric-card is-balance"
+      class="fiber-link-dashboard__metric is-balance"
       title="Tips you’ve received and can withdraw."
     >
-      <span class="fiber-link-dashboard__metric-icon" aria-hidden="true">💳</span>
+      <span class="fiber-link-dashboard__metric-label">Available Balance</span>
       {{#if this.model.isInitialLoading}}
         <p class="fiber-link-dashboard__metric-value">Loading…</p>
       {{else}}
         <p class="fiber-link-dashboard__metric-value">
-          {{this.model.availableBalance}} {{this.model.balanceAsset}}
+          <strong>{{this.model.availableBalance}}</strong>
+          <span>{{this.model.balanceAsset}}</span>
         </p>
       {{/if}}
-      <span class="sr-only">Available Balance: tips you’ve received and can withdraw.</span>
+      <span class="fiber-link-dashboard__metric-caption is-black">
+        <span aria-hidden="true"></span>
+        Available to withdraw
+      </span>
     </article>
 
     <article
-      class="fiber-link-dashboard__metric-card is-pending"
+      class="fiber-link-dashboard__metric is-pending"
       title="Pending payments awaiting settlement."
     >
-      <span class="fiber-link-dashboard__metric-icon" aria-hidden="true">⏱</span>
-      <p class="fiber-link-dashboard__metric-value">{{this.model.pendingCount}} Payments</p>
-      <span class="sr-only">Pending Payments</span>
+      <span class="fiber-link-dashboard__metric-label">Pending</span>
+      <p
+        class="fiber-link-dashboard__metric-value"
+      >
+        <strong>{{this.model.pendingBalance}}</strong>
+        <span>{{this.model.balanceAsset}}</span>
+      </p>
+      <span class="fiber-link-dashboard__metric-caption">
+        <span aria-hidden="true"></span>
+        {{this.model.pendingCaption}}
+      </span>
     </article>
 
     <article
-      class="fiber-link-dashboard__metric-card is-completed"
+      class="fiber-link-dashboard__metric is-completed"
       title="Completed settled payments."
     >
-      <span class="fiber-link-dashboard__metric-icon" aria-hidden="true">✓</span>
-      <p class="fiber-link-dashboard__metric-value">{{this.model.completedCount}} Payments</p>
-      <span class="sr-only">Completed Payments</span>
+      <span class="fiber-link-dashboard__metric-label">Completed</span>
+      <p
+        class="fiber-link-dashboard__metric-value"
+      >
+        <strong>{{this.model.completedCount}}</strong>
+        <span>TX</span>
+      </p>
+      <span class="fiber-link-dashboard__metric-caption is-success">
+        <span aria-hidden="true"></span>
+        {{this.model.completedCaption}}
+      </span>
+    </article>
+
+    <article
+      class="fiber-link-dashboard__metric is-failed"
+      title="Failed payments that may need attention."
+    >
+      <span class="fiber-link-dashboard__metric-label">Failed</span>
+      <p
+        class="fiber-link-dashboard__metric-value"
+      >
+        <strong>{{this.model.failedCount}}</strong>
+        <span>TX</span>
+      </p>
+      <span class="fiber-link-dashboard__metric-caption is-black">
+        <span aria-hidden="true"></span>
+        {{this.model.failedCaption}}
+      </span>
     </article>
   </section>
 
@@ -66,22 +109,6 @@
     />
 
     <section class="fiber-link-dashboard__activity">
-      <div class="fiber-link-dashboard__activity-header">
-        <div>
-          <h3>Recent Activity</h3>
-          <p class="fiber-link-dashboard__subtle">
-            {{#if this.model.isRefreshing}}
-              Refreshing in background…
-            {{else}}
-              All recent transactions from Discourse.
-            {{/if}}
-          </p>
-        </div>
-        {{#if this.model.generatedAt}}
-          <p class="fiber-link-dashboard__meta">Generated {{this.model.generatedAt}}</p>
-        {{/if}}
-      </div>
-
       <FiberLinkTipFeed
         @tips={{this.model.tipFeedItems}}
         @isLoading={{this.model.isInitialLoading}}

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -8,7 +8,7 @@
 }
 
 .fiber-link-tip-entry__button {
-  font-weight: 600;
+  font-weight: 650;
 }
 
 .fiber-link-tip-button--icon-only {
@@ -42,948 +42,41 @@
   border-radius: 999px;
 }
 
-.fiber-link-tip-modal .d-modal__container {
-  max-width: 420px;
-}
-
-.fiber-link-tip-modal__content {
-  display: grid;
-  gap: 0.85rem;
-}
-
-.fiber-link-tip-modal__header {
-  display: grid;
-  gap: 0.15rem;
-  padding: 0.2rem 0;
-}
-
-.fiber-link-tip-modal__recipient,
-.fiber-link-tip-step-card__eyebrow,
-.fiber-link-tip-step-card__caption,
-.fiber-link-tip-invoice-label,
-.fiber-link-dashboard__metric-label,
-.fiber-link-dashboard__meta,
-.fiber-link-dashboard__subtle,
-.fiber-link-dashboard__withdrawal-summary-item span {
-  margin: 0;
-  color: var(--primary-medium);
-  font-size: 0.82rem;
-}
-
-.fiber-link-tip-modal__recipient-name {
-  font-size: 1rem;
-}
-
-.fiber-link-tip-modal__amount {
-  margin: 0.15rem 0 0;
-  font-size: 2rem;
-  line-height: 1;
-  font-weight: 700;
-  color: var(--primary-high);
-}
-
-.fiber-link-tip-alert {
-  margin: 0;
-  border-radius: 12px;
-  padding: 0.65rem 0.75rem;
-  font-size: 0.92rem;
-}
-
-.fiber-link-tip-alert.is-error,
-.fiber-link-dashboard__alert.is-error {
-  background: var(--danger-low);
-  color: var(--danger);
-}
-
-.fiber-link-tip-alert.is-warning {
-  background: var(--highlight-low);
-  color: var(--primary);
-}
-
-.fiber-link-tip-alert.is-success {
-  background: var(--success-low);
-  color: var(--success);
-}
-
-.fiber-link-tip-step-card {
-  display: grid;
-  gap: 0.65rem;
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 14px;
-  padding: 0.85rem;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--secondary) 86%, white 14%) 0%,
-    var(--secondary) 100%
-  );
-}
-
-.fiber-link-tip-step-card__header {
-  display: grid;
-  gap: 0.12rem;
-}
-
-.fiber-link-tip-step-card__header h3,
-.fiber-link-dashboard__withdrawal-header h3,
-.fiber-link-dashboard__activity-header h3,
-.fiber-link-dashboard__header h2 {
-  margin: 0;
-}
-
-.fiber-link-tip-step-card__placeholder {
-  margin: 0;
-  color: var(--primary-medium);
-  font-size: 0.9rem;
-  line-height: 1.45;
-}
-
-.fiber-link-tip-form,
-.fiber-link-tip-field,
-.fiber-link-dashboard__withdrawal-form,
-.fiber-link-dashboard__withdrawal-actions {
-  display: grid;
-  gap: 0.45rem;
-}
-
-.fiber-link-tip-label {
-  font-weight: 600;
-  color: var(--primary-high);
-}
-
-.fiber-link-tip-input {
-  width: 100%;
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 10px;
-  padding: 0.58rem 0.7rem;
-  background: white;
-}
-
-.fiber-link-tip-textarea {
-  resize: vertical;
-  min-height: 88px;
-}
-
-.fiber-link-tip-input-error,
-.fiber-link-dashboard__withdrawal-validation {
-  margin: 0;
-  font-size: 0.86rem;
-}
-
-.fiber-link-tip-input-error,
-.fiber-link-dashboard__withdrawal-validation.is-error {
-  color: var(--danger);
-}
-
-.fiber-link-dashboard__withdrawal-validation.is-success {
-  color: var(--success);
-}
-
-.fiber-link-tip-invoice-visual {
-  display: grid;
-  place-items: center;
-  padding: 0.75rem;
-  border-radius: 12px;
-  background: white;
-  border: 1px solid var(--primary-low-mid);
-}
-
-.fiber-link-tip-invoice-qr {
-  width: min(100%, 210px);
-  height: auto;
-  display: block;
-}
-
-.fiber-link-tip-step-card__actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.fiber-link-tip-wallet-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem 0.8rem;
-  border-radius: 999px;
-  border: 1px solid var(--primary-low-mid);
-  text-decoration: none;
-  color: var(--primary-high);
-  background: var(--secondary);
-}
-
-.fiber-link-tip-copy-feedback {
-  color: var(--primary-medium);
-  font-size: 0.82rem;
-}
-
-.fiber-link-tip-advanced-toggle {
-  justify-self: start;
-  padding: 0;
-}
-
-.fiber-link-tip-advanced-panel {
-  display: grid;
-  gap: 0.45rem;
-  padding-top: 0.2rem;
-}
-
-.fiber-link-tip-invoice {
-  display: block;
-  max-height: 110px;
-  overflow: auto;
-  padding: 0.55rem;
-  border-radius: 10px;
-  background: var(--secondary);
-  border: 1px solid var(--primary-low-mid);
-  font-size: 0.78rem;
-  line-height: 1.35;
-}
-
-.fiber-link-tip-status-row {
-  display: grid;
-  gap: 0.4rem;
-}
-
-.fiber-link-tip-status-badge,
-.fiber-link-status-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: fit-content;
-  border-radius: 999px;
-  font-size: 0.78rem;
-  line-height: 1;
-  font-weight: 600;
-  padding: 0.34rem 0.58rem;
-  background: var(--primary-low);
-  color: var(--primary);
-}
-
-.fiber-link-tip-status-badge.is-success,
-.fiber-link-status-badge.is-success {
-  background: var(--success-low);
-  color: var(--success);
-}
-
-.fiber-link-tip-status-badge.is-danger,
-.fiber-link-status-badge.is-danger {
-  background: var(--danger-low);
-  color: var(--danger);
-}
-
-.fiber-link-tip-status-badge.is-warning,
-.fiber-link-status-badge.is-warning {
-  background: var(--highlight-low);
-  color: #8a6b00;
-}
-
-.fiber-link-status-badge.is-liquidity-pending {
-  background: color-mix(in srgb, var(--tertiary) 14%, white 86%);
-  color: var(--tertiary);
-}
-
-.fiber-link-dashboard {
-  max-width: 1080px;
-  margin: 0 auto;
-  display: grid;
-  gap: 1rem;
-  color: var(--primary-high);
-}
-
-.fiber-link-dashboard__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: end;
-}
-
-.fiber-link-dashboard__header p,
-.fiber-link-dashboard__withdrawal-header p,
-.fiber-link-dashboard__activity-header p {
-  margin: 0.3rem 0 0;
-  color: var(--primary-medium);
-}
-
-.fiber-link-dashboard__alert {
-  margin: 0;
-  border-radius: 12px;
-  padding: 0.75rem 0.9rem;
-}
-
-.fiber-link-dashboard__metrics {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.75rem;
-}
-
-.fiber-link-dashboard__metric-card,
-.fiber-link-dashboard__activity {
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 12px;
-  background: var(--secondary);
-}
-
-.fiber-link-dashboard__metric-card {
-  padding: 0.95rem 1rem;
-}
-
-.fiber-link-dashboard__metric-value {
-  margin: 0.4rem 0 0;
-  font-size: 1.35rem;
-  font-weight: 700;
-}
-
-.fiber-link-dashboard__content-grid {
-  display: grid;
-  grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
-  gap: 1rem;
-  align-items: start;
-}
-
-.fiber-link-dashboard__withdrawal {
-  display: grid;
-  gap: 0.85rem;
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 16px;
-  padding: 1rem;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--secondary) 80%, white 20%) 0%,
-    var(--secondary) 100%
-  );
-}
-
-.fiber-link-dashboard__withdrawal-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.8rem;
-  align-items: start;
-}
-
-.fiber-link-dashboard__withdrawal-badge {
-  display: grid;
-  gap: 0.15rem;
-  min-width: 96px;
-  padding: 0.65rem 0.75rem;
-  border-radius: 14px;
-  background: white;
-  border: 1px solid var(--primary-low-mid);
-  text-align: right;
-}
-
-.fiber-link-dashboard__withdrawal-badge span {
-  color: var(--primary-medium);
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.fiber-link-dashboard__withdrawal-summary-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.6rem;
-}
-
-.fiber-link-dashboard__withdrawal-summary-item {
-  display: grid;
-  gap: 0.18rem;
-  padding: 0.7rem 0.75rem;
-  border-radius: 12px;
-  border: 1px solid var(--primary-low-mid);
-  background: white;
-}
-
-.fiber-link-dashboard__withdrawal-summary-item strong {
-  font-size: 1rem;
-}
-
-.fiber-link-dashboard__withdrawal-summary-item.is-highlighted {
-  background: color-mix(in srgb, var(--success-low) 65%, white 35%);
-}
-
-.fiber-link-dashboard__withdrawal-input.is-address,
-.fiber-link-tip-invoice {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    monospace;
-}
-
-.fiber-link-dashboard__withdrawal-submit {
-  justify-content: center;
-}
-
-.fiber-link-dashboard__withdrawal-meta,
-.fiber-link-dashboard__withdrawal-success,
-.fiber-link-dashboard__withdrawal-note {
-  margin: 0;
-}
-
-.fiber-link-dashboard__activity {
-  padding: 0.95rem 1rem;
-}
-
-.fiber-link-dashboard__activity-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-bottom: 0.75rem;
-}
-
-.fiber-link-tip-feed-loading,
-.fiber-link-tip-feed-empty,
-.fiber-link-tip-feed-error {
-  margin: 0;
-  border-radius: 10px;
-  padding: 0.78rem 0.82rem;
-}
-
-.fiber-link-tip-feed-loading,
-.fiber-link-tip-feed-empty {
-  background: white;
-  color: var(--primary-medium);
-}
-
-.fiber-link-tip-feed-error {
-  background: var(--danger-low);
-  color: var(--danger);
-}
-
-.fiber-link-tip-feed-table {
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-}
-
-.fiber-link-tip-feed-table th,
-.fiber-link-tip-feed-table td {
-  padding: 0.7rem 0.45rem;
-  border-bottom: 1px solid var(--primary-low-mid);
-  text-align: left;
-  vertical-align: top;
-}
-
-.fiber-link-tip-feed-table th {
-  color: var(--primary-medium);
-  font-size: 0.82rem;
-  font-weight: 600;
-}
-
-.fiber-link-tip-feed-primary,
-.fiber-link-tip-feed-direction-row,
-.fiber-link-tip-feed-message {
-  margin: 0;
-}
-
-.fiber-link-tip-feed-direction-row {
-  margin-top: 0.3rem;
-}
-
-.fiber-link-tip-feed-direction {
-  font-size: 0.75rem;
-  border-radius: 999px;
-  padding: 0.2rem 0.5rem;
-  background: var(--primary-low);
-  color: var(--primary-medium);
-}
-
-.fiber-link-tip-feed-message {
-  margin-top: 0.35rem;
-  color: var(--primary-medium);
-  font-size: 0.84rem;
-  line-height: 1.4;
-}
-
-@media (max-width: 900px) {
-  .fiber-link-dashboard__metrics {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .fiber-link-dashboard__content-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .fiber-link-dashboard__activity-header,
-  .fiber-link-dashboard__header {
-    display: grid;
-    gap: 0.35rem;
-  }
-}
-
-@media (max-width: 680px) {
-  .fiber-link-dashboard__metrics,
-  .fiber-link-dashboard__withdrawal-summary-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .fiber-link-dashboard__withdrawal-header {
-    display: grid;
-  }
-
-  .fiber-link-dashboard__withdrawal-badge {
-    text-align: left;
-  }
-
-  .fiber-link-tip-feed-table {
-    display: block;
-    overflow-x: auto;
-  }
-}
-
-/* Fiber Link polished dashboard + payment dialog pass, aligned with May 2026 design mockups. */
 .fiber-link-user-menu-dashboard a {
   color: var(--primary);
 }
 
-.fiber-link-tip-modal .d-modal__container {
-  max-width: 720px;
-  border-radius: 22px;
-}
-
-.fiber-link-tip-modal .d-modal__body {
-  padding: 1.35rem 1.6rem;
-}
-
-.fiber-link-tip-modal .d-modal__footer {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: flex-end;
-  padding: 1rem 1.6rem;
-  border-top: 1px solid var(--primary-low);
-}
-
-.fiber-link-tip-footer-primary {
-  min-width: 220px;
-  justify-content: center;
-}
-
-.fiber-link-tip-modal__content {
-  gap: 1.1rem;
-}
-
-.fiber-link-tip-modal__header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1rem 1.5rem;
-  align-items: end;
-  padding-bottom: 0.95rem;
-  border-bottom: 1px solid var(--primary-low-mid);
-}
-
-.fiber-link-tip-modal__recipient-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.fiber-link-tip-modal__avatar {
-  display: inline-grid;
-  place-items: center;
-  width: 2.8rem;
-  height: 2.8rem;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #f0e9ff, #dcd2ff);
-  color: var(--primary-high);
-  font-weight: 800;
-  font-size: 1.2rem;
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--tertiary) 24%, transparent);
-}
-
-.fiber-link-tip-modal__recipient-name {
-  font-size: 1.35rem;
-}
-
-.fiber-link-tip-modal__copy-recipient {
-  color: var(--primary-medium);
-  min-height: 2rem;
-}
-
-.fiber-link-tip-modal__amount-hero {
-  text-align: right;
-}
-
-.fiber-link-tip-modal__amount {
-  font-size: 2.9rem;
-  color: var(--tertiary);
-  letter-spacing: -0.04em;
-}
-
-.fiber-link-tip-modal__amount-label,
-.fiber-link-tip-help,
-.fiber-link-tip-character-count {
-  color: var(--primary-medium);
-  font-size: 0.86rem;
-}
-
-.fiber-link-tip-modal__receive-note {
-  grid-column: 2;
-  margin: 0;
-  padding: 0.55rem 0.75rem;
-  border-radius: 12px;
-  color: var(--success);
-  background: color-mix(in srgb, var(--success-low) 65%, white 35%);
-  border: 1px solid color-mix(in srgb, var(--success) 18%, transparent);
-  font-size: 0.9rem;
-}
-
-.fiber-link-tip-step-card {
-  gap: 1rem;
-  border-radius: 18px;
-  padding: 1.25rem;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--secondary) 94%, var(--tertiary) 6%) 0%,
-    var(--secondary) 100%
-  );
-  box-shadow: 0 16px 38px color-mix(in srgb, var(--primary) 6%, transparent);
-}
-
-.fiber-link-tip-step-card__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: flex-start;
-}
-
-.fiber-link-tip-step-card__eyebrow {
-  display: inline-flex;
-  width: fit-content;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--tertiary) 12%, white 88%);
-  color: var(--tertiary);
-  font-weight: 700;
-  font-size: 0.88rem;
-}
-
-.fiber-link-tip-step-card__header h3 {
-  margin-top: 0.7rem;
-  font-size: 1.55rem;
-}
-
-.fiber-link-tip-step-card__caption {
-  margin-top: 0.35rem;
-  font-size: 1rem;
-}
-
-.fiber-link-tip-step-card__icon {
-  display: grid;
-  place-items: center;
-  width: 4rem;
-  height: 4rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--tertiary) 12%, white 88%);
-  color: var(--tertiary);
-  font-size: 2rem;
-}
-
-.fiber-link-tip-amount-input-wrap {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 74px;
-  border: 1px solid var(--tertiary);
-  border-radius: 12px;
-  overflow: hidden;
-  background: white;
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--tertiary) 8%, transparent);
-}
-
-.fiber-link-tip-amount-input-wrap .fiber-link-tip-input {
-  border: 0;
-  border-radius: 0;
-  font-size: 1.15rem;
-}
-
-.fiber-link-tip-amount-input-wrap span {
-  display: grid;
-  place-items: center;
-  border-left: 1px solid var(--primary-low-mid);
-  color: var(--primary-medium);
-  font-weight: 700;
-}
-
-.fiber-link-tip-quick-amounts {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
-}
-
-.fiber-link-tip-quick-amount {
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 12px;
-  padding: 0.7rem 0.9rem;
-  background: var(--secondary);
-  color: var(--primary-high);
-  font-weight: 700;
-}
-
-.fiber-link-tip-quick-amount.is-selected {
-  border-color: var(--tertiary);
-  color: var(--tertiary);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--tertiary) 10%, transparent);
-}
-
-.fiber-link-tip-textarea-wrap {
-  position: relative;
-}
-
-.fiber-link-tip-textarea {
-  min-height: 112px;
-  padding-bottom: 2rem;
-}
-
-.fiber-link-tip-character-count {
-  position: absolute;
-  right: 0.75rem;
-  bottom: 0.6rem;
-}
-
-.fiber-link-tip-invoice-visual {
-  max-width: 360px;
-  margin-inline: auto;
-  padding: 1.1rem;
-  border-radius: 18px;
-  box-shadow: 0 12px 30px color-mix(in srgb, var(--primary) 10%, transparent);
-}
-
-.fiber-link-tip-invoice-qr {
-  width: min(100%, 280px);
-}
-
-.fiber-link-tip-status-row {
-  justify-items: center;
-}
-
-.fiber-link-tip-status-badge.is-info,
-.fiber-link-status-badge.is-info {
-  background: color-mix(in srgb, var(--tertiary) 12%, white 88%);
-  color: var(--tertiary);
-}
-
-.fiber-link-tip-step-card__actions {
-  justify-content: center;
-}
-
-.fiber-link-tip-wallet-link {
-  border-color: var(--tertiary);
-  background: var(--tertiary);
-  color: var(--secondary);
-  padding-inline: 1.25rem;
-}
-
+.fiber-link-tip-modal,
 .fiber-link-dashboard {
-  max-width: 1180px;
-  gap: 1.35rem;
-}
-
-.fiber-link-dashboard__topbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-bottom: 0.85rem;
-  border-bottom: 1px solid var(--primary-low);
-}
-
-.fiber-link-dashboard__brand,
-.fiber-link-dashboard__refresh {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-}
-
-.fiber-link-dashboard__brand {
-  font-size: 1.25rem;
-}
-
-.fiber-link-dashboard__brand-icon {
-  color: var(--tertiary);
-}
-
-.fiber-link-dashboard__refresh span,
-.fiber-link-dashboard__metric-caption {
-  color: var(--primary-medium);
-  font-size: 0.82rem;
-}
-
-.fiber-link-dashboard__refresh strong {
-  padding: 0.35rem 0.55rem;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--tertiary) 10%, white 90%);
-  color: var(--tertiary);
-  font-size: 0.82rem;
-}
-
-.fiber-link-dashboard__metric-card {
-  position: relative;
-  display: grid;
-  grid-template-columns: 3.3rem minmax(0, 1fr);
-  gap: 0.15rem 0.9rem;
-  padding: 1.25rem;
-  border-radius: 14px;
-  box-shadow: 0 10px 28px color-mix(in srgb, var(--primary) 5%, transparent);
-}
-
-.fiber-link-dashboard__metric-icon {
-  grid-row: span 3;
-  display: grid;
-  place-items: center;
-  width: 3.1rem;
-  height: 3.1rem;
-  border-radius: 50%;
-  font-weight: 800;
-  font-size: 1.45rem;
-  background: color-mix(in srgb, var(--tertiary) 12%, white 88%);
-  color: var(--tertiary);
-}
-
-.fiber-link-dashboard__metric-card.is-pending
-  .fiber-link-dashboard__metric-icon {
-  background: #fff4df;
-  color: #d98600;
-}
-
-.fiber-link-dashboard__metric-card.is-completed
-  .fiber-link-dashboard__metric-icon {
-  background: var(--success-low);
-  color: var(--success);
-}
-
-.fiber-link-dashboard__metric-card.is-failed
-  .fiber-link-dashboard__metric-icon {
-  background: var(--danger-low);
-  color: var(--danger);
-}
-
-.fiber-link-dashboard__metric-value,
-.fiber-link-dashboard__metric-caption {
-  margin: 0;
-}
-
-.fiber-link-dashboard__content-grid {
-  grid-template-columns: minmax(300px, 370px) minmax(0, 1fr);
-  gap: 1.25rem;
-}
-
-.fiber-link-dashboard__activity,
-.fiber-link-dashboard__withdrawal {
-  border-radius: 16px;
-  box-shadow: 0 12px 34px color-mix(in srgb, var(--primary) 5%, transparent);
-}
-
-.fiber-link-tip-feed-toolbar {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: center;
-  margin-bottom: 0.8rem;
-}
-
-.fiber-link-filter-group {
-  display: flex;
-  gap: 0.45rem;
-  flex-wrap: wrap;
-}
-
-.fiber-link-filter-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 8px;
-  padding: 0.48rem 0.65rem;
-  background: var(--secondary);
-  color: var(--primary);
-  font-weight: 650;
-  font-size: 0.82rem;
-}
-
-.fiber-link-filter-chip.is-active {
-  background: color-mix(in srgb, var(--tertiary) 9%, white 91%);
-  border-color: color-mix(in srgb, var(--tertiary) 18%, var(--primary-low-mid));
-  color: var(--tertiary);
-}
-
-.fiber-link-dot {
-  width: 0.45rem;
-  height: 0.45rem;
-  border-radius: 999px;
-  background: var(--primary-medium);
-}
-
-.fiber-link-dot.is-received {
-  background: var(--success);
-}
-.fiber-link-dot.is-sent {
-  background: var(--tertiary);
-}
-.fiber-link-dot.is-pending {
-  background: #d98600;
-}
-.fiber-link-dot.is-failed {
-  background: var(--danger);
-}
-
-.fiber-link-tip-feed-search input {
-  min-width: 190px;
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 10px;
-  padding: 0.55rem 0.7rem;
-}
-
-.fiber-link-direction-badge {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 8px;
-  padding: 0.32rem 0.58rem;
-  font-size: 0.78rem;
-  font-weight: 750;
-}
-
-.fiber-link-direction-badge.is-received {
-  background: var(--success-low);
-  color: var(--success);
-}
-
-.fiber-link-direction-badge.is-sent {
-  background: color-mix(in srgb, var(--tertiary) 10%, white 90%);
-  color: var(--tertiary);
-}
-
-.fiber-link-tip-feed-summary {
-  margin: 0.85rem 0 0;
-  color: var(--primary-medium);
-  font-size: 0.86rem;
-}
-
-@media (max-width: 760px) {
-  .fiber-link-tip-modal__header,
-  .fiber-link-tip-modal__receive-note {
-    display: block;
-    grid-column: auto;
-    text-align: left;
-  }
-
-  .fiber-link-tip-modal__amount-hero {
-    text-align: left;
-    margin-top: 1rem;
-  }
-
-  .fiber-link-tip-feed-toolbar {
-    align-items: stretch;
-    flex-direction: column;
-  }
-}
-
-/* Fiber Link shadcn-inspired control polish pass: buttons, inputs, activity toolbar. */
-.fiber-link-tip-modal button,
-.fiber-link-tip-modal .btn,
-.fiber-link-dashboard button,
-.fiber-link-dashboard .btn,
-.fiber-link-tip-feed-toolbar button,
-.fiber-link-tip-feed-toolbar input,
-.fiber-link-tip-input,
-.fiber-link-dashboard__withdrawal-input {
-  font: inherit;
+  --fl-primary: hsl(211, 100%, 45%);
+  --fl-primary-hover: hsl(211, 100%, 35%);
+  --fl-primary-active: hsl(211, 100%, 25%);
+  --fl-primary-weak: hsl(211, 100%, 96%);
+  --fl-blue: var(--fl-primary);
+  --fl-blue-weak: var(--fl-primary-weak);
+  --fl-green: #0f8f44;
+  --fl-green-weak: #edf9f1;
+  --fl-amber: #ad7200;
+  --fl-amber-weak: #fff3d8;
+  --fl-red: #d92d20;
+  --fl-red-weak: #fff0ef;
+  --fl-outline-ghost: rgba(173, 179, 180, 0.18);
+  --fl-border: var(--fl-outline-ghost);
+  --fl-border-soft: var(--fl-outline-ghost);
+  --fl-surface: #f9f9f9;
+  --fl-surface-low: #f2f4f4;
+  --fl-surface-lowest: #ffffff;
+  --fl-surface-high: #e4e9ea;
+  --fl-surface-raised: var(--fl-surface);
+  --fl-text: #2d3435;
+  --fl-text-muted: #5a6061;
+  --fl-on-primary: #faf7f6;
+  --fl-focus: hsla(211, 100%, 45%, 0.18);
+  --fl-shadow:
+    0 6px 24px rgba(45, 52, 53, 0.07), 0 20px 56px rgba(45, 52, 53, 0.09);
+  --fl-shadow-soft:
+    0 4px 20px rgba(45, 52, 53, 0.04), 0 10px 40px rgba(45, 52, 53, 0.06);
+  color: var(--fl-text);
 }
 
 .fiber-link-tip-modal button,
@@ -991,19 +84,30 @@
 .fiber-link-tip-modal a.btn,
 .fiber-link-dashboard button,
 .fiber-link-dashboard .btn,
-.fiber-link-tip-feed-toolbar button {
+.fiber-link-tip-input,
+.fiber-link-dashboard__withdrawal-input,
+.fiber-link-tip-feed-search input {
+  font: inherit;
+}
+
+.fiber-link-tip-modal button,
+.fiber-link-tip-modal .btn,
+.fiber-link-tip-modal a.btn,
+.fiber-link-dashboard button,
+.fiber-link-dashboard .btn {
   appearance: none;
   -webkit-appearance: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.45rem;
-  min-height: 2.25rem;
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 10px;
-  background: var(--secondary);
-  color: var(--primary-high);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--primary) 8%, transparent);
+  min-height: 2.55rem;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.55rem 0.85rem;
+  background: var(--fl-surface-low);
+  color: var(--fl-text);
+  box-shadow: none;
   cursor: pointer;
   text-decoration: none;
   transition:
@@ -1018,12 +122,11 @@
 .fiber-link-tip-modal .btn:hover,
 .fiber-link-tip-modal a.btn:hover,
 .fiber-link-dashboard button:hover,
-.fiber-link-dashboard .btn:hover,
-.fiber-link-tip-feed-toolbar button:hover {
-  border-color: color-mix(in srgb, var(--tertiary) 24%, var(--primary-low-mid));
-  background: color-mix(in srgb, var(--primary-low) 56%, var(--secondary) 44%);
-  color: var(--primary-high);
-  box-shadow: 0 4px 12px color-mix(in srgb, var(--primary) 9%, transparent);
+.fiber-link-dashboard .btn:hover {
+  border-color: color-mix(in srgb, var(--fl-blue) 30%, var(--fl-border));
+  background: var(--fl-surface-high);
+  color: var(--fl-text);
+  box-shadow: none;
   transform: translateY(-1px);
 }
 
@@ -1032,13 +135,12 @@
 .fiber-link-tip-modal a.btn:focus-visible,
 .fiber-link-dashboard button:focus-visible,
 .fiber-link-dashboard .btn:focus-visible,
-.fiber-link-tip-feed-toolbar button:focus-visible,
-.fiber-link-tip-feed-toolbar input:focus-visible,
 .fiber-link-tip-input:focus-visible,
-.fiber-link-dashboard__withdrawal-input:focus-visible {
+.fiber-link-dashboard__withdrawal-input:focus-visible,
+.fiber-link-tip-feed-search input:focus-visible {
   outline: 0;
-  border-color: var(--tertiary);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--tertiary) 18%, transparent);
+  border-color: var(--fl-blue);
+  box-shadow: 0 0 0 3px var(--fl-focus);
 }
 
 .fiber-link-tip-modal button:disabled,
@@ -1054,18 +156,16 @@
 .fiber-link-tip-modal .btn-primary,
 .fiber-link-dashboard .btn-primary,
 .fiber-link-tip-wallet-link {
-  border-color: color-mix(in srgb, var(--tertiary) 82%, black 18%);
-  background: var(--tertiary);
-  color: var(--secondary);
-  box-shadow: 0 8px 18px color-mix(in srgb, var(--tertiary) 20%, transparent);
+  background: var(--fl-primary);
+  color: var(--fl-on-primary);
+  box-shadow: 0 10px 24px hsla(211, 100%, 25%, 0.14);
 }
 
 .fiber-link-tip-modal .btn-primary:hover,
 .fiber-link-dashboard .btn-primary:hover,
 .fiber-link-tip-wallet-link:hover {
-  border-color: color-mix(in srgb, var(--tertiary) 74%, black 26%);
-  background: color-mix(in srgb, var(--tertiary) 90%, black 10%);
-  color: var(--secondary);
+  background: var(--fl-primary-hover);
+  color: var(--fl-on-primary);
 }
 
 .fiber-link-tip-modal .btn-link,
@@ -1073,48 +173,13 @@
   border-color: transparent;
   background: transparent;
   box-shadow: none;
-  color: var(--tertiary);
+  color: var(--fl-primary);
 }
 
 .fiber-link-tip-modal .btn-link:hover,
 .fiber-link-dashboard .btn-link:hover {
-  background: color-mix(in srgb, var(--tertiary) 8%, transparent);
+  background: var(--fl-primary-weak);
   box-shadow: none;
-}
-
-.fiber-link-filter-chip {
-  min-height: 2.15rem;
-  border-radius: 999px;
-  padding: 0.36rem 0.56rem;
-  background: color-mix(in srgb, var(--secondary) 94%, var(--primary-low) 6%);
-  font-weight: 600;
-  font-size: 0.78rem;
-}
-
-.fiber-link-filter-chip.is-active {
-  background: var(--primary-high);
-  border-color: var(--primary-high);
-  color: var(--secondary);
-  box-shadow: 0 8px 18px color-mix(in srgb, var(--primary) 12%, transparent);
-}
-
-.fiber-link-filter-chip.is-active .fiber-link-dot {
-  background: currentColor;
-}
-
-.fiber-link-tip-quick-amount {
-  min-height: 2.65rem;
-  border-radius: 12px;
-  background: var(--secondary);
-}
-
-.fiber-link-tip-quick-amount.is-selected {
-  background: color-mix(in srgb, var(--tertiary) 10%, var(--secondary) 90%);
-  border-color: var(--tertiary);
-  color: var(--tertiary);
-  box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, var(--tertiary) 36%, transparent),
-    0 6px 16px color-mix(in srgb, var(--tertiary) 10%, transparent);
 }
 
 .fiber-link-tip-input,
@@ -1122,249 +187,2914 @@
 .fiber-link-tip-feed-search input {
   appearance: none;
   -webkit-appearance: none;
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 10px;
-  background: var(--secondary);
-  color: var(--primary-high);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--primary) 5%, transparent);
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: var(--fl-surface);
+  color: var(--fl-text);
+  box-shadow: none;
   transition:
     border-color 140ms ease,
     box-shadow 140ms ease,
     background-color 140ms ease;
 }
 
-.fiber-link-dashboard__activity {
-  padding: 1rem;
+.fiber-link-tip-input {
+  padding: 0.68rem 0.78rem;
 }
 
-.fiber-link-tip-feed-toolbar {
+.fiber-link-tip-modal .fiber-link-tip-input {
+  box-sizing: border-box;
+  padding: 0.5rem 0.72rem;
+}
+
+.fiber-link-tip-label {
+  font-weight: 700;
+  color: var(--fl-text);
+}
+
+.fiber-link-tip-field,
+.fiber-link-tip-form,
+.fiber-link-dashboard__withdrawal-form,
+.fiber-link-dashboard__withdrawal-actions {
   display: grid;
-  grid-template-columns: minmax(360px, 1fr) minmax(160px, 200px);
   gap: 0.55rem;
-  align-items: start;
-  padding: 0.65rem;
-  margin-bottom: 0.9rem;
-  border: 1px solid var(--primary-low);
+}
+
+.fiber-link-tip-alert,
+.fiber-link-dashboard__alert {
+  margin: 0;
+  border-radius: 8px;
+  padding: 0.72rem 0.85rem;
+  font-size: 0.92rem;
+}
+
+.fiber-link-tip-alert.is-error,
+.fiber-link-dashboard__alert.is-error {
+  background: var(--fl-red-weak);
+  color: var(--fl-red);
+}
+
+.fiber-link-tip-alert.is-warning {
+  background: var(--fl-amber-weak);
+  color: var(--fl-amber);
+}
+
+.fiber-link-tip-alert.is-success {
+  background: var(--fl-green-weak);
+  color: var(--fl-green);
+}
+
+.fiber-link-tip-modal .d-modal__container {
+  max-width: 560px;
   border-radius: 14px;
-  background: color-mix(in srgb, var(--primary-low) 28%, var(--secondary) 72%);
+  background: var(--fl-surface-lowest);
+  box-shadow: var(--fl-shadow);
 }
 
-.fiber-link-filter-group {
+.fiber-link-tip-modal .d-modal__header {
+  display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.72rem;
+  padding: 0.95rem 1.1rem 0.55rem;
+  border-bottom: 0;
+  box-shadow: none;
 }
 
-.fiber-link-tip-feed-search-shell {
+.fiber-link-tip-modal .d-modal__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--fl-text);
+}
+
+.fiber-link-tip-modal .d-modal__title-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.46rem;
+  margin: 0;
+  color: var(--fl-text);
+  font-size: 1.24rem;
+  line-height: 1.16;
+  font-weight: 760;
+  letter-spacing: 0;
+}
+
+.fiber-link-tip-modal .d-modal__title-text::before {
+  --fl-tip-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='8' width='18' height='4' rx='1'/%3E%3Cpath d='M12 8v13'/%3E%3Cpath d='M19 12v7a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-7'/%3E%3Cpath d='M7.5 8a2.5 2.5 0 0 1 0-5A4.8 4.8 0 0 1 12 8a4.8 4.8 0 0 1 4.5-5 2.5 2.5 0 0 1 0 5'/%3E%3C/svg%3E");
+
+  content: "";
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+  background: var(--fl-primary);
+  mask: var(--fl-tip-icon) center / contain no-repeat;
+  -webkit-mask: var(--fl-tip-icon) center / contain no-repeat;
+}
+
+.fiber-link-tip-modal .modal-close {
+  display: grid;
+  place-items: center;
+  flex: 0 0 2.2rem;
+  width: 2.2rem;
+  min-width: 2.2rem;
+  height: 2.2rem;
+  min-height: 2.2rem;
+  padding: 0;
+  border-radius: 8px;
+  color: var(--fl-text);
+  line-height: 1;
+}
+
+.fiber-link-tip-modal .modal-close .d-icon,
+.fiber-link-tip-modal .modal-close svg {
+  display: block;
+  width: 1.05rem;
+  height: 1.05rem;
+  margin: 0;
+}
+
+.fiber-link-tip-modal .modal-close > span {
+  display: none;
+}
+
+.fiber-link-tip-modal .d-modal__body {
+  padding: 0.85rem 1.1rem;
+}
+
+.fiber-link-tip-modal .d-modal__footer {
+  padding: 0.6rem 1.1rem 0.95rem;
+  border-top: 0;
+  box-shadow: none;
+}
+
+.fiber-link-tip-modal__content {
+  display: grid;
+  gap: 0.68rem;
+}
+
+.fiber-link-tip-modal__header {
+  display: grid;
+  gap: 0.95rem;
+}
+
+.fiber-link-tip-modal__amount-label,
+.fiber-link-tip-step-card__caption,
+.fiber-link-tip-help,
+.fiber-link-tip-character-count,
+.fiber-link-dashboard__metric-label,
+.fiber-link-dashboard__metric-caption,
+.fiber-link-dashboard__meta,
+.fiber-link-dashboard__subtle,
+.fiber-link-dashboard__withdrawal-summary-item span,
+.fiber-link-dashboard__withdrawal-footnote,
+.fiber-link-tip-feed-summary,
+.fiber-link-tip-feed-message {
+  margin: 0;
+  color: var(--fl-text-muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.fiber-link-tip-modal__powered-by {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  width: fit-content;
+  color: var(--fl-text-muted);
+  font-size: 0.78rem;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.fiber-link-tip-modal__powered-by a {
+  color: var(--fl-text);
+  text-decoration: none;
+}
+
+.fiber-link-tip-modal__powered-by a:hover {
+  color: var(--fl-primary);
+}
+
+.fiber-link-tip-modal__powered-by strong {
+  font-weight: 700;
+}
+
+.fiber-link-tip-modal__brand-logo {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+}
+
+.fiber-link-tip-modal__recipient-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.72rem;
+  min-width: 0;
+  padding: 0.62rem 0.68rem;
+  border-radius: 10px;
+  background: var(--fl-surface);
+  box-shadow: none;
+}
+
+.fiber-link-tip-modal__recipient-identity {
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+  min-width: 0;
+}
+
+.fiber-link-tip-modal__recipient-avatar {
+  display: block;
+  flex: 0 0 2.35rem;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--fl-surface-high);
+}
+
+.fiber-link-tip-modal__recipient-avatar--fallback {
+  display: grid;
+  place-items: center;
+  color: var(--fl-text);
+  font-size: 0.94rem;
+  font-weight: 760;
+}
+
+.fiber-link-tip-modal__recipient-copy {
+  display: grid;
+  gap: 0.08rem;
+  min-width: 0;
+}
+
+.fiber-link-tip-modal__recipient-copy strong {
+  overflow: hidden;
+  color: var(--fl-text);
+  font-size: 0.94rem;
+  line-height: 1.15;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fiber-link-tip-modal__recipient-copy span {
+  color: var(--fl-text-muted);
+  font-size: 0.74rem;
+  line-height: 1.2;
+}
+
+.fiber-link-tip-modal__payment-overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 0.8rem;
+  padding-top: 0;
+}
+
+.fiber-link-tip-modal__amount-block {
+  min-width: 0;
+}
+
+.fiber-link-tip-modal__amount {
+  margin: 0;
+  color: var(--fl-primary);
+  font-size: 2rem;
+  line-height: 1;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.fiber-link-tip-modal__amount-label {
+  margin-top: 0.12rem;
+  font-size: 0.7rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.fiber-link-tip-modal__receive-note {
+  margin: 0;
+  flex: 0 0 auto;
+  max-width: 17rem;
+  border-radius: 8px;
+  padding: 0.42rem 0.58rem;
+  background: var(--fl-green-weak);
+  color: var(--fl-green);
+  font-size: 0.8rem;
+  font-weight: 300;
+  line-height: 1.2;
+  text-align: right;
+}
+
+.fiber-link-tip-modal__summary-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.58rem;
+  min-width: 0;
+  max-width: 20rem;
+  padding: 0.48rem 0.6rem;
+  border-radius: 999px;
+  background: var(--fl-surface);
+  color: var(--fl-text-muted);
+  font-size: 0.76rem;
+  line-height: 1.2;
+  box-shadow: none;
+}
+
+.fiber-link-tip-modal__summary-strip p {
+  display: flex;
+  align-items: center;
+  gap: 0.26rem;
+  margin: 0;
+  min-width: 0;
+}
+
+.fiber-link-tip-modal__summary-strip p:first-child {
+  flex: 1 1 auto;
+}
+
+.fiber-link-tip-modal__summary-strip p:last-child {
+  flex: 0 0 auto;
+}
+
+.fiber-link-tip-modal__summary-strip strong {
+  overflow: hidden;
+  color: var(--fl-text);
+  font-weight: 720;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fiber-link-tip-modal__summary-divider {
+  flex: 0 0 1px;
+  width: 1px;
+  height: 0.86rem;
+  background: var(--fl-outline-ghost);
+}
+
+.fiber-link-tip-step-card {
+  display: grid;
+  gap: 0.7rem;
+  border: 0;
+  border-top: 1px solid var(--fl-border-soft);
+  border-radius: 0;
+  margin-top: 0.35rem;
+  padding: 0.9rem 0 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.fiber-link-tip-step-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.fiber-link-tip-step-card__header.is-centered {
+  display: grid;
+  justify-items: center;
+  text-align: center;
+}
+
+.fiber-link-tip-step-card__header h3 {
+  margin: 0 0 0.16rem;
+  color: var(--fl-text);
+  font-size: 1.18rem;
+  line-height: 1.26;
+}
+
+.fiber-link-tip-step-card--pay .fiber-link-tip-step-card__header h3 {
+  margin-top: 0.56rem;
+}
+
+.fiber-link-tip-step-card--pay .fiber-link-tip-step-card__caption {
+  color: color-mix(in srgb, var(--fl-text-muted) 68%, white 32%);
+}
+
+.fiber-link-tip-step-card__eyebrow {
+  display: inline-flex;
+  width: fit-content;
+  padding: 0.24rem 0.55rem;
+  border-radius: 999px;
+  background: var(--fl-surface-low);
+  color: var(--fl-primary);
+  font-weight: 520;
+  font-size: 0.78rem;
+}
+
+.fiber-link-tip-step-card__caption {
+  line-height: 1.68;
+}
+
+.fiber-link-tip-input-group {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 4.65rem;
+  border: 0;
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--fl-surface);
+  box-shadow: none;
+}
+
+.fiber-link-tip-input-group:focus-within {
+  background: var(--fl-surface-lowest);
+  box-shadow: 0 0 0 3px var(--fl-focus);
+}
+
+.fiber-link-tip-input-group .fiber-link-tip-input {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  font-size: 1.05rem;
+  min-height: 2.55rem;
+}
+
+.fiber-link-tip-input-group .fiber-link-tip-input:focus-visible {
+  box-shadow: none;
+}
+
+.fiber-link-tip-input-suffix {
+  display: grid;
+  place-items: center;
+  color: var(--fl-text-muted);
+  font-weight: 800;
+}
+
+.fiber-link-tip-quick-amounts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.fiber-link-tip-chip {
+  min-height: 2.25rem;
+  font-weight: 750;
+}
+
+.fiber-link-tip-chip.is-selected {
+  background: var(--fl-surface-high);
+  color: var(--fl-text);
+  box-shadow: none;
+}
+
+.fiber-link-tip-textarea-wrap {
+  position: relative;
+  display: block;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-textarea {
+  display: block;
+  margin: 0;
+  min-height: 68px;
+  resize: vertical;
+  padding-bottom: 1.55rem;
+}
+
+.fiber-link-tip-character-count {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 2px;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.fiber-link-tip-input-error,
+.fiber-link-dashboard__withdrawal-validation {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.fiber-link-tip-input-error,
+.fiber-link-dashboard__withdrawal-validation.is-error {
+  color: var(--fl-red);
+}
+
+.fiber-link-dashboard__withdrawal-validation.is-success {
+  color: var(--fl-green);
+}
+
+.fiber-link-tip-invoice-visual {
+  display: grid;
+  place-items: center;
+  width: min(100%, 330px);
+  margin-inline: auto;
+  padding: 0.85rem;
+  border-radius: 10px;
+  background: var(--fl-surface);
+  box-shadow: var(--fl-shadow-soft);
+}
+
+.fiber-link-tip-invoice-visual--placeholder {
+  min-height: 11rem;
+}
+
+.fiber-link-tip-step-card__placeholder {
+  margin: 0;
+  color: var(--fl-text-muted);
+  text-align: center;
+  line-height: 1.45;
+}
+
+.fiber-link-tip-invoice-qr {
+  display: block;
+  width: min(100%, 250px);
+  height: auto;
+}
+
+.fiber-link-tip-status-row {
+  display: grid;
+  justify-items: center;
+  gap: 0.48rem;
+}
+
+.fiber-link-tip-status-badge,
+.fiber-link-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.42rem;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0.38rem 0.7rem;
+  background: var(--primary-low);
+  color: var(--primary);
+  font-size: 0.78rem;
+  font-weight: 750;
+  line-height: 1;
+}
+
+.fiber-link-tip-status-badge.is-success,
+.fiber-link-status-badge.is-success {
+  background: var(--fl-green-weak);
+  color: var(--fl-green);
+}
+
+.fiber-link-tip-status-badge.is-danger,
+.fiber-link-status-badge.is-danger {
+  background: var(--fl-red-weak);
+  color: var(--fl-red);
+}
+
+.fiber-link-tip-status-badge.is-warning,
+.fiber-link-status-badge.is-warning,
+.fiber-link-status-badge.is-info {
+  background: var(--fl-amber-weak);
+  color: var(--fl-amber);
+}
+
+.fiber-link-tip-status-badge.is-warning {
+  background: var(--fl-surface-low);
+  color: var(--fl-text);
+}
+
+.fiber-link-tip-status-badge.is-info {
+  background: var(--fl-blue-weak);
+  color: var(--fl-blue);
+}
+
+.fiber-link-tip-status-spinner {
+  flex: 0 0 auto;
+  width: 0.72rem;
+  height: 0.72rem;
+  border: 1.5px solid color-mix(in srgb, currentColor 24%, transparent);
+  border-top-color: currentColor;
+  border-radius: 999px;
+  animation: fiber-link-tip-status-spin 800ms linear infinite;
+}
+
+@keyframes fiber-link-tip-status-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fiber-link-tip-status-spinner {
+    animation: none;
+  }
+}
+
+.fiber-link-status-badge.is-liquidity-pending {
+  background: var(--fl-amber-weak);
+  color: var(--fl-amber);
+}
+
+.fiber-link-tip-panel__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-wallet-link:disabled,
+.fiber-link-tip-modal .fiber-link-tip-wallet-link:disabled:hover {
+  background: var(--fl-surface-high);
+  color: var(--fl-text-muted);
+  box-shadow: none;
+  opacity: 1;
+  transform: none;
+}
+
+.fiber-link-tip-success-mark {
+  display: grid;
+  place-items: center;
+  width: 4rem;
+  height: 4rem;
+  margin-inline: auto;
+  border-radius: 50%;
+  background: var(--fl-green-weak);
+  color: var(--fl-green);
+  font-size: 2rem;
+  font-weight: 800;
+}
+
+.fiber-link-tip-step-card--confirmed {
+  justify-items: center;
+  text-align: center;
+}
+
+.fiber-link-tip-footer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.85rem;
+  width: 100%;
+}
+
+.fiber-link-tip-footer__actions {
   display: flex;
   justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.fiber-link-tip-footer__primary,
+.fiber-link-tip-footer__secondary {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.fiber-link-tip-modal {
+  --fl-modal-eggshell: #fdfcfc;
+  --fl-modal-powder: #f5f3f1;
+  --fl-modal-chalk: #e5e5e5;
+  --fl-modal-hairline: #ebe9e5;
+  --fl-modal-slate: #a59f97;
+  --fl-modal-gravel: #777169;
+  --fl-modal-cinder: #3a3733;
+  --fl-modal-obsidian: #000000;
+  --fl-modal-positive: #1f6f4a;
+  --fl-modal-mono:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
+  --fl-modal-sans:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}
+
+.fiber-link-tip-modal .d-modal__container {
+  width: min(520px, calc(100vw - 2rem));
+  max-width: 520px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 20px;
+  background: var(--fl-modal-eggshell);
+  color: var(--fl-modal-obsidian);
+  font-family: var(--fl-modal-sans);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 24px 60px rgba(0, 0, 0, 0.5),
+    0 0 0 0.5px rgba(0, 0, 0, 0.4);
+}
+
+.fiber-link-tip-modal .d-modal__header {
+  box-sizing: border-box;
+  min-height: 0;
+  height: 72px;
+  padding: 0 28px;
+  border-bottom: 0;
+}
+
+.fiber-link-tip-modal .d-modal__title-text {
+  gap: 12px;
+  color: var(--fl-modal-gravel);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fiber-link-tip-modal .d-modal__title-text::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  background: var(--fl-modal-obsidian);
+  border-radius: 999px;
+  mask: none;
+  -webkit-mask: none;
+}
+
+.fiber-link-tip-modal .modal-close,
+.fiber-link-tip-modal .modal-close.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  flex-basis: 28px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
+  border: 1px solid var(--fl-modal-hairline);
+  border-radius: 9999px;
+  padding: 0;
+  background: var(--fl-modal-powder);
+  color: var(--fl-modal-slate);
+  cursor: pointer;
+  line-height: 1;
+  box-shadow: none;
+  transform: none;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease;
+}
+
+.fiber-link-tip-modal .modal-close:hover,
+.fiber-link-tip-modal .modal-close:focus,
+.fiber-link-tip-modal .modal-close.btn:hover,
+.fiber-link-tip-modal .modal-close.btn:focus {
+  border-color: var(--fl-modal-gravel);
+  background: var(--fl-modal-chalk);
+  color: var(--fl-modal-obsidian);
+  box-shadow: none;
+  transform: none;
+}
+
+.fiber-link-tip-modal .modal-close .d-icon,
+.fiber-link-tip-modal .modal-close svg {
+  width: 12px;
+  height: 12px;
+  margin: 0;
+  color: currentColor;
+  fill: currentColor;
+}
+
+.fiber-link-tip-modal .d-modal__body {
+  padding: 0;
+}
+
+.fiber-link-tip-modal .d-modal__footer {
+  box-sizing: border-box;
+  min-height: 0;
+  padding: 20px 28px;
+  border-top: 1px solid var(--fl-modal-hairline);
+  background: var(--fl-modal-powder);
+}
+
+.fiber-link-tip-modal__content,
+.fiber-link-tip-modal__header {
+  display: block;
+}
+
+.fiber-link-tip-modal__hero {
+  padding: 8px 28px 28px;
+  border-bottom: 1px solid var(--fl-modal-hairline);
+}
+
+.fiber-link-tip-modal__hero h2 {
+  margin: 0 0 8px;
+  color: var(--fl-modal-obsidian);
+  font-size: 44px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.fiber-link-tip-modal__hero h2 em {
+  color: var(--fl-modal-gravel);
+  font-style: normal;
+  font-weight: 300;
+  letter-spacing: -0.02em;
+}
+
+.fiber-link-tip-modal__hero-sub {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--fl-modal-gravel);
+  font-size: 13px;
+}
+
+.fiber-link-tip-modal__hero-handle {
+  border-radius: 9999px;
+  padding: 3px 8px;
+  background: var(--fl-modal-powder);
+  color: var(--fl-modal-obsidian);
+  font-family: var(--fl-modal-mono);
+  font-size: 12px;
+}
+
+.fiber-link-tip-modal__recipient-strip {
+  min-height: 0;
+  padding: 18px 28px;
+  border-bottom: 1px solid var(--fl-modal-hairline);
+  border-radius: 0;
+  background: transparent;
+  gap: 14px;
+}
+
+.fiber-link-tip-modal__recipient-identity {
+  gap: 14px;
+}
+
+.fiber-link-tip-modal__recipient-avatar {
+  flex-basis: 40px;
+  width: 40px;
+  height: 40px;
+  background: var(--fl-modal-powder);
+}
+
+.fiber-link-tip-modal__recipient-avatar--fallback {
+  color: var(--fl-modal-cinder);
+  font-family: var(--fl-modal-mono);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.fiber-link-tip-modal__recipient-copy {
+  gap: 2px;
+}
+
+.fiber-link-tip-modal__recipient-copy strong {
+  color: var(--fl-modal-obsidian);
+  font-family: var(--fl-modal-mono);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.fiber-link-tip-modal__recipient-copy span {
+  color: var(--fl-modal-gravel);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.fiber-link-tip-modal__receive-note {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  max-width: none;
+  padding: 0;
+  background: transparent;
+  color: var(--fl-modal-gravel);
+  font-size: 12px;
+  font-weight: 400;
+  text-align: left;
+}
+
+.fiber-link-tip-modal__receive-note strong {
+  color: var(--fl-modal-positive);
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.fiber-link-tip-modal__receive-note small {
+  margin-left: 4px;
+  color: var(--fl-modal-gravel);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.fiber-link-tip-modal__meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-bottom: 1px solid var(--fl-modal-hairline);
+}
+
+.fiber-link-tip-modal__meta-cell {
+  min-width: 0;
+  padding: 10px 28px;
+}
+
+.fiber-link-tip-modal__meta-cell + .fiber-link-tip-modal__meta-cell {
+  border-left: 1px solid var(--fl-modal-hairline);
+}
+
+.fiber-link-tip-modal__meta-cell span,
+.fiber-link-tip-field-row {
+  color: var(--fl-modal-gravel);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fiber-link-tip-modal__meta-cell strong {
+  display: block;
+  overflow: hidden;
+  margin-top: 4px;
+  color: var(--fl-modal-obsidian);
+  font-family: var(--fl-modal-mono);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fiber-link-tip-step-card {
+  display: block;
+  margin: 0;
+  padding: 28px;
+  border: 0;
+}
+
+.fiber-link-tip-step-card__header {
+  display: block;
+  margin-bottom: 18px;
+}
+
+.fiber-link-tip-step-card__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 0;
+  background: transparent;
+  color: var(--fl-modal-gravel);
+  font-family: var(--fl-modal-mono);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.fiber-link-tip-step-card__eyebrow strong {
+  color: var(--fl-modal-obsidian);
+  font-weight: 400;
+}
+
+.fiber-link-tip-step-card__line {
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--fl-modal-hairline);
+}
+
+.fiber-link-tip-step-card__progress {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 4px;
+}
+
+.fiber-link-tip-step-card__progress span {
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--fl-modal-chalk);
+}
+
+.fiber-link-tip-step-card__progress .is-active {
+  background: var(--fl-modal-obsidian);
+}
+
+.fiber-link-tip-form {
+  display: block;
+}
+
+.fiber-link-tip-field {
+  display: block;
+  margin-bottom: 24px;
+}
+
+.fiber-link-tip-field-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.fiber-link-tip-label {
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.fiber-link-tip-field-hint {
+  color: var(--fl-modal-gravel);
+  font-family: var(--fl-modal-mono);
+}
+
+.fiber-link-tip-input-group {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 6px 0 12px;
+  border-bottom: 1px solid var(--fl-modal-obsidian);
+  border-radius: 0;
+  background: transparent;
+}
+
+.fiber-link-tip-input-group:focus-within {
+  background: transparent;
+  box-shadow: none;
+}
+
+.fiber-link-tip-input-group .fiber-link-tip-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: auto;
+  padding: 0;
+  background: transparent;
+  color: var(--fl-modal-obsidian);
+  font-size: 40px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.fiber-link-tip-input-suffix {
+  flex: 0 0 auto;
+  color: var(--fl-modal-gravel);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fiber-link-tip-quick-amounts {
+  display: flex;
+  gap: 6px;
+  margin: 14px 0 24px;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 0;
+  height: 32px;
+  min-height: 32px;
+  border: 1px solid var(--fl-modal-chalk);
+  border-radius: 9999px;
+  padding: 0 6px;
+  background: transparent;
+  color: var(--fl-modal-obsidian);
+  cursor: pointer;
+  font-family: var(--fl-modal-mono);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1;
+  transform: none;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-chip:hover,
+.fiber-link-tip-modal .fiber-link-tip-chip:focus {
+  border-color: var(--fl-modal-obsidian);
+  background: transparent;
+  color: var(--fl-modal-obsidian);
+  box-shadow: none;
+  transform: none;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-chip.is-selected,
+.fiber-link-tip-modal .fiber-link-tip-chip.is-selected:hover,
+.fiber-link-tip-modal .fiber-link-tip-chip.is-selected:focus {
+  border-color: var(--fl-modal-obsidian);
+  background: var(--fl-modal-obsidian);
+  color: var(--fl-modal-eggshell);
+  box-shadow: none;
+  transform: none;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-textarea-wrap {
+  display: block;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--fl-modal-chalk);
+}
+
+.fiber-link-tip-modal .fiber-link-tip-textarea {
+  min-height: 48px;
+  padding: 0;
+  background: transparent;
+  color: var(--fl-modal-obsidian);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-textarea::placeholder {
+  color: var(--fl-modal-gravel);
+  font-weight: 300;
+  opacity: 0.72;
+}
+
+.fiber-link-tip-invoice-visual {
+  position: relative;
+  box-sizing: border-box;
+  display: grid;
+  place-items: center;
+  width: 240px;
+  height: 240px;
+  margin: 8px auto 0;
+  padding: 18px;
+  border: 1px solid var(--fl-modal-hairline);
+  border-radius: 8px;
+  background: var(--fl-modal-eggshell);
+  box-shadow: none;
+}
+
+.fiber-link-tip-invoice-visual::before,
+.fiber-link-tip-invoice-visual::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid var(--fl-modal-obsidian);
+  pointer-events: none;
+}
+
+.fiber-link-tip-invoice-visual::before {
+  top: -1px;
+  left: -1px;
+  border-right: 0;
+  border-bottom: 0;
+  border-radius: 8px 0 0 0;
+}
+
+.fiber-link-tip-invoice-visual::after {
+  right: -1px;
+  bottom: -1px;
+  border-top: 0;
+  border-left: 0;
+  border-radius: 0 0 8px 0;
+}
+
+.fiber-link-tip-invoice-qr {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.fiber-link-tip-status-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 18px;
+}
+
+.fiber-link-tip-status-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--fl-modal-obsidian);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.fiber-link-tip-status-line small {
+  color: var(--fl-modal-gravel);
+  font-family: var(--fl-modal-mono);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.fiber-link-tip-status-spinner {
+  width: 14px;
+  height: 14px;
+  border-color: var(--fl-modal-chalk);
+  border-top-color: var(--fl-modal-obsidian);
+}
+
+.fiber-link-tip-invoice-line {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+  padding: 14px 0;
+  border-top: 1px dashed var(--fl-modal-chalk);
+  border-bottom: 1px dashed var(--fl-modal-chalk);
+  color: var(--fl-modal-gravel);
+  font-family: var(--fl-modal-mono);
+  font-size: 12px;
+}
+
+.fiber-link-tip-invoice-line > span {
+  flex: 0 0 auto;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fiber-link-tip-invoice-line strong {
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--fl-modal-obsidian);
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-copy-button,
+.fiber-link-tip-modal .fiber-link-tip-copy-button.btn,
+.fiber-link-tip-modal .fiber-link-tip-copy-button.btn.no-text {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 28px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
+  border: 1px solid var(--fl-modal-chalk);
+  border-radius: 9999px;
+  padding: 0;
+  background: transparent;
+  color: var(--fl-modal-obsidian);
+  line-height: 1;
+  box-shadow: none;
+  transform: none;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-copy-button:hover,
+.fiber-link-tip-modal .fiber-link-tip-copy-button:focus,
+.fiber-link-tip-modal .fiber-link-tip-copy-button.btn:hover,
+.fiber-link-tip-modal .fiber-link-tip-copy-button.btn:focus {
+  border-color: var(--fl-modal-obsidian);
+  background: var(--fl-modal-eggshell);
+  color: var(--fl-modal-obsidian);
+  box-shadow: none;
+  transform: none;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-copy-button .d-icon,
+.fiber-link-tip-modal .fiber-link-tip-copy-button svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  color: currentColor;
+  fill: currentColor;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-copy-button:hover .d-icon,
+.fiber-link-tip-modal .fiber-link-tip-copy-button:focus .d-icon,
+.fiber-link-tip-modal .fiber-link-tip-copy-button.btn:hover .d-icon,
+.fiber-link-tip-modal .fiber-link-tip-copy-button.btn:focus .d-icon,
+.fiber-link-tip-modal .fiber-link-tip-copy-button:hover svg,
+.fiber-link-tip-modal .fiber-link-tip-copy-button:focus svg,
+.fiber-link-tip-modal .fiber-link-tip-copy-button.btn:hover svg,
+.fiber-link-tip-modal .fiber-link-tip-copy-button.btn:focus svg {
+  color: var(--fl-modal-obsidian) !important;
+  fill: var(--fl-modal-obsidian) !important;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-copy-button > span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.fiber-link-tip-timer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--fl-modal-hairline);
+  color: var(--fl-modal-gravel);
+  font-size: 12px;
+}
+
+.fiber-link-tip-timer > span:first-child {
+  flex: 0 0 auto;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fiber-link-tip-timer__track {
+  position: relative;
+  flex: 1 1 auto;
+  height: 2px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--fl-modal-chalk);
+}
+
+.fiber-link-tip-timer__track::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 62%;
+  background: var(--fl-modal-obsidian);
+}
+
+.fiber-link-tip-timer strong {
+  color: var(--fl-modal-obsidian);
+  font-family: var(--fl-modal-mono);
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.fiber-link-tip-footer {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.fiber-link-tip-modal__powered-by {
+  gap: 8px;
+  color: var(--fl-modal-gravel);
+  font-size: 12px;
+}
+
+.fiber-link-tip-modal__powered-by a,
+.fiber-link-tip-modal__powered-by strong {
+  color: var(--fl-modal-obsidian);
+  font-weight: 500;
+}
+
+.fiber-link-tip-modal__brand-logo {
+  width: 14px;
+  height: 14px;
+}
+
+.fiber-link-tip-footer__actions {
+  gap: 8px;
+}
+
+.fiber-link-tip-modal .btn,
+.fiber-link-tip-modal .btn-primary,
+.fiber-link-tip-modal .fiber-link-tip-wallet-link {
+  min-height: 36px;
+  border: 1px solid var(--fl-modal-chalk);
+  border-radius: 9999px;
+  padding: 0 18px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.fiber-link-tip-modal .btn-primary,
+.fiber-link-tip-modal .fiber-link-tip-wallet-link {
+  border-color: var(--fl-modal-obsidian);
+  background: var(--fl-modal-obsidian);
+  color: var(--fl-modal-eggshell);
+  opacity: 1;
+}
+
+.fiber-link-tip-modal .fiber-link-tip-wallet-link:disabled,
+.fiber-link-tip-modal .fiber-link-tip-wallet-link:disabled:hover,
+.fiber-link-tip-modal .fiber-link-tip-wallet-link[disabled] {
+  border-color: var(--fl-modal-line);
+  background: var(--fl-modal-chalk);
+  color: var(--fl-modal-stone);
+  box-shadow: none;
+  cursor: not-allowed;
+  opacity: 0.46;
+  transform: none;
+}
+
+body:has(.fiber-link-dashboard) .dev-tools-toolbar,
+body:has(.fiber-link-dashboard) .profiler-results {
+  display: none;
+}
+
+.fiber-link-dashboard {
+  --fl-dashboard-black: #000000;
+  --fl-dashboard-ink: #3a3733;
+  --fl-dashboard-muted: #777169;
+  --fl-dashboard-faint: #a59f97;
+  --fl-dashboard-line: #ebe9e5;
+  --fl-dashboard-chalk: #e5e5e5;
+  --fl-dashboard-powder: #f5f3f1;
+  --fl-dashboard-green: #1f6f4a;
+  --fl-dashboard-red: #8a1f1f;
+  --fl-dashboard-bg: transparent;
+  --fl-dashboard-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --fl-dashboard-mono: "JetBrains Mono", ui-monospace, Menlo, Monaco, monospace;
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px 40px 96px;
+  background: var(--fl-dashboard-bg);
+  color: var(--fl-dashboard-black);
+  font-family: var(--fl-dashboard-sans);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "kern" 1;
+}
+
+.fiber-link-dashboard button,
+.fiber-link-dashboard .btn {
+  border-radius: 999px;
+  background: transparent;
+  color: var(--fl-dashboard-black);
+}
+
+.fiber-link-dashboard button:hover,
+.fiber-link-dashboard .btn:hover {
+  border-color: transparent;
+  background: transparent;
+  color: var(--fl-dashboard-black);
+  box-shadow: none;
+  transform: none;
+}
+
+.fiber-link-dashboard__hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 2rem;
+}
+
+.fiber-link-dashboard__hero-copy h1 {
+  margin: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: clamp(2.75rem, 4vw, 3.25rem);
+  font-weight: 400;
+  line-height: 0.94;
+  white-space: nowrap;
+}
+
+.fiber-link-dashboard__hero-copy h1 span {
+  color: var(--fl-dashboard-black);
+  font-weight: 520;
+}
+
+.fiber-link-dashboard__hero-copy p {
+  max-width: 35rem;
+  margin: 1.2rem 0 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 1.05rem;
+  line-height: 1.45;
+}
+
+.fiber-link-dashboard__sync {
+  display: flex;
+  align-items: center;
+  gap: 2.5rem;
+  padding-bottom: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.95rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.fiber-link-dashboard__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 9.4rem;
+  contain: layout paint;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  transform: translateZ(0);
+  transition: none;
+}
+
+.fiber-link-dashboard__live > span {
+  display: inline-grid;
+  place-items: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 999px;
+  background: rgba(31, 122, 77, 0.12);
+}
+
+.fiber-link-dashboard__live > span::before {
+  content: "";
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: inherit;
+  background: var(--fl-dashboard-green);
+}
+
+.fiber-link-dashboard__refresh-select {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin: 0;
+  min-height: 1.4rem;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.fiber-link-dashboard__refresh-select::after {
+  content: "";
+  flex: 0 0 auto;
+  width: 0.42rem;
+  height: 0.42rem;
+  margin-left: -0.82rem;
+  border-right: 1.5px solid var(--fl-dashboard-black);
+  border-bottom: 1.5px solid var(--fl-dashboard-black);
+  transform: rotate(45deg) translateY(-0.12rem);
+  pointer-events: none;
+}
+
+.fiber-link-dashboard__refresh-select > span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.4rem;
+}
+
+.fiber-link-dashboard__refresh-select select {
+  appearance: none;
+  -webkit-appearance: none;
+  display: block;
+  width: auto;
+  min-width: 4.2rem;
+  max-width: 5.5rem;
+  height: 1.4rem;
+  border: 0;
+  margin: 0;
+  padding: 0 1.1rem 0 0;
+  background: transparent;
+  color: var(--fl-dashboard-black);
+  font: inherit;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-weight: 620;
+  line-height: 1.4rem;
+}
+
+.fiber-link-dashboard__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-top: 1px solid var(--fl-dashboard-line);
+  border-bottom: 1px solid var(--fl-dashboard-line);
+}
+
+.fiber-link-dashboard__metric {
+  display: grid;
+  gap: 0.92rem;
+  min-height: 7.25rem;
+  padding: 1.42rem 2.2rem 1.35rem 0;
+}
+
+.fiber-link-dashboard__metric + .fiber-link-dashboard__metric {
+  border-left: 1px solid var(--fl-dashboard-line);
+  padding-left: 2.7rem;
+}
+
+.fiber-link-dashboard__metric-label,
+.fiber-link-dashboard__section-kicker,
+.fiber-link-tip-feed-table th,
+.fiber-link-dashboard__field-row,
+.fiber-link-dashboard__quick-amounts {
+  color: var(--fl-dashboard-muted);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  text-transform: uppercase;
+}
+
+.fiber-link-dashboard__metric-label {
+  font-size: 0.86rem;
+  line-height: 1;
+}
+
+.fiber-link-dashboard__metric-value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.85rem;
+  margin: 0;
+  color: var(--fl-dashboard-black);
+}
+
+.fiber-link-dashboard__metric-value strong {
+  font-size: 2.05rem;
+  font-weight: 720;
+  line-height: 0.95;
+}
+
+.fiber-link-dashboard__metric-value span {
+  color: var(--fl-dashboard-muted);
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.fiber-link-dashboard__metric-caption {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.82rem;
+  line-height: 1.25;
+}
+
+.fiber-link-dashboard__metric-caption > span {
+  flex: 0 0 auto;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: var(--fl-dashboard-muted);
+}
+
+.fiber-link-dashboard__metric-caption.is-black > span {
+  background: var(--fl-dashboard-black);
+}
+
+.fiber-link-dashboard__metric-caption.is-success > span {
+  background: var(--fl-dashboard-green);
+}
+
+.fiber-link-dashboard__content-grid {
+  display: grid;
+  grid-template-columns: minmax(26rem, 0.8fr) minmax(34rem, 1.1fr);
+  gap: 3.4rem;
+  align-items: start;
+  margin-top: 1.45rem;
+}
+
+.fiber-link-dashboard__withdrawal,
+.fiber-link-dashboard__activity {
+  display: grid;
+  gap: 1.55rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.fiber-link-dashboard__section-kicker {
+  display: flex;
+  align-items: baseline;
+  gap: 0.85rem;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.92rem;
+  line-height: 1;
+}
+
+.fiber-link-dashboard__section-kicker strong {
+  color: var(--fl-dashboard-black);
+  font-weight: 520;
+}
+
+.fiber-link-dashboard__withdrawal-heading h3,
+.fiber-link-tip-feed-header h3 {
+  margin: 0;
+  color: var(--fl-dashboard-black);
+  font-size: clamp(1.72rem, 2.5vw, 2rem);
+  font-weight: 520;
+  line-height: 1.06;
+}
+
+.fiber-link-dashboard__withdrawal-heading h3 span,
+.fiber-link-tip-feed-header h3 span {
+  color: var(--fl-dashboard-muted);
+  font-weight: 350;
+}
+
+.fiber-link-dashboard__withdrawal-heading p,
+.fiber-link-tip-feed-header p,
+.fiber-link-dashboard__withdrawal-footnote {
+  margin: 1.05rem 0 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.fiber-link-dashboard__withdrawal-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--fl-dashboard-line);
+  border-bottom: 1px solid var(--fl-dashboard-line);
+}
+
+.fiber-link-dashboard__withdrawal-summary-item {
+  display: grid;
+  gap: 0.55rem;
+  min-height: 4.5rem;
+  padding: 1.05rem 1.25rem 1rem 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.fiber-link-dashboard__withdrawal-summary-item + .fiber-link-dashboard__withdrawal-summary-item {
+  border-left: 1px solid var(--fl-dashboard-line);
+  padding-left: 1.25rem;
+}
+
+.fiber-link-dashboard__withdrawal-summary-item span {
+  color: var(--fl-dashboard-muted);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.86rem;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-dashboard__withdrawal-summary-item strong {
+  color: var(--fl-dashboard-black);
+  font-size: 1.35rem;
+  font-weight: 620;
+  line-height: 1;
+}
+
+.fiber-link-dashboard__withdrawal-summary-item.is-highlighted strong {
+  color: var(--fl-dashboard-green);
+}
+
+.fiber-link-dashboard__withdrawal-form {
+  display: grid;
+  gap: 1.55rem;
+}
+
+.fiber-link-dashboard__field-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.9rem;
+}
+
+.fiber-link-tip-label {
+  color: var(--fl-dashboard-muted);
+  font-weight: 520;
+}
+
+.fiber-link-dashboard__amount-input-wrap {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 1rem;
+  border-bottom: 2px solid var(--fl-dashboard-black);
+}
+
+.fiber-link-dashboard__amount-input-wrap > span {
+  padding-bottom: 0.62rem;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.98rem;
+  font-weight: 650;
+}
+
+.fiber-link-dashboard__withdrawal-input {
+  border: 0 !important;
+  border-radius: 0;
+  background: transparent !important;
+  color: var(--fl-dashboard-black);
+  outline: 0 !important;
+  -webkit-focus-ring-color: transparent;
+  box-shadow: none !important;
+}
+
+.fiber-link-dashboard__withdrawal-input:focus,
+.fiber-link-dashboard__withdrawal-input:focus-visible {
+  outline: 0 !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.fiber-link-dashboard :is(input, select, textarea):focus,
+.fiber-link-dashboard :is(input, select, textarea):focus-visible {
+  outline: 0 !important;
+  box-shadow: none !important;
+  -webkit-focus-ring-color: transparent;
+}
+
+.fiber-link-dashboard__amount-input-wrap:focus-within,
+.fiber-link-dashboard .fiber-link-tip-field:focus-within {
+  outline: 0 !important;
+  box-shadow: none !important;
+}
+
+.fiber-link-dashboard__withdrawal-input.is-amount {
+  min-height: 4.15rem;
+  padding: 0;
+  font-size: 2.55rem;
+  font-weight: 620;
+  line-height: 1;
+}
+
+.fiber-link-dashboard__withdrawal-input.is-address {
+  min-height: 3.35rem;
+  border-bottom: 2px solid var(--fl-dashboard-black);
+  padding: 0.25rem 0 0.62rem;
+  color: var(--fl-dashboard-black);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 1rem;
+}
+
+.fiber-link-dashboard__withdrawal-input.is-address:focus,
+.fiber-link-dashboard__withdrawal-input.is-address:focus-visible {
+  border-bottom-color: var(--fl-dashboard-black) !important;
+}
+
+.fiber-link-dashboard__withdrawal-input::placeholder {
+  color: var(--fl-dashboard-faint);
+  opacity: 1;
+}
+
+.fiber-link-dashboard__quick-amounts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.55rem;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.9rem;
+}
+
+.fiber-link-dashboard__quick-amounts button,
+.fiber-link-dashboard__paste-button {
+  min-height: 0;
+  border-radius: 0;
+  padding: 0 0 0.12rem;
+  border-bottom: 1px dotted var(--fl-dashboard-line);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+.fiber-link-dashboard__paste-button {
+  border-bottom-style: solid;
+  color: var(--fl-dashboard-black);
+  text-transform: none;
+}
+
+.fiber-link-dashboard__withdrawal-validation {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--fl-dashboard-red);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.92rem;
+}
+
+.fiber-link-dashboard__withdrawal-validation::before {
+  content: "!";
+  display: inline-grid;
+  place-items: center;
+  width: 1.28rem;
+  height: 1.28rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-family: inherit;
+  font-size: 0.92rem;
+  line-height: 1;
+}
+
+.fiber-link-dashboard__withdrawal-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.2rem;
+  align-items: start;
+  justify-items: start;
+}
+
+.fiber-link-dashboard .fiber-link-dashboard__withdrawal-submit,
+.fiber-link-dashboard .fiber-link-dashboard__withdrawal-submit:hover {
+  justify-self: start;
+  justify-content: center;
+  min-width: 17rem;
+  min-height: 4rem;
+  border-radius: 999px;
+  padding: 0 2rem;
+  background: var(--fl-dashboard-black);
+  color: white;
+  font-size: 1.08rem;
+  font-weight: 620;
+  white-space: nowrap;
+}
+
+.fiber-link-dashboard__withdrawal-meta,
+.fiber-link-dashboard__withdrawal-success,
+.fiber-link-dashboard__withdrawal-note {
+  margin: 0;
+}
+
+.fiber-link-tip-feed-loading,
+.fiber-link-tip-feed-empty,
+.fiber-link-tip-feed-error {
+  margin: 0;
+  border-radius: 0;
+  padding: 1rem 0;
+  background: transparent;
+  color: var(--fl-dashboard-muted);
+}
+
+.fiber-link-tip-feed-error {
+  color: var(--fl-red);
+}
+
+.fiber-link-tip-feed-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(15rem, 22rem);
+  gap: 2rem;
+  align-items: end;
 }
 
 .fiber-link-tip-feed-search {
   position: relative;
   display: block;
+  justify-self: end;
   width: 100%;
+  max-width: 22rem;
+  transform: scale(0.6);
+  transform-origin: right bottom;
 }
 
 .fiber-link-tip-feed-search__icon {
   position: absolute;
-  left: 0.78rem;
+  left: 0;
   top: 50%;
+  width: 0.88rem;
+  height: 0.88rem;
+  color: var(--fl-dashboard-muted);
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
   transform: translateY(-50%);
-  color: var(--primary-medium);
-  font-size: 1rem;
   pointer-events: none;
 }
 
 .fiber-link-tip-feed-search input {
-  width: 100%;
   min-width: 0;
-  height: 2.35rem;
-  padding: 0.5rem 0.75rem 0.5rem 2.15rem;
+  min-height: 2.25rem;
+  border-bottom: 1px solid var(--fl-dashboard-line);
+  border-radius: 0;
+  padding: 0.28rem 0 0.35rem 1.55rem;
+  background: transparent;
+  color: var(--fl-dashboard-black);
+  font-size: 0.9rem;
+  font-weight: 400;
+}
+
+.fiber-link-dashboard .fiber-link-tip-feed-search input:focus,
+.fiber-link-dashboard .fiber-link-tip-feed-search input:focus-visible {
+  outline: 0 !important;
+  border-color: var(--fl-dashboard-black);
+  box-shadow: none !important;
+}
+
+.fiber-link-tip-feed-search input::placeholder {
+  color: var(--fl-dashboard-faint);
+  opacity: 1;
+}
+
+.fiber-link-filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip {
+  gap: 0.65rem;
+  min-height: 2.8rem;
+  border: 1px solid var(--fl-dashboard-line);
+  border-radius: 999px;
+  padding: 0 1.25rem;
+  background: transparent;
+  color: var(--fl-dashboard-black);
+  font-size: 1rem;
+  font-weight: 520;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip:hover {
+  border-color: var(--fl-dashboard-line);
+  background: transparent;
+  color: var(--fl-dashboard-black);
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip strong {
+  color: var(--fl-dashboard-muted);
+  font-size: 0.9rem;
+  font-weight: 520;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip.is-active {
+  border-color: var(--fl-dashboard-black);
+  background: var(--fl-dashboard-black);
+  color: white;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip.is-active:hover {
+  border-color: var(--fl-dashboard-black);
+  background: var(--fl-dashboard-black);
+  color: white;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip.is-active strong {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip.is-active:hover strong {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.fiber-link-tip-feed-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.fiber-link-tip-feed-table th,
+.fiber-link-tip-feed-table td {
+  border-bottom: 1px solid var(--fl-dashboard-line);
+  padding: 1.45rem 0;
+  text-align: left;
+  vertical-align: middle;
 }
 
 .fiber-link-tip-feed-table th {
-  font-size: 0.76rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  padding-top: 0.1rem;
+  padding-bottom: 1.35rem;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.98rem;
+  font-weight: 520;
 }
 
-@media (max-width: 760px) {
-  .fiber-link-tip-feed-toolbar {
-    grid-template-columns: 1fr;
-  }
-
-  .fiber-link-tip-feed-search-shell {
-    justify-content: stretch;
-  }
+.fiber-link-tip-feed-table th:nth-child(1),
+.fiber-link-tip-feed-table td:nth-child(1) {
+  width: 11rem;
 }
 
-/* Fiber Link confirmed compact dashboard + dropdown activity pass. */
-.fiber-link-dashboard__metrics.is-compact {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+.fiber-link-tip-feed-table th:nth-child(2),
+.fiber-link-tip-feed-table td:nth-child(2) {
+  width: 12rem;
 }
 
-.fiber-link-dashboard__metrics.is-compact .fiber-link-dashboard__metric-card {
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
-  gap: 0.8rem;
-  min-height: 5rem;
-  padding: 1rem 1.15rem;
+.fiber-link-tip-feed-table th:nth-child(3),
+.fiber-link-tip-feed-table td:nth-child(3) {
+  width: 12rem;
 }
 
-.fiber-link-dashboard__metrics.is-compact .fiber-link-dashboard__metric-icon {
-  grid-row: auto;
-  width: 2.75rem;
-  height: 2.75rem;
-  font-size: 1.25rem;
+.fiber-link-tip-feed-table th:nth-child(5),
+.fiber-link-tip-feed-table td:nth-child(5) {
+  width: 4.5rem;
+  color: var(--fl-dashboard-muted);
+  text-align: right;
 }
 
-.fiber-link-dashboard__metrics.is-compact .fiber-link-dashboard__metric-value {
-  margin: 0;
-  font-size: 1.35rem;
-  line-height: 1.15;
-  letter-spacing: -0.02em;
-}
-
-.fiber-link-tip-feed-toolbar {
-  grid-template-columns: minmax(190px, 260px) minmax(0, 1fr);
-  align-items: center;
-}
-
-.fiber-link-filter-select-shell {
-  display: grid;
-  gap: 0.35rem;
-  width: min(100%, 260px);
-}
-
-.fiber-link-filter-select-label {
-  color: var(--primary-medium);
-  font-size: 0.76rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.fiber-link-filter-select-wrap {
-  position: relative;
-  display: block;
-}
-
-.fiber-link-filter-select {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 100%;
-  min-height: 2.4rem;
-  border: 1px solid var(--primary-low-mid);
-  border-radius: 10px;
-  padding: 0.55rem 2.2rem 0.55rem 0.75rem;
-  background: var(--secondary);
-  color: transparent;
-  font: inherit;
-  font-weight: 650;
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--primary) 5%, transparent);
-  cursor: pointer;
-}
-
-.fiber-link-filter-select:focus-visible {
-  outline: 0;
-  border-color: var(--tertiary);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--tertiary) 18%, transparent);
-}
-
-.fiber-link-filter-select-current {
-  position: absolute;
-  inset: 0 2.2rem 0 0.75rem;
+.fiber-link-tip-feed-amount {
   display: flex;
-  align-items: center;
-  color: var(--primary-high);
+  align-items: baseline;
+  gap: 0.38rem;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.fiber-link-tip-feed-amount strong {
+  color: var(--fl-dashboard-black);
+  font-size: 1.2rem;
   font-weight: 650;
-  pointer-events: none;
 }
 
-.fiber-link-filter-select-chevron {
-  position: absolute;
-  right: 0.75rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--primary-medium);
-  pointer-events: none;
+.fiber-link-tip-feed-amount span {
+  color: var(--fl-dashboard-muted);
+  font-size: 0.9rem;
+  font-weight: 650;
 }
 
-.fiber-link-tip-feed-table.is-icon-first {
-  table-layout: auto;
+.fiber-link-tip-feed-amount.is-positive strong {
+  color: var(--fl-dashboard-green);
 }
 
-.fiber-link-tip-feed-table.is-icon-first th:first-child,
-.fiber-link-tip-feed-table.is-icon-first td:first-child {
-  width: 4.25rem;
-  text-align: center;
+.fiber-link-tip-feed-type,
+.fiber-link-tip-feed-status,
+.fiber-link-tip-feed-user {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.62rem;
 }
 
 .fiber-link-direction-icon {
+  display: inline;
+  width: auto;
+  height: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--fl-dashboard-muted);
+  font-size: 1.1rem;
+  font-weight: 520;
+  line-height: 1;
+}
+
+.fiber-link-tip-feed-status-dot {
+  flex: 0 0 auto;
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: 999px;
+  background: var(--fl-dashboard-faint);
+}
+
+.fiber-link-tip-feed-status-dot.is-completed {
+  background: var(--fl-dashboard-green);
+}
+
+.fiber-link-tip-feed-status-dot.is-failed {
+  background: var(--fl-dashboard-red);
+}
+
+.fiber-link-tip-feed-status-text {
+  color: var(--fl-dashboard-ink);
+}
+
+.fiber-link-tip-feed-status-text.is-completed {
+  color: var(--fl-dashboard-green);
+}
+
+.fiber-link-tip-feed-status-text.is-failed {
+  color: var(--fl-dashboard-red);
+}
+
+.fiber-link-tip-feed-avatar {
   display: inline-grid;
   place-items: center;
-  width: 2rem;
-  height: 2rem;
+  flex: 0 0 auto;
+  width: 2.55rem;
+  height: 2.55rem;
   border-radius: 999px;
-  font-weight: 800;
-  font-size: 1rem;
+  background: #f2f0ee;
+  color: var(--fl-dashboard-ink);
+  font-size: 0.88rem;
+  font-weight: 760;
+}
+
+.fiber-link-tip-feed-user > span:last-child {
+  display: grid;
+  gap: 0.22rem;
+  min-width: 0;
+}
+
+.fiber-link-tip-feed-user strong {
+  color: var(--fl-dashboard-black);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.98rem;
+  font-weight: 620;
+  line-height: 1.1;
+}
+
+.fiber-link-tip-feed-message {
+  margin: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 0.92rem;
+  line-height: 1.25;
+}
+
+.fiber-link-tip-feed-summary {
+  margin: -1rem 0 0;
+  color: var(--fl-dashboard-faint);
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.78rem;
   line-height: 1;
-  border: 1px solid transparent;
 }
 
-.fiber-link-direction-icon.is-received {
-  background: var(--success-low);
-  color: var(--success);
-  border-color: color-mix(in srgb, var(--success) 20%, transparent);
+/* Dashboard standalone HTML fidelity pass. */
+.fiber-link-dashboard__hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 56px;
 }
 
-.fiber-link-direction-icon.is-sent {
-  background: color-mix(in srgb, var(--tertiary) 10%, white 90%);
-  color: var(--tertiary);
-  border-color: color-mix(in srgb, var(--tertiary) 18%, transparent);
+.fiber-link-dashboard__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  line-height: normal;
+  text-transform: uppercase;
 }
 
-.fiber-link-direction-icon.is-withdrawn {
-  background: color-mix(in srgb, var(--primary-high) 8%, white 92%);
-  color: var(--primary-high);
-  border-color: color-mix(in srgb, var(--primary-high) 16%, transparent);
-}
-
-.fiber-link-status-badge {
-  padding: 0.28rem 0.5rem;
+.fiber-link-dashboard__eyebrow::before {
+  content: "";
+  width: 6px;
+  height: 6px;
   border-radius: 999px;
-  font-size: 0.74rem;
-  font-weight: 650;
-  box-shadow: none;
+  background: var(--fl-dashboard-black);
 }
 
-.fiber-link-status-badge.is-info {
-  background: #fff7e8;
-  color: #a96700;
+.fiber-link-dashboard__hero-copy h1 {
+  margin: 0 0 14px;
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 48px;
+  font-weight: 300;
+  line-height: 1.02;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
 }
 
-.fiber-link-status-badge.is-success {
-  background: color-mix(in srgb, var(--success-low) 75%, white 25%);
-  color: var(--success);
+.fiber-link-dashboard__hero-copy h1 span {
+  color: var(--fl-dashboard-black);
+  font-weight: 600;
+  letter-spacing: -0.03em;
 }
 
-.fiber-link-status-badge.is-danger {
-  background: color-mix(in srgb, var(--danger-low) 78%, white 22%);
-  color: var(--danger);
+.fiber-link-dashboard__hero-copy p {
+  max-width: 520px;
+  margin: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 15px;
+  line-height: 1.55;
 }
 
-@media (max-width: 900px) {
-  .fiber-link-dashboard__metrics.is-compact {
+.fiber-link-dashboard__sync {
+  gap: 20px;
+  color: var(--fl-dashboard-muted);
+  font-size: 13px;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__live {
+  gap: 8px;
+  min-width: 0;
+}
+
+.fiber-link-dashboard__live > span {
+  width: 6px;
+  height: 6px;
+  background: var(--fl-dashboard-green);
+  box-shadow: 0 0 0 4px rgba(31, 111, 74, 0.12);
+}
+
+.fiber-link-dashboard__live > span::before {
+  display: none;
+}
+
+.fiber-link-dashboard__refresh-select {
+  gap: 8px;
+  min-height: 0;
+  font-size: 13px;
+  font-weight: 400 !important;
+}
+
+.fiber-link-dashboard__refresh-select > span {
+  color: var(--fl-dashboard-muted);
+  font-weight: 400;
+}
+
+.fiber-link-dashboard__refresh-select select {
+  min-width: 0;
+  max-width: none;
+  height: auto;
+  padding: 4px 18px 4px 0;
+  font-family: var(--fl-dashboard-mono);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__refresh-select::after {
+  width: 4px;
+  height: 4px;
+  margin-left: -18px;
+  border-width: 1px;
+}
+
+.fiber-link-dashboard__metrics {
+  margin-bottom: 80px;
+  border-color: var(--fl-dashboard-line);
+}
+
+.fiber-link-dashboard__metric {
+  display: block;
+  min-height: 0;
+  padding: 28px 32px 28px 0;
+}
+
+.fiber-link-dashboard__metric + .fiber-link-dashboard__metric {
+  border-left-color: var(--fl-dashboard-line);
+  padding-left: 32px;
+}
+
+.fiber-link-dashboard__metric-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 18px;
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__metric-value {
+  gap: 8px;
+  margin: 0 0 14px;
+}
+
+.fiber-link-dashboard__metric-value strong {
+  font-size: 36px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.fiber-link-dashboard__metric-value span {
+  color: var(--fl-dashboard-muted);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.fiber-link-dashboard__metric-caption {
+  gap: 8px;
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__metric-caption > span {
+  width: 6px;
+  height: 6px;
+}
+
+.fiber-link-dashboard__content-grid {
+  grid-template-columns: minmax(0, 440px) minmax(0, 1fr);
+  gap: 80px;
+  margin-top: 0;
+}
+
+.fiber-link-dashboard__withdrawal,
+.fiber-link-dashboard__activity {
+  gap: 0;
+}
+
+.fiber-link-dashboard__section-kicker {
+  gap: 10px;
+  margin-bottom: 20px;
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__section-kicker strong {
+  color: var(--fl-dashboard-black);
+  font-family: var(--fl-dashboard-mono);
+  font-weight: 400;
+}
+
+.fiber-link-dashboard__withdrawal-heading h3,
+.fiber-link-tip-feed-header h3 {
+  margin: 0 0 12px;
+  color: var(--fl-dashboard-black);
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+}
+
+.fiber-link-dashboard__withdrawal-heading h3 span,
+.fiber-link-tip-feed-header h3 span {
+  color: var(--fl-dashboard-muted);
+  font-weight: 300;
+}
+
+.fiber-link-dashboard__withdrawal-heading p,
+.fiber-link-tip-feed-header p {
+  max-width: 380px;
+  margin: 0 0 32px;
+  color: var(--fl-dashboard-muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.fiber-link-dashboard__withdrawal-summary-grid {
+  margin-bottom: 36px;
+  border-color: var(--fl-dashboard-line);
+}
+
+.fiber-link-dashboard__withdrawal-summary-item {
+  gap: 8px;
+  min-height: 0;
+  padding: 18px 16px 18px 0;
+}
+
+.fiber-link-dashboard__withdrawal-summary-item + .fiber-link-dashboard__withdrawal-summary-item {
+  border-left-color: var(--fl-dashboard-line);
+  padding-left: 16px;
+}
+
+.fiber-link-dashboard__withdrawal-summary-item span {
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__withdrawal-summary-item strong {
+  color: var(--fl-dashboard-black);
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.fiber-link-dashboard__withdrawal-form {
+  gap: 24px;
+}
+
+.fiber-link-dashboard__field-row {
+  margin-bottom: 10px;
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__field-row > span:last-child {
+  font-family: var(--fl-dashboard-mono);
+  letter-spacing: 0;
+}
+
+.fiber-link-dashboard .fiber-link-tip-label {
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.fiber-link-dashboard__amount-input-wrap {
+  gap: 12px;
+  align-items: baseline;
+  border-bottom: 1px solid var(--fl-dashboard-black);
+  padding: 6px 0 10px;
+  color: var(--fl-dashboard-black);
+  font-weight: 400;
+}
+
+.fiber-link-dashboard__amount-input-wrap > span {
+  padding-bottom: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-dashboard__withdrawal-input.is-amount {
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  font-size: 28px;
+  font-weight: 500;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.fiber-link-dashboard__withdrawal-input.is-address {
+  min-height: 0;
+  border-bottom: 1px solid var(--fl-dashboard-black);
+  padding: 14px 0;
+  font-family: var(--fl-dashboard-mono);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__quick-amounts {
+  gap: 6px;
+  margin-top: 14px;
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: normal;
+}
+
+.fiber-link-dashboard__quick-amounts button,
+.fiber-link-dashboard__paste-button {
+  padding: 4px 0;
+  border-bottom-color: var(--fl-dashboard-chalk);
+  font-weight: 400;
+}
+
+.fiber-link-dashboard__quick-amounts button + button {
+  margin-left: 14px;
+}
+
+.fiber-link-dashboard__withdrawal-validation {
+  margin-top: -2px;
+  color: var(--fl-dashboard-red);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 12px;
+}
+
+.fiber-link-dashboard__withdrawal-validation::before {
+  width: 14px;
+  height: 14px;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.fiber-link-dashboard__withdrawal-actions {
+  margin-top: 8px;
+  gap: 14px;
+}
+
+.fiber-link-dashboard .fiber-link-dashboard__withdrawal-submit,
+.fiber-link-dashboard .fiber-link-dashboard__withdrawal-submit:hover {
+  min-width: 0;
+  min-height: 44px;
+  padding: 0 22px;
+  background: var(--fl-dashboard-black);
+  color: #fdfcfc;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.fiber-link-tip-feed-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+.fiber-link-tip-feed-header > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.fiber-link-tip-feed-search {
+  flex: 0 0 220px;
+  width: 220px;
+  min-width: 220px;
+  max-width: 220px;
+  font-weight: 400;
+  transform: scale(0.6);
+  transform-origin: right bottom;
+}
+
+.fiber-link-tip-feed-search__icon {
+  left: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--fl-dashboard-muted);
+  stroke-width: 1.8;
+}
+
+.fiber-link-tip-feed-search input {
+  width: 220px;
+  min-height: 0;
+  border-bottom: 1px solid var(--fl-dashboard-chalk);
+  padding: 6px 0 6px 22px;
+  font-size: 13px;
+  line-height: normal;
+}
+
+.fiber-link-filter-group {
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip {
+  gap: 8px;
+  min-height: 30px;
+  padding: 0 14px;
+  border-color: var(--fl-dashboard-chalk);
+  color: var(--fl-dashboard-black);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip strong {
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip.is-active,
+.fiber-link-dashboard .fiber-link-filter-chip.is-active:hover {
+  border-color: var(--fl-dashboard-black);
+  background: var(--fl-dashboard-black);
+  color: #fdfcfc;
+}
+
+.fiber-link-dashboard .fiber-link-filter-chip.is-active strong,
+.fiber-link-dashboard .fiber-link-filter-chip.is-active:hover strong {
+  color: rgba(253, 252, 252, 0.6);
+}
+
+.fiber-link-tip-feed-table {
+  margin-top: 12px;
+}
+
+.fiber-link-tip-feed-table th,
+.fiber-link-tip-feed-table td {
+  border-bottom-color: var(--fl-dashboard-line);
+  padding: 22px 12px;
+  font-size: 14px;
+}
+
+.fiber-link-tip-feed-table th {
+  padding-top: 18px;
+  padding-bottom: 18px;
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
+.fiber-link-tip-feed-table th:first-child,
+.fiber-link-tip-feed-table td:first-child {
+  padding-left: 0;
+}
+
+.fiber-link-tip-feed-table th:last-child,
+.fiber-link-tip-feed-table td:last-child {
+  padding-right: 0;
+  text-align: right;
+}
+
+.fiber-link-tip-feed-table th:nth-child(1),
+.fiber-link-tip-feed-table td:nth-child(1) {
+  width: 140px;
+}
+
+.fiber-link-tip-feed-table th:nth-child(2),
+.fiber-link-tip-feed-table td:nth-child(2) {
+  width: 130px;
+}
+
+.fiber-link-tip-feed-table th:nth-child(3),
+.fiber-link-tip-feed-table td:nth-child(3) {
+  width: 120px;
+}
+
+.fiber-link-tip-feed-table th:nth-child(5),
+.fiber-link-tip-feed-table td:nth-child(5) {
+  width: 90px;
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 12px;
+}
+
+.fiber-link-tip-feed-amount {
+  gap: 6px;
+}
+
+.fiber-link-tip-feed-amount strong {
+  color: var(--fl-dashboard-black);
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.fiber-link-tip-feed-amount.is-positive strong {
+  color: var(--fl-dashboard-black);
+}
+
+.fiber-link-tip-feed-amount.is-positive strong::first-letter {
+  color: var(--fl-dashboard-green);
+}
+
+.fiber-link-tip-feed-amount.is-negative strong {
+  color: var(--fl-dashboard-ink);
+}
+
+.fiber-link-tip-feed-amount span {
+  color: var(--fl-dashboard-muted);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.fiber-link-tip-feed-type,
+.fiber-link-tip-feed-status,
+.fiber-link-tip-feed-user {
+  gap: 10px;
+}
+
+.fiber-link-tip-feed-type {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.fiber-link-direction-icon {
+  color: var(--fl-dashboard-muted);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.fiber-link-tip-feed-status {
+  gap: 6px;
+}
+
+.fiber-link-tip-feed-status-dot {
+  width: 6px;
+  height: 6px;
+}
+
+.fiber-link-tip-feed-status-dot.is-completed {
+  background: var(--fl-dashboard-green);
+}
+
+.fiber-link-tip-feed-status-dot.is-failed {
+  background: var(--fl-dashboard-red);
+}
+
+.fiber-link-tip-feed-status-text {
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.fiber-link-tip-feed-status-text.is-completed {
+  color: var(--fl-dashboard-green);
+}
+
+.fiber-link-tip-feed-status-text.is-failed {
+  color: var(--fl-dashboard-red);
+}
+
+.fiber-link-tip-feed-avatar {
+  width: 28px;
+  height: 28px;
+  background: var(--fl-dashboard-powder);
+  color: var(--fl-dashboard-ink);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.fiber-link-tip-feed-user {
+  gap: 12px;
+}
+
+.fiber-link-tip-feed-user > span:last-child {
+  gap: 0;
+}
+
+.fiber-link-tip-feed-user strong {
+  color: var(--fl-dashboard-black);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: normal;
+  letter-spacing: -0.01em;
+}
+
+.fiber-link-tip-feed-message {
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.fiber-link-tip-feed-summary {
+  margin: 8px 0 0;
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 12px;
+  line-height: normal;
+}
+
+@media (max-width: 1180px) {
+  .fiber-link-dashboard {
+    gap: 3rem;
+  }
+
+  .fiber-link-dashboard__hero,
+  .fiber-link-dashboard__content-grid {
     grid-template-columns: 1fr;
+  }
+
+  .fiber-link-dashboard__sync {
+    justify-self: start;
+  }
+
+  .fiber-link-dashboard__metric,
+  .fiber-link-dashboard__metric + .fiber-link-dashboard__metric {
+    padding-inline: 1.4rem;
+  }
+}
+
+@media (max-width: 860px) {
+  .fiber-link-dashboard__metrics,
+  .fiber-link-dashboard__withdrawal-summary-grid,
+  .fiber-link-tip-feed-header {
+    grid-template-columns: 1fr;
+  }
+
+  .fiber-link-dashboard__hero-copy h1 {
+    white-space: normal;
+  }
+
+  .fiber-link-dashboard__metric + .fiber-link-dashboard__metric,
+  .fiber-link-dashboard__withdrawal-summary-item + .fiber-link-dashboard__withdrawal-summary-item {
+    border-left: 0;
+    border-top: 1px solid var(--fl-dashboard-line);
+    padding-left: 0;
+  }
+
+  .fiber-link-dashboard__metric {
+    min-height: auto;
+    padding: 1.8rem 0;
+  }
+
+  .fiber-link-dashboard__withdrawal-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .fiber-link-tip-feed-table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
   }
 }
 
 @media (max-width: 760px) {
-  .fiber-link-tip-feed-toolbar {
+  .fiber-link-tip-modal .d-modal__container {
+    left: 0.5rem;
+    right: 0.5rem;
+    width: auto;
+    max-width: none;
+  }
+
+  .fiber-link-tip-modal .d-modal__header,
+  .fiber-link-tip-modal .d-modal__body,
+  .fiber-link-tip-modal .d-modal__footer {
+    padding-inline: 1rem;
+  }
+
+  .fiber-link-tip-modal .d-modal__title-text {
+    font-size: 1.18rem;
+  }
+
+  .fiber-link-tip-modal__payment-overview {
     grid-template-columns: 1fr;
   }
 
-  .fiber-link-filter-select-shell {
+  .fiber-link-tip-modal__recipient-strip {
+    align-items: flex-start;
+  }
+
+  .fiber-link-tip-modal__receive-note {
+    max-width: none;
+    text-align: left;
+  }
+
+  .fiber-link-tip-modal__summary-strip {
+    max-width: none;
+    width: 100%;
+    border-radius: 10px;
+  }
+
+  .fiber-link-tip-modal__summary-strip p:first-child,
+  .fiber-link-tip-modal__summary-strip p:last-child {
+    flex: 1 1 auto;
+  }
+
+  .fiber-link-tip-panel__actions,
+  .fiber-link-tip-footer {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .fiber-link-tip-footer__actions {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.55rem;
+  }
+
+  .fiber-link-tip-footer__primary,
+  .fiber-link-tip-footer__secondary {
+    width: 100%;
+  }
+
+  .fiber-link-tip-footer__primary > *,
+  .fiber-link-tip-footer__secondary > * {
     width: 100%;
   }
 }

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -38,31 +38,27 @@
   border: 0;
 }
 
-.post-action-menu__fiber-link-tip.fiber-link-tip-button--icon-only {
+.fiber-link-tip-entry__button.fiber-link-tip-button--icon-only {
   border-radius: 999px;
 }
 
 .fiber-link-tip-modal .d-modal__container {
-  max-width: 860px;
+  max-width: 420px;
 }
 
 .fiber-link-tip-modal__content {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
-.fiber-link-tip-modal__content--checkout {
-  gap: 1rem;
-}
-
-.fiber-link-tip-modal__hero {
+.fiber-link-tip-modal__header {
   display: grid;
-  gap: 0.18rem;
+  gap: 0.15rem;
+  padding: 0.2rem 0;
 }
 
-.fiber-link-tip-modal__eyebrow,
-.fiber-link-tip-summary__eyebrow,
-.fiber-link-tip-label,
+.fiber-link-tip-modal__recipient,
+.fiber-link-tip-step-card__eyebrow,
 .fiber-link-tip-step-card__caption,
 .fiber-link-tip-invoice-label,
 .fiber-link-dashboard__metric-label,
@@ -72,69 +68,24 @@
   margin: 0;
   color: var(--primary-medium);
   font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
-.fiber-link-tip-modal__hero h2,
-.fiber-link-tip-panel__header h3,
-.fiber-link-dashboard__withdrawal-header h3,
-.fiber-link-dashboard__activity-header h3,
-.fiber-link-dashboard__header h2 {
-  margin: 0;
+.fiber-link-tip-modal__recipient-name {
+  font-size: 1rem;
 }
 
-.fiber-link-tip-modal__hero h2 {
+.fiber-link-tip-modal__amount {
+  margin: 0.15rem 0 0;
   font-size: 2rem;
-  line-height: 1.05;
+  line-height: 1;
+  font-weight: 700;
   color: var(--primary-high);
-}
-
-.fiber-link-tip-modal__hero-subtitle,
-.fiber-link-tip-panel__header p,
-.fiber-link-tip-step-card__placeholder {
-  margin: 0;
-  color: var(--primary-medium);
-  font-size: 0.95rem;
-  line-height: 1.55;
-}
-
-.fiber-link-tip-stepper {
-  list-style: none;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
-  margin: 0;
-  padding: 0;
-}
-
-.fiber-link-tip-stepper li {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.5rem;
-  padding: 0.55rem 0.8rem;
-  border-radius: 999px;
-  background: var(--secondary);
-  color: var(--primary-medium);
-  font-size: 0.9rem;
-  font-weight: 600;
-}
-
-.fiber-link-tip-stepper li.is-active {
-  background: color-mix(in srgb, var(--tertiary) 12%, var(--secondary) 88%);
-  color: var(--tertiary);
-}
-
-.fiber-link-tip-stepper li.is-complete {
-  background: color-mix(in srgb, var(--success-low) 72%, var(--secondary) 28%);
-  color: var(--success);
 }
 
 .fiber-link-tip-alert {
   margin: 0;
-  border-radius: 14px;
-  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
   font-size: 0.92rem;
 }
 
@@ -154,106 +105,36 @@
   color: var(--success);
 }
 
-.fiber-link-tip-modal__grid {
+.fiber-link-tip-step-card {
   display: grid;
-  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
-  gap: 1rem;
-  align-items: stretch;
+  gap: 0.65rem;
+  border: 1px solid var(--primary-low-mid);
+  border-radius: 14px;
+  padding: 0.85rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--secondary) 86%, white 14%) 0%,
+    var(--secondary) 100%
+  );
 }
 
-.fiber-link-tip-summary {
+.fiber-link-tip-step-card__header {
   display: grid;
-  gap: 0.9rem;
-  min-height: 100%;
-  padding: 1rem;
-  border-radius: 18px;
-  background: color-mix(in srgb, var(--secondary) 94%, white 6%);
+  gap: 0.12rem;
 }
 
-.fiber-link-tip-summary__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+.fiber-link-tip-step-card__header h3,
+.fiber-link-dashboard__withdrawal-header h3,
+.fiber-link-dashboard__activity-header h3,
+.fiber-link-dashboard__header h2 {
+  margin: 0;
 }
 
-.fiber-link-tip-summary__brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  color: var(--primary-high);
-  text-decoration: none;
+.fiber-link-tip-step-card__placeholder {
+  margin: 0;
+  color: var(--primary-medium);
   font-size: 0.9rem;
-  font-weight: 600;
-}
-
-.fiber-link-tip-summary__logo {
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  object-fit: cover;
-}
-
-.fiber-link-tip-summary__list {
-  display: grid;
-  gap: 0.8rem;
-  margin: 0;
-}
-
-.fiber-link-tip-summary__list div {
-  display: grid;
-  gap: 0.2rem;
-}
-
-.fiber-link-tip-summary__list dt {
-  color: var(--primary-medium);
-  font-size: 0.8rem;
-}
-
-.fiber-link-tip-summary__list dd {
-  margin: 0;
-  color: var(--primary-high);
-  font-weight: 600;
   line-height: 1.45;
-  word-break: break-word;
-}
-
-.fiber-link-tip-summary__meta {
-  margin: auto 0 0;
-  color: var(--primary-medium);
-  font-size: 0.82rem;
-  line-height: 1.45;
-}
-
-.fiber-link-tip-modal__main {
-  display: grid;
-  gap: 0.85rem;
-  min-height: 100%;
-}
-
-.fiber-link-tip-panel {
-  display: grid;
-  gap: 0.9rem;
-  min-height: 100%;
-  padding: 1rem;
-  border-radius: 18px;
-  background: color-mix(in srgb, var(--secondary) 97%, white 3%);
-}
-
-.fiber-link-tip-panel--pay,
-.fiber-link-tip-panel--confirmed {
-  align-content: start;
-}
-
-.fiber-link-tip-panel__header {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.fiber-link-tip-panel__header--centered,
-.fiber-link-tip-status-row--success {
-  justify-items: center;
-  text-align: center;
 }
 
 .fiber-link-tip-form,
@@ -261,7 +142,7 @@
 .fiber-link-dashboard__withdrawal-form,
 .fiber-link-dashboard__withdrawal-actions {
   display: grid;
-  gap: 0.55rem;
+  gap: 0.45rem;
 }
 
 .fiber-link-tip-label {
@@ -269,81 +150,17 @@
   color: var(--primary-high);
 }
 
-.fiber-link-tip-label__optional {
-  color: var(--primary-medium);
-  font-size: 0.82rem;
-  text-transform: none;
-  letter-spacing: normal;
-}
-
-.fiber-link-tip-input-group {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  border-radius: 14px;
-  background: white;
-  box-shadow: inset 0 0 0 1px var(--primary-low-mid);
-}
-
 .fiber-link-tip-input {
   width: 100%;
-  border: 0;
-  border-radius: 14px;
-  padding: 0.72rem 0.85rem;
+  border: 1px solid var(--primary-low-mid);
+  border-radius: 10px;
+  padding: 0.58rem 0.7rem;
   background: white;
-  box-shadow: none;
-}
-
-.fiber-link-tip-input:focus,
-.fiber-link-tip-textarea:focus {
-  outline: 2px solid color-mix(in srgb, var(--tertiary) 42%, white 58%);
-  outline-offset: 2px;
-}
-
-.fiber-link-tip-input-group:focus-within {
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--tertiary) 45%, var(--primary-low-mid) 55%);
-}
-
-.fiber-link-tip-input--amount {
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.fiber-link-tip-input-suffix {
-  padding: 0 0.9rem;
-  color: var(--primary-medium);
-  font-size: 0.92rem;
-  font-weight: 700;
-}
-
-.fiber-link-tip-quick-amounts {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.fiber-link-tip-chip {
-  border: 0;
-  border-radius: 999px;
-  padding: 0.45rem 0.8rem;
-  background: var(--secondary);
-  color: var(--primary-high);
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.fiber-link-tip-chip:hover,
-.fiber-link-tip-chip:focus-visible {
-  background: color-mix(in srgb, var(--tertiary) 10%, var(--secondary) 90%);
-  color: var(--tertiary);
-  outline: none;
 }
 
 .fiber-link-tip-textarea {
   resize: vertical;
-  min-height: 68px;
-  box-shadow: inset 0 0 0 1px var(--primary-low-mid);
+  min-height: 88px;
 }
 
 .fiber-link-tip-input-error,
@@ -361,53 +178,42 @@
   color: var(--success);
 }
 
-.fiber-link-tip-status-row {
-  display: grid;
-  gap: 0.4rem;
-}
-
-.fiber-link-tip-status-row--panel {
-  padding: 0.85rem 0.9rem;
-  border-radius: 16px;
-  background: color-mix(in srgb, var(--secondary) 84%, white 16%);
-}
-
-.fiber-link-tip-status-copy,
-.fiber-link-tip-pay-hint,
-.fiber-link-tip-copy-feedback {
-  margin: 0;
-  color: var(--primary-medium);
-  font-size: 0.88rem;
-  line-height: 1.45;
-}
-
 .fiber-link-tip-invoice-visual {
   display: grid;
   place-items: center;
-  padding: 1.25rem;
-  border-radius: 20px;
+  padding: 0.75rem;
+  border-radius: 12px;
   background: white;
-}
-
-.fiber-link-tip-invoice-visual--hero {
-  min-height: 310px;
-}
-
-.fiber-link-tip-invoice-visual--placeholder {
-  min-height: 220px;
+  border: 1px solid var(--primary-low-mid);
 }
 
 .fiber-link-tip-invoice-qr {
-  width: min(100%, 280px);
+  width: min(100%, 210px);
   height: auto;
   display: block;
 }
 
-.fiber-link-tip-panel__actions {
+.fiber-link-tip-step-card__actions {
   display: flex;
-  align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
+}
+
+.fiber-link-tip-wallet-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--primary-low-mid);
+  text-decoration: none;
+  color: var(--primary-high);
+  background: var(--secondary);
+}
+
+.fiber-link-tip-copy-feedback {
+  color: var(--primary-medium);
+  font-size: 0.82rem;
 }
 
 .fiber-link-tip-advanced-toggle {
@@ -417,40 +223,25 @@
 
 .fiber-link-tip-advanced-panel {
   display: grid;
-  gap: 0.55rem;
-  padding: 0.9rem;
-  border-radius: 14px;
-  background: var(--secondary);
-}
-
-.fiber-link-tip-advanced-panel__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
+  gap: 0.45rem;
+  padding-top: 0.2rem;
 }
 
 .fiber-link-tip-invoice {
   display: block;
-  max-height: 120px;
+  max-height: 110px;
   overflow: auto;
-  padding: 0.7rem;
-  border-radius: 14px;
-  background: white;
+  padding: 0.55rem;
+  border-radius: 10px;
+  background: var(--secondary);
+  border: 1px solid var(--primary-low-mid);
   font-size: 0.78rem;
   line-height: 1.35;
 }
 
-.fiber-link-tip-wallet-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.65rem 0.95rem;
-  border-radius: 999px;
-  text-decoration: none;
-}
-
-.fiber-link-tip-wallet-link--primary {
-  min-width: 190px;
+.fiber-link-tip-status-row {
+  display: grid;
+  gap: 0.4rem;
 }
 
 .fiber-link-tip-status-badge,
@@ -486,86 +277,9 @@
   color: #8a6b00;
 }
 
-.fiber-link-tip-status-badge.is-info,
-.fiber-link-status-badge.is-info,
 .fiber-link-status-badge.is-liquidity-pending {
   background: color-mix(in srgb, var(--tertiary) 14%, white 86%);
   color: var(--tertiary);
-}
-
-.fiber-link-tip-success-mark {
-  width: 74px;
-  height: 74px;
-  margin: 0 auto;
-  display: grid;
-  place-items: center;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--success-low) 78%, white 22%);
-  color: var(--success);
-  font-size: 2rem;
-  font-weight: 700;
-}
-
-.fiber-link-tip-confirmed-summary {
-  display: grid;
-  gap: 0.35rem;
-  color: var(--primary-medium);
-  justify-items: center;
-  text-align: center;
-}
-
-.fiber-link-tip-confirmed-summary p {
-  margin: 0;
-}
-
-.fiber-link-tip-footer {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.fiber-link-tip-footer__secondary,
-.fiber-link-tip-footer__primary {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-}
-
-@media (max-width: 900px) {
-  .fiber-link-tip-modal .d-modal__container {
-    max-width: 680px;
-  }
-
-  .fiber-link-tip-modal__grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 600px) {
-  .fiber-link-tip-stepper {
-    grid-template-columns: 1fr;
-  }
-
-  .fiber-link-tip-summary,
-  .fiber-link-tip-panel {
-    padding: 0.85rem;
-    border-radius: 16px;
-  }
-
-  .fiber-link-tip-footer {
-    flex-direction: column-reverse;
-    align-items: stretch;
-  }
-
-  .fiber-link-tip-footer__secondary,
-  .fiber-link-tip-footer__primary,
-  .fiber-link-tip-panel__actions,
-  .fiber-link-tip-advanced-panel__actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
 }
 
 .fiber-link-dashboard {
@@ -813,5 +527,844 @@
   .fiber-link-tip-feed-table {
     display: block;
     overflow-x: auto;
+  }
+}
+
+/* Fiber Link polished dashboard + payment dialog pass, aligned with May 2026 design mockups. */
+.fiber-link-user-menu-dashboard a {
+  color: var(--primary);
+}
+
+.fiber-link-tip-modal .d-modal__container {
+  max-width: 720px;
+  border-radius: 22px;
+}
+
+.fiber-link-tip-modal .d-modal__body {
+  padding: 1.35rem 1.6rem;
+}
+
+.fiber-link-tip-modal .d-modal__footer {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding: 1rem 1.6rem;
+  border-top: 1px solid var(--primary-low);
+}
+
+.fiber-link-tip-footer-primary {
+  min-width: 220px;
+  justify-content: center;
+}
+
+.fiber-link-tip-modal__content {
+  gap: 1.1rem;
+}
+
+.fiber-link-tip-modal__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem 1.5rem;
+  align-items: end;
+  padding-bottom: 0.95rem;
+  border-bottom: 1px solid var(--primary-low-mid);
+}
+
+.fiber-link-tip-modal__recipient-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.fiber-link-tip-modal__avatar {
+  display: inline-grid;
+  place-items: center;
+  width: 2.8rem;
+  height: 2.8rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #f0e9ff, #dcd2ff);
+  color: var(--primary-high);
+  font-weight: 800;
+  font-size: 1.2rem;
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--tertiary) 24%, transparent);
+}
+
+.fiber-link-tip-modal__recipient-name {
+  font-size: 1.35rem;
+}
+
+.fiber-link-tip-modal__copy-recipient {
+  color: var(--primary-medium);
+  min-height: 2rem;
+}
+
+.fiber-link-tip-modal__amount-hero {
+  text-align: right;
+}
+
+.fiber-link-tip-modal__amount {
+  font-size: 2.9rem;
+  color: var(--tertiary);
+  letter-spacing: -0.04em;
+}
+
+.fiber-link-tip-modal__amount-label,
+.fiber-link-tip-help,
+.fiber-link-tip-character-count {
+  color: var(--primary-medium);
+  font-size: 0.86rem;
+}
+
+.fiber-link-tip-modal__receive-note {
+  grid-column: 2;
+  margin: 0;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  color: var(--success);
+  background: color-mix(in srgb, var(--success-low) 65%, white 35%);
+  border: 1px solid color-mix(in srgb, var(--success) 18%, transparent);
+  font-size: 0.9rem;
+}
+
+.fiber-link-tip-step-card {
+  gap: 1rem;
+  border-radius: 18px;
+  padding: 1.25rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--secondary) 94%, var(--tertiary) 6%) 0%,
+    var(--secondary) 100%
+  );
+  box-shadow: 0 16px 38px color-mix(in srgb, var(--primary) 6%, transparent);
+}
+
+.fiber-link-tip-step-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.fiber-link-tip-step-card__eyebrow {
+  display: inline-flex;
+  width: fit-content;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tertiary) 12%, white 88%);
+  color: var(--tertiary);
+  font-weight: 700;
+  font-size: 0.88rem;
+}
+
+.fiber-link-tip-step-card__header h3 {
+  margin-top: 0.7rem;
+  font-size: 1.55rem;
+}
+
+.fiber-link-tip-step-card__caption {
+  margin-top: 0.35rem;
+  font-size: 1rem;
+}
+
+.fiber-link-tip-step-card__icon {
+  display: grid;
+  place-items: center;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tertiary) 12%, white 88%);
+  color: var(--tertiary);
+  font-size: 2rem;
+}
+
+.fiber-link-tip-amount-input-wrap {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 74px;
+  border: 1px solid var(--tertiary);
+  border-radius: 12px;
+  overflow: hidden;
+  background: white;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--tertiary) 8%, transparent);
+}
+
+.fiber-link-tip-amount-input-wrap .fiber-link-tip-input {
+  border: 0;
+  border-radius: 0;
+  font-size: 1.15rem;
+}
+
+.fiber-link-tip-amount-input-wrap span {
+  display: grid;
+  place-items: center;
+  border-left: 1px solid var(--primary-low-mid);
+  color: var(--primary-medium);
+  font-weight: 700;
+}
+
+.fiber-link-tip-quick-amounts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.fiber-link-tip-quick-amount {
+  border: 1px solid var(--primary-low-mid);
+  border-radius: 12px;
+  padding: 0.7rem 0.9rem;
+  background: var(--secondary);
+  color: var(--primary-high);
+  font-weight: 700;
+}
+
+.fiber-link-tip-quick-amount.is-selected {
+  border-color: var(--tertiary);
+  color: var(--tertiary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--tertiary) 10%, transparent);
+}
+
+.fiber-link-tip-textarea-wrap {
+  position: relative;
+}
+
+.fiber-link-tip-textarea {
+  min-height: 112px;
+  padding-bottom: 2rem;
+}
+
+.fiber-link-tip-character-count {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.6rem;
+}
+
+.fiber-link-tip-invoice-visual {
+  max-width: 360px;
+  margin-inline: auto;
+  padding: 1.1rem;
+  border-radius: 18px;
+  box-shadow: 0 12px 30px color-mix(in srgb, var(--primary) 10%, transparent);
+}
+
+.fiber-link-tip-invoice-qr {
+  width: min(100%, 280px);
+}
+
+.fiber-link-tip-status-row {
+  justify-items: center;
+}
+
+.fiber-link-tip-status-badge.is-info,
+.fiber-link-status-badge.is-info {
+  background: color-mix(in srgb, var(--tertiary) 12%, white 88%);
+  color: var(--tertiary);
+}
+
+.fiber-link-tip-step-card__actions {
+  justify-content: center;
+}
+
+.fiber-link-tip-wallet-link {
+  border-color: var(--tertiary);
+  background: var(--tertiary);
+  color: var(--secondary);
+  padding-inline: 1.25rem;
+}
+
+.fiber-link-dashboard {
+  max-width: 1180px;
+  gap: 1.35rem;
+}
+
+.fiber-link-dashboard__topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid var(--primary-low);
+}
+
+.fiber-link-dashboard__brand,
+.fiber-link-dashboard__refresh {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.fiber-link-dashboard__brand {
+  font-size: 1.25rem;
+}
+
+.fiber-link-dashboard__brand-icon {
+  color: var(--tertiary);
+}
+
+.fiber-link-dashboard__refresh span,
+.fiber-link-dashboard__metric-caption {
+  color: var(--primary-medium);
+  font-size: 0.82rem;
+}
+
+.fiber-link-dashboard__refresh strong {
+  padding: 0.35rem 0.55rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--tertiary) 10%, white 90%);
+  color: var(--tertiary);
+  font-size: 0.82rem;
+}
+
+.fiber-link-dashboard__metric-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 3.3rem minmax(0, 1fr);
+  gap: 0.15rem 0.9rem;
+  padding: 1.25rem;
+  border-radius: 14px;
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--primary) 5%, transparent);
+}
+
+.fiber-link-dashboard__metric-icon {
+  grid-row: span 3;
+  display: grid;
+  place-items: center;
+  width: 3.1rem;
+  height: 3.1rem;
+  border-radius: 50%;
+  font-weight: 800;
+  font-size: 1.45rem;
+  background: color-mix(in srgb, var(--tertiary) 12%, white 88%);
+  color: var(--tertiary);
+}
+
+.fiber-link-dashboard__metric-card.is-pending
+  .fiber-link-dashboard__metric-icon {
+  background: #fff4df;
+  color: #d98600;
+}
+
+.fiber-link-dashboard__metric-card.is-completed
+  .fiber-link-dashboard__metric-icon {
+  background: var(--success-low);
+  color: var(--success);
+}
+
+.fiber-link-dashboard__metric-card.is-failed
+  .fiber-link-dashboard__metric-icon {
+  background: var(--danger-low);
+  color: var(--danger);
+}
+
+.fiber-link-dashboard__metric-value,
+.fiber-link-dashboard__metric-caption {
+  margin: 0;
+}
+
+.fiber-link-dashboard__content-grid {
+  grid-template-columns: minmax(300px, 370px) minmax(0, 1fr);
+  gap: 1.25rem;
+}
+
+.fiber-link-dashboard__activity,
+.fiber-link-dashboard__withdrawal {
+  border-radius: 16px;
+  box-shadow: 0 12px 34px color-mix(in srgb, var(--primary) 5%, transparent);
+}
+
+.fiber-link-tip-feed-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 0.8rem;
+}
+
+.fiber-link-filter-group {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.fiber-link-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--primary-low-mid);
+  border-radius: 8px;
+  padding: 0.48rem 0.65rem;
+  background: var(--secondary);
+  color: var(--primary);
+  font-weight: 650;
+  font-size: 0.82rem;
+}
+
+.fiber-link-filter-chip.is-active {
+  background: color-mix(in srgb, var(--tertiary) 9%, white 91%);
+  border-color: color-mix(in srgb, var(--tertiary) 18%, var(--primary-low-mid));
+  color: var(--tertiary);
+}
+
+.fiber-link-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: var(--primary-medium);
+}
+
+.fiber-link-dot.is-received {
+  background: var(--success);
+}
+.fiber-link-dot.is-sent {
+  background: var(--tertiary);
+}
+.fiber-link-dot.is-pending {
+  background: #d98600;
+}
+.fiber-link-dot.is-failed {
+  background: var(--danger);
+}
+
+.fiber-link-tip-feed-search input {
+  min-width: 190px;
+  border: 1px solid var(--primary-low-mid);
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+}
+
+.fiber-link-direction-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 8px;
+  padding: 0.32rem 0.58rem;
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.fiber-link-direction-badge.is-received {
+  background: var(--success-low);
+  color: var(--success);
+}
+
+.fiber-link-direction-badge.is-sent {
+  background: color-mix(in srgb, var(--tertiary) 10%, white 90%);
+  color: var(--tertiary);
+}
+
+.fiber-link-tip-feed-summary {
+  margin: 0.85rem 0 0;
+  color: var(--primary-medium);
+  font-size: 0.86rem;
+}
+
+@media (max-width: 760px) {
+  .fiber-link-tip-modal__header,
+  .fiber-link-tip-modal__receive-note {
+    display: block;
+    grid-column: auto;
+    text-align: left;
+  }
+
+  .fiber-link-tip-modal__amount-hero {
+    text-align: left;
+    margin-top: 1rem;
+  }
+
+  .fiber-link-tip-feed-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
+/* Fiber Link shadcn-inspired control polish pass: buttons, inputs, activity toolbar. */
+.fiber-link-tip-modal button,
+.fiber-link-tip-modal .btn,
+.fiber-link-dashboard button,
+.fiber-link-dashboard .btn,
+.fiber-link-tip-feed-toolbar button,
+.fiber-link-tip-feed-toolbar input,
+.fiber-link-tip-input,
+.fiber-link-dashboard__withdrawal-input {
+  font: inherit;
+}
+
+.fiber-link-tip-modal button,
+.fiber-link-tip-modal .btn,
+.fiber-link-tip-modal a.btn,
+.fiber-link-dashboard button,
+.fiber-link-dashboard .btn,
+.fiber-link-tip-feed-toolbar button {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 2.25rem;
+  border: 1px solid var(--primary-low-mid);
+  border-radius: 10px;
+  background: var(--secondary);
+  color: var(--primary-high);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--primary) 8%, transparent);
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.fiber-link-tip-modal button:hover,
+.fiber-link-tip-modal .btn:hover,
+.fiber-link-tip-modal a.btn:hover,
+.fiber-link-dashboard button:hover,
+.fiber-link-dashboard .btn:hover,
+.fiber-link-tip-feed-toolbar button:hover {
+  border-color: color-mix(in srgb, var(--tertiary) 24%, var(--primary-low-mid));
+  background: color-mix(in srgb, var(--primary-low) 56%, var(--secondary) 44%);
+  color: var(--primary-high);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--primary) 9%, transparent);
+  transform: translateY(-1px);
+}
+
+.fiber-link-tip-modal button:focus-visible,
+.fiber-link-tip-modal .btn:focus-visible,
+.fiber-link-tip-modal a.btn:focus-visible,
+.fiber-link-dashboard button:focus-visible,
+.fiber-link-dashboard .btn:focus-visible,
+.fiber-link-tip-feed-toolbar button:focus-visible,
+.fiber-link-tip-feed-toolbar input:focus-visible,
+.fiber-link-tip-input:focus-visible,
+.fiber-link-dashboard__withdrawal-input:focus-visible {
+  outline: 0;
+  border-color: var(--tertiary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--tertiary) 18%, transparent);
+}
+
+.fiber-link-tip-modal button:disabled,
+.fiber-link-tip-modal .btn:disabled,
+.fiber-link-dashboard button:disabled,
+.fiber-link-dashboard .btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+  transform: none;
+  box-shadow: none;
+}
+
+.fiber-link-tip-modal .btn-primary,
+.fiber-link-dashboard .btn-primary,
+.fiber-link-tip-wallet-link {
+  border-color: color-mix(in srgb, var(--tertiary) 82%, black 18%);
+  background: var(--tertiary);
+  color: var(--secondary);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--tertiary) 20%, transparent);
+}
+
+.fiber-link-tip-modal .btn-primary:hover,
+.fiber-link-dashboard .btn-primary:hover,
+.fiber-link-tip-wallet-link:hover {
+  border-color: color-mix(in srgb, var(--tertiary) 74%, black 26%);
+  background: color-mix(in srgb, var(--tertiary) 90%, black 10%);
+  color: var(--secondary);
+}
+
+.fiber-link-tip-modal .btn-link,
+.fiber-link-dashboard .btn-link {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+  color: var(--tertiary);
+}
+
+.fiber-link-tip-modal .btn-link:hover,
+.fiber-link-dashboard .btn-link:hover {
+  background: color-mix(in srgb, var(--tertiary) 8%, transparent);
+  box-shadow: none;
+}
+
+.fiber-link-filter-chip {
+  min-height: 2.15rem;
+  border-radius: 999px;
+  padding: 0.36rem 0.56rem;
+  background: color-mix(in srgb, var(--secondary) 94%, var(--primary-low) 6%);
+  font-weight: 600;
+  font-size: 0.78rem;
+}
+
+.fiber-link-filter-chip.is-active {
+  background: var(--primary-high);
+  border-color: var(--primary-high);
+  color: var(--secondary);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--primary) 12%, transparent);
+}
+
+.fiber-link-filter-chip.is-active .fiber-link-dot {
+  background: currentColor;
+}
+
+.fiber-link-tip-quick-amount {
+  min-height: 2.65rem;
+  border-radius: 12px;
+  background: var(--secondary);
+}
+
+.fiber-link-tip-quick-amount.is-selected {
+  background: color-mix(in srgb, var(--tertiary) 10%, var(--secondary) 90%);
+  border-color: var(--tertiary);
+  color: var(--tertiary);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--tertiary) 36%, transparent),
+    0 6px 16px color-mix(in srgb, var(--tertiary) 10%, transparent);
+}
+
+.fiber-link-tip-input,
+.fiber-link-dashboard__withdrawal-input,
+.fiber-link-tip-feed-search input {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--primary-low-mid);
+  border-radius: 10px;
+  background: var(--secondary);
+  color: var(--primary-high);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--primary) 5%, transparent);
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    background-color 140ms ease;
+}
+
+.fiber-link-dashboard__activity {
+  padding: 1rem;
+}
+
+.fiber-link-tip-feed-toolbar {
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) minmax(160px, 200px);
+  gap: 0.55rem;
+  align-items: start;
+  padding: 0.65rem;
+  margin-bottom: 0.9rem;
+  border: 1px solid var(--primary-low);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--primary-low) 28%, var(--secondary) 72%);
+}
+
+.fiber-link-filter-group {
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.fiber-link-tip-feed-search-shell {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.fiber-link-tip-feed-search {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+.fiber-link-tip-feed-search__icon {
+  position: absolute;
+  left: 0.78rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--primary-medium);
+  font-size: 1rem;
+  pointer-events: none;
+}
+
+.fiber-link-tip-feed-search input {
+  width: 100%;
+  min-width: 0;
+  height: 2.35rem;
+  padding: 0.5rem 0.75rem 0.5rem 2.15rem;
+}
+
+.fiber-link-tip-feed-table th {
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 760px) {
+  .fiber-link-tip-feed-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .fiber-link-tip-feed-search-shell {
+    justify-content: stretch;
+  }
+}
+
+/* Fiber Link confirmed compact dashboard + dropdown activity pass. */
+.fiber-link-dashboard__metrics.is-compact {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.fiber-link-dashboard__metrics.is-compact .fiber-link-dashboard__metric-card {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.8rem;
+  min-height: 5rem;
+  padding: 1rem 1.15rem;
+}
+
+.fiber-link-dashboard__metrics.is-compact .fiber-link-dashboard__metric-icon {
+  grid-row: auto;
+  width: 2.75rem;
+  height: 2.75rem;
+  font-size: 1.25rem;
+}
+
+.fiber-link-dashboard__metrics.is-compact .fiber-link-dashboard__metric-value {
+  margin: 0;
+  font-size: 1.35rem;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.fiber-link-tip-feed-toolbar {
+  grid-template-columns: minmax(190px, 260px) minmax(0, 1fr);
+  align-items: center;
+}
+
+.fiber-link-filter-select-shell {
+  display: grid;
+  gap: 0.35rem;
+  width: min(100%, 260px);
+}
+
+.fiber-link-filter-select-label {
+  color: var(--primary-medium);
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.fiber-link-filter-select-wrap {
+  position: relative;
+  display: block;
+}
+
+.fiber-link-filter-select {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  min-height: 2.4rem;
+  border: 1px solid var(--primary-low-mid);
+  border-radius: 10px;
+  padding: 0.55rem 2.2rem 0.55rem 0.75rem;
+  background: var(--secondary);
+  color: transparent;
+  font: inherit;
+  font-weight: 650;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--primary) 5%, transparent);
+  cursor: pointer;
+}
+
+.fiber-link-filter-select:focus-visible {
+  outline: 0;
+  border-color: var(--tertiary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--tertiary) 18%, transparent);
+}
+
+.fiber-link-filter-select-current {
+  position: absolute;
+  inset: 0 2.2rem 0 0.75rem;
+  display: flex;
+  align-items: center;
+  color: var(--primary-high);
+  font-weight: 650;
+  pointer-events: none;
+}
+
+.fiber-link-filter-select-chevron {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--primary-medium);
+  pointer-events: none;
+}
+
+.fiber-link-tip-feed-table.is-icon-first {
+  table-layout: auto;
+}
+
+.fiber-link-tip-feed-table.is-icon-first th:first-child,
+.fiber-link-tip-feed-table.is-icon-first td:first-child {
+  width: 4.25rem;
+  text-align: center;
+}
+
+.fiber-link-direction-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 1rem;
+  line-height: 1;
+  border: 1px solid transparent;
+}
+
+.fiber-link-direction-icon.is-received {
+  background: var(--success-low);
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 20%, transparent);
+}
+
+.fiber-link-direction-icon.is-sent {
+  background: color-mix(in srgb, var(--tertiary) 10%, white 90%);
+  color: var(--tertiary);
+  border-color: color-mix(in srgb, var(--tertiary) 18%, transparent);
+}
+
+.fiber-link-direction-icon.is-withdrawn {
+  background: color-mix(in srgb, var(--primary-high) 8%, white 92%);
+  color: var(--primary-high);
+  border-color: color-mix(in srgb, var(--primary-high) 16%, transparent);
+}
+
+.fiber-link-status-badge {
+  padding: 0.28rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 650;
+  box-shadow: none;
+}
+
+.fiber-link-status-badge.is-info {
+  background: #fff7e8;
+  color: #a96700;
+}
+
+.fiber-link-status-badge.is-success {
+  background: color-mix(in srgb, var(--success-low) 75%, white 25%);
+  color: var(--success);
+}
+
+.fiber-link-status-badge.is-danger {
+  background: color-mix(in srgb, var(--danger-low) 78%, white 22%);
+  color: var(--danger);
+}
+
+@media (max-width: 900px) {
+  .fiber-link-dashboard__metrics.is-compact {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .fiber-link-tip-feed-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .fiber-link-filter-select-shell {
+    width: 100%;
   }
 }

--- a/fiber-link-discourse-plugin/config/locales/client.en.yml
+++ b/fiber-link-discourse-plugin/config/locales/client.en.yml
@@ -5,6 +5,8 @@ en:
         fiber_link:
           tip_received_notification: "received a tip"
     fiber_link:
+      dashboard:
+        user_menu_link: "Fiber Link Dashboard"
       tip_received_notification: "<p><span>%{username}</span> tipped you <span>%{amount} %{asset}</span>.</p>"
       notification:
         title: "you received a tip"

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
@@ -53,7 +53,22 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
 
     runtime = page.evaluate_script("window.__fiberLinkRuntime")
     expect(runtime).to include("initialized" => true, "rpcPath" => "/fiber-link/rpc")
-    expect(page).to have_content("Fiber Link Dashboard")
+    expect(page).to have_content("Fiber Link Dashboard.")
+  end
+
+  it "links to the dashboard from the user menu profile panel" do
+    visit "/"
+
+    find(".d-header-icons .current-user button").click
+    find("#user-menu-button-profile").click
+
+    within("#quick-access-profile") do
+      expect(page).to have_css(
+        "li.fiber-link-user-menu-dashboard a[href$='/fiber-link']",
+        text: "Fiber Link Dashboard",
+      )
+      expect(page).to have_css("li.fiber-link-user-menu-dashboard .d-icon-gift")
+    end
   end
 
   it "shows finance summary cards and payments activity" do
@@ -115,22 +130,37 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
 
     visit "/fiber-link"
 
-    expect(page).to have_css(".fiber-link-dashboard__metrics.is-compact")
+    expect(page).to have_css(".fiber-link-dashboard__metrics")
+    expect(page).to have_content("Fiber Link Dashboard.")
+    expect(page).to have_content("Live · synced 2s ago")
     expect(page).to have_content("12.5 CKB")
-    expect(page).to have_content("1 Payments")
-    expect(page).to have_content("2 Payments")
-    expect(page).to have_no_content("Failed payments")
-    expect(page).to have_content("Recent Activity")
+    expect(page).to have_content("AVAILABLE BALANCE")
+    expect(page).to have_content("Available to withdraw")
+    within(".fiber-link-dashboard__metric.is-pending") do
+      expect(page).to have_content("4")
+      expect(page).to have_content("CKB")
+    end
+    expect(page).to have_content("Completed")
+    expect(page).to have_content("1 invoice awaiting settlement")
+    expect(page).to have_content("Successful payments · 30d")
+    expect(page).to have_content("Requires attention")
+    expect(page).to have_content("All transactions.")
     expect(page).to have_content("Auto-refresh")
-    expect(page).to have_content("Every 10s")
+    refresh_select = find(".fiber-link-dashboard__refresh-select select")
+    expect(refresh_select.value).to eq("10000")
+    refresh_select.find("option", text: "30s").select_option
+    expect(find(".fiber-link-dashboard__refresh-select select").value).to eq("30000")
     expect(page).to have_content("@fiber_tipper")
-    expect(page).to have_content("User")
-    expect(page).to have_select("Activity filter", selected: "All Activity")
+    expect(page).to have_content("USER")
+    expect(page).to have_button("All 2")
+    expect(page).to have_button("Received 1")
+    expect(page).to have_button("Sent 1")
+    expect(page).to have_css("input[placeholder='Search user...']")
     expect(page).to have_content("Completed")
     expect(page).to have_content("Completed")
-    expect(page).to have_content("1 hour ago")
     expect(page).to have_content("Great post")
     expect(page).to have_content("Nice reply")
+    expect(page).to have_no_link("View full ledger")
   end
 
   it "keeps visible data stable while background polling refreshes" do
@@ -231,7 +261,11 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
     visit "/fiber-link"
 
     expect(page).to have_content("12.5 CKB")
-    expect(page).to have_content("1 Payments")
+    within(".fiber-link-dashboard__metric.is-pending") do
+      expect(page).to have_content("31")
+      expect(page).to have_content("CKB")
+    end
+    expect(page).to have_content("1 invoice awaiting settlement")
 
     Timeout.timeout(16) do
       loop do
@@ -242,7 +276,7 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
 
     expect(page).to have_no_content("Loading…", wait: 0)
     expect(page).to have_content("99 CKB")
-    expect(page).to have_content("1 Payments")
+    expect(page).to have_content("Completed")
   end
 
   it "shows a friendly empty state with no admin section" do
@@ -327,23 +361,52 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
 
     visit "/fiber-link"
 
-    expect(page).to have_content("Withdraw")
+    expect(page).to have_content("Move your settled CKB.")
+    expect(page).to have_content("Minimum withdrawal is 61 CKB.")
+    expect(page).to have_button("25%")
+    expect(page).to have_button("50%")
+    expect(page).to have_button("75%")
+    expect(page).to have_button("Max · 124")
+    expect(page).to have_no_content("Enter a valid CKB withdrawal address.")
+    expect(page).to have_button("Request withdrawal", disabled: true)
+
+    click_button "25%"
+    expect(find("[data-fiber-link-withdrawal-input='amount']").value).to eq("61")
+    click_button "75%"
+    expect(find("[data-fiber-link-withdrawal-input='amount']").value).to eq("93")
+    click_button "Max · 124"
+    expect(find("[data-fiber-link-withdrawal-input='amount']").value).to eq("124")
+
     fill_in "Amount", with: "61"
-    fill_in "Destination Address", with: "ckt1qyqg5xa84dfwfy76tptw2sy0k9q98xaeka9q5tvdlm"
+
+    page.execute_script(<<~JS)
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { readText: () => Promise.reject(new Error("denied")) },
+      });
+    JS
+    click_button "Paste"
+    expect(page).to have_content("Clipboard access failed. Paste manually.")
+
+    find("[data-fiber-link-withdrawal-input='address']").set(
+      "ckt1qyqg5xa84dfwfy76tptw2sy0k9q98xaeka9q5tvdlm",
+    )
 
     expect(page).to have_content("Available")
     expect(page).to have_content("124 CKB")
-    expect(page).to have_content("Locked")
+    expect(page).to have_content("LOCKED")
     expect(page).to have_content("61 CKB")
-    expect(page).to have_content("Network fee")
+    expect(page).to have_content("NETWORK FEE")
     expect(page).to have_content("0.00001 CKB")
-    expect(page).to have_content("You receive")
+    expect(page).to have_content("YOU RECEIVE")
     expect(page).to have_content("Address valid")
+    expect(page).to have_button("Request withdrawal", disabled: false)
 
-    click_button "Request Withdrawal"
+    click_button "Request withdrawal"
 
-    expect(page).to have_content("Requested withdrawal wd-1")
-    expect(page).to have_content("PENDING")
+    expect(page).to have_css(".fk-d-toast", text: "Requested withdrawal wd-1")
+    expect(page).to have_no_css("[data-fiber-link-withdrawal-result='success']")
+    expect(page).to have_css("[data-fiber-link-withdrawal-result='id']", text: "wd-1")
 
     expect(WebMock).to have_requested(:post, "https://fiber-link.example/rpc").with { |request|
       body = JSON.parse(request.body)
@@ -412,11 +475,13 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
     visit "/fiber-link"
 
     fill_in "Amount", with: "61"
-    fill_in "Destination Address", with: "ckt1qyqg5xa84dfwfy76tptw2sy0k9q98xaeka9q5tvdlm"
-    click_button "Request Withdrawal"
+    find("[data-fiber-link-withdrawal-input='address']").set(
+      "ckt1qyqg5xa84dfwfy76tptw2sy0k9q98xaeka9q5tvdlm",
+    )
+    click_button "Request withdrawal"
 
-    expect(page).to have_content("Withdrawal queued until liquidity is available.")
-    expect(page).to have_content("Liquidity Pending")
-    expect(page).to have_content("Requested withdrawal wd-liquidity")
+    expect(page).to have_css(".fk-d-toast", text: "Withdrawal queued until liquidity is available.")
+    expect(page).to have_no_css("[data-fiber-link-withdrawal-result='success']")
+    expect(page).to have_css("[data-fiber-link-withdrawal-result='id']", text: "wd-liquidity")
   end
 end

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
@@ -92,6 +92,20 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
                 createdAt: "2026-02-16T00:00:00.000Z",
                 settledAt: "2026-02-16T00:05:00.000Z",
               },
+              {
+                id: "tip-live-2",
+                invoice: "inv-live-2",
+                postId: "p2",
+                amount: "5",
+                asset: "CKB",
+                state: "SETTLED",
+                direction: "OUT",
+                counterpartyUserId: tipper.id.to_s,
+                counterpartyUsername: tipper.username,
+                message: "Nice reply",
+                createdAt: "2026-02-16T00:10:00.000Z",
+                settledAt: "2026-02-16T00:11:00.000Z",
+              },
             ],
             generatedAt: "2026-02-16T01:00:00.000Z",
           ),
@@ -101,18 +115,22 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
 
     visit "/fiber-link"
 
-    expect(page).to have_content("Balance")
-    expect(page).to have_content("Pending")
-    expect(page).to have_content("Completed")
-    expect(page).to have_content("Failed")
+    expect(page).to have_css(".fiber-link-dashboard__metrics.is-compact")
     expect(page).to have_content("12.5 CKB")
-    expect(page).to have_content("4 CKB")
-    expect(page).to have_content("Payments")
-    expect(page).to have_content("Auto-refresh every 10s")
+    expect(page).to have_content("1 Payments")
+    expect(page).to have_content("2 Payments")
+    expect(page).to have_no_content("Failed payments")
+    expect(page).to have_content("Recent Activity")
+    expect(page).to have_content("Auto-refresh")
+    expect(page).to have_content("Every 10s")
     expect(page).to have_content("@fiber_tipper")
-    expect(page).to have_content("Incoming")
+    expect(page).to have_content("User")
+    expect(page).to have_select("Activity filter", selected: "All Activity")
+    expect(page).to have_content("Completed")
+    expect(page).to have_content("Completed")
     expect(page).to have_content("1 hour ago")
     expect(page).to have_content("Great post")
+    expect(page).to have_content("Nice reply")
   end
 
   it "keeps visible data stable while background polling refreshes" do
@@ -213,7 +231,7 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
     visit "/fiber-link"
 
     expect(page).to have_content("12.5 CKB")
-    expect(page).to have_content("Pending")
+    expect(page).to have_content("1 Payments")
 
     Timeout.timeout(16) do
       loop do
@@ -224,7 +242,7 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
 
     expect(page).to have_no_content("Loading…", wait: 0)
     expect(page).to have_content("99 CKB")
-    expect(page).to have_content("Payment received")
+    expect(page).to have_content("1 Payments")
   end
 
   it "shows a friendly empty state with no admin section" do
@@ -318,6 +336,7 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
     expect(page).to have_content("Locked")
     expect(page).to have_content("61 CKB")
     expect(page).to have_content("Network fee")
+    expect(page).to have_content("0.00001 CKB")
     expect(page).to have_content("You receive")
     expect(page).to have_content("Address valid")
 

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe "Fiber Link Tip", type: :system do
   fab!(:user)
   fab!(:author) { Fabricate(:user) }
   fab!(:topic) { Fabricate(:topic_with_op, user: author) }
+  fab!(:reply) do
+    Fabricate(
+      :post,
+      topic: topic,
+      user: author,
+      raw: "Reply tip context should appear in the payment dialog.",
+    )
+  end
 
   before do
     SiteSetting.fiber_link_enabled = true
@@ -16,7 +24,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
     sign_in(user)
   end
 
-  it "shows a single-step payment flow that advances from generate to pay to confirmed" do
+  it "shows a compact two-step payment flow that advances from amount to pay to confirmed" do
     stub_request(:post, "https://fiber-link.example/rpc")
       .with { |request| JSON.parse(request.body).fetch("method") == "tip.create" }
       .to_return(
@@ -24,7 +32,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
         body: {
           jsonrpc: "2.0",
           id: "1",
-          result: { invoice: "inv-tip-1" },
+          result: { invoice: "inv-tip-1", invoiceQrDataUrl: "data:image/png;base64,ZmliZXItbGluaw==" },
         }.to_json,
         headers: { "Content-Type" => "application/json" },
       )
@@ -39,7 +47,22 @@ RSpec.describe "Fiber Link Tip", type: :system do
         },
         {
           status: 200,
-          body: { jsonrpc: "2.0", id: "3", result: { state: "SETTLED" } }.to_json,
+          body: { jsonrpc: "2.0", id: "3", result: { state: "UNPAID" } }.to_json,
+          headers: { "Content-Type" => "application/json" },
+        },
+        {
+          status: 200,
+          body: { jsonrpc: "2.0", id: "4", result: { state: "UNPAID" } }.to_json,
+          headers: { "Content-Type" => "application/json" },
+        },
+        {
+          status: 200,
+          body: { jsonrpc: "2.0", id: "5", result: { state: "UNPAID" } }.to_json,
+          headers: { "Content-Type" => "application/json" },
+        },
+        {
+          status: 200,
+          body: { jsonrpc: "2.0", id: "6", result: { state: "SETTLED" } }.to_json,
           headers: { "Content-Type" => "application/json" },
         },
       )
@@ -49,34 +72,78 @@ RSpec.describe "Fiber Link Tip", type: :system do
     expect(page).to have_no_css(".topic-above-post-stream-outlet [data-fiber-link-tip-button]")
     click_button "Tip", match: :first
 
-    expect(page).to have_content("Pay with Fiber")
-    expect(page).to have_content("Pay 1 CKB")
-    expect(page).to have_content("to @#{topic.first_post.user.username}")
+    expect(page).to have_content("SEND A TIP")
+    expect(page).to have_content("1 CKB")
+    expect(page).to have_content("Tipping")
+    expect(page).to have_content("@#{topic.first_post.user.username}")
+    within("[data-fiber-link-tip-modal='recipient']") do
+      expect(page).to have_css("img[data-fiber-link-tip-modal='recipient-avatar']")
+      expect(page).to have_content("@#{topic.first_post.user.username}")
+      expect(page).to have_content("RECIPIENT · VERIFIED 2D AGO")
+      expect(page).to have_content("Receives")
+      expect(page).to have_content("1CKB")
+    end
     expect(page).to have_css("img[data-fiber-link-tip-modal='brand-logo']")
-    expect(page).to have_link("Fiber Link", href: "https://fiberlink.me/")
+    expect(page).to have_link("Fiber Link", href: "https://www.fiberlink.me")
+    expect(page).to have_css(
+      "a[data-fiber-link-tip-modal='brand-link'][href='https://www.fiberlink.me'][target='_blank']",
+    )
     expect(page).to have_css("[data-fiber-link-tip-modal='summary']")
+    within("[data-fiber-link-tip-modal='summary']") do
+      expect(page).to have_content("TOPIC")
+      expect(page).to have_content(topic.title)
+      expect(page).to have_content("NETWORK")
+      expect(page).to have_content("Fiber Link · Mainnet")
+    end
     expect(page).to have_css("[data-fiber-link-tip-modal-step='generate']")
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='pay']")
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='confirmed']")
+    expect(page).to have_content("STEP 01")
+    expect(page).to have_content("OF 02 · AMOUNT")
+    expect(page).to have_css("[data-fiber-link-tip-modal='stepper'] span", count: 2)
+    expect(page).to have_css("[data-fiber-link-tip-modal='stepper'] span.is-active", count: 1)
+    expect(page).to have_no_content("Amount & message")
+    expect(page).to have_no_content("Choose an amount and optionally add a short note.")
+    expect(page).to have_content("AMOUNT")
+    expect(page).to have_no_content("Amount (CKB)")
+    expect(page).to have_css("textarea[placeholder='Leave a short note']")
+    expect(page).to have_no_content("Add reaction")
+    expect(page).to have_no_content("Markdown supported")
+    expect(page).to have_button("1 CKB")
+    expect(page).to have_button("5 CKB")
+    expect(page).to have_button("10 CKB")
 
     fill_in "Amount", with: "31"
-    fill_in "Message (optional)", with: "Great post"
-    click_button "Continue to Payment"
+    expect(page).to have_css(".fiber-link-tip-chip.is-selected", text: "Custom")
+    expect(page).to have_css("button[aria-pressed='true']", text: "Custom")
+    expect(page).to have_css("button[aria-pressed='false']", text: "1 CKB")
+    find("textarea[placeholder='Leave a short note']").set("Great post")
+    click_button "Review & Pay"
 
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='generate']")
     expect(page).to have_css("[data-fiber-link-tip-modal-step='pay']")
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='confirmed']")
+    expect(page).to have_content("STEP 02")
+    expect(page).to have_content("OF 02 · PAY WITH WALLET")
+    expect(page).to have_css("[data-fiber-link-tip-modal='stepper'] span", count: 2)
+    expect(page).to have_css("[data-fiber-link-tip-modal='stepper'] span.is-active", count: 2)
     expect(page).to have_content("31 CKB")
     expect(page).to have_content("Awaiting payment")
-    expect(page).to have_content("Status updates automatically")
+    expect(page).to have_no_content("Status updates automatically")
     expect(page).to have_css("img[data-fiber-link-tip-modal=invoice-qr]")
-    expect(page).to have_button("Copy Invoice")
-    expect(page).to have_link("Open Fiber Wallet", href: "fiber://invoice/inv-tip-1")
-    expect(page).to have_no_text("inv-tip-1")
-
-    click_button "More options"
-    expect(page).to have_text("inv-tip-1")
-    expect(page).to have_button("Check status")
+    expect(page).to have_css("[data-fiber-link-tip-modal='status-spinner']")
+    expect(page).to have_no_css(".fiber-link-tip-progress-dots")
+    expect(page).to have_css("[data-fiber-link-tip-modal='copy-invoice'][title='Copy invoice']")
+    expect(page).to have_css("[data-fiber-link-tip-modal='copy-invoice'] .d-icon-copy")
+    expect(page).to have_no_button("Copy ↗")
+    expect(page).to have_button("Open Fiber Wallet →", disabled: true)
+    expect(page).to have_no_link("Open Fiber Wallet")
+    expect(page).to have_content("INVOICE")
+    expect(page).to have_content("inv-tip-1")
+    expect(page).to have_no_content("Expires in")
+    expect(page).to have_no_button("More options")
+    expect(page).to have_no_content("Payment details")
+    expect(page).to have_no_button("Check status", disabled: :all)
 
     expect(WebMock).to have_requested(:post, "https://fiber-link.example/rpc").with { |request|
       body = JSON.parse(request.body)
@@ -88,13 +155,13 @@ RSpec.describe "Fiber Link Tip", type: :system do
     }
 
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='generate']")
+    expect(page).to have_css("[data-fiber-link-tip-modal-step='confirmed']", wait: 8)
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='pay']")
-    expect(page).to have_css("[data-fiber-link-tip-modal-step='confirmed']")
     expect(page).to have_content("Payment complete")
     expect(page).to have_button("Done")
   end
 
-  it "keeps manual status checks available inside advanced details" do
+  it "keeps pending payments focused on passive status polling" do
     stub_request(:post, "https://fiber-link.example/rpc")
       .with { |request| JSON.parse(request.body).fetch("method") == "tip.create" }
       .to_return(
@@ -102,7 +169,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
         body: {
           jsonrpc: "2.0",
           id: "1",
-          result: { invoice: "inv-tip-2" },
+          result: { invoice: "inv-tip-2", invoiceQrDataUrl: "data:image/png;base64,ZmliZXItbGluaw==" },
         }.to_json,
         headers: { "Content-Type" => "application/json" },
       )
@@ -111,7 +178,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
       .with { |request| JSON.parse(request.body).fetch("method") == "tip.status" }
       .to_return(
         status: 200,
-        body: { jsonrpc: "2.0", id: "2", result: { state: "SETTLED" } }.to_json,
+        body: { jsonrpc: "2.0", id: "2", result: { state: "UNPAID" } }.to_json,
         headers: { "Content-Type" => "application/json" },
       )
 
@@ -121,14 +188,50 @@ RSpec.describe "Fiber Link Tip", type: :system do
     click_button "Tip", match: :first
     expect(page).to have_css("[data-fiber-link-tip-modal-step='generate']")
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='pay']")
-    click_button "Continue to Payment"
+    click_button "Review & Pay"
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='generate']")
     expect(page).to have_css("[data-fiber-link-tip-modal-step='pay']")
-    click_button "More options"
-    click_button "Check status"
 
-    expect(page).to have_no_css("[data-fiber-link-tip-modal-step='pay']")
-    expect(page).to have_css("[data-fiber-link-tip-modal-step='confirmed']")
-    expect(page).to have_content("Payment complete")
+    expect(page).to have_css("[data-fiber-link-tip-modal-step='pay']")
+    expect(page).to have_content("Awaiting payment")
+    expect(page).to have_css("[data-fiber-link-tip-modal='status-spinner']")
+    expect(page).to have_no_button("More options")
+    expect(page).to have_no_content("Payment details")
+    expect(page).to have_no_button("Check status", disabled: :all)
+    expect(page).to have_button("Open Fiber Wallet", disabled: true)
+    expect(page).to have_no_link("Open Fiber Wallet")
+    expect(page).to have_no_content("Expires in")
+
+    page.execute_script(<<~JS)
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText: () => Promise.resolve() },
+      });
+    JS
+
+    find("[data-fiber-link-tip-modal='copy-invoice']").click
+    expect(page).to have_css("[data-fiber-link-tip-modal='copy-invoice'][title='Copied']")
+    expect(page).to have_css("[data-fiber-link-tip-modal='copy-invoice'] .d-icon-check")
+    expect(page).to have_no_content("Copied invoice")
+    expect(page).to have_css("[data-fiber-link-tip-modal='copy-invoice'][title='Copy invoice']", wait: 4)
+    expect(page).to have_css("[data-fiber-link-tip-modal='copy-invoice'] .d-icon-copy")
+  end
+
+  it "labels the context as a reply when opened from a reply tip button" do
+    visit topic.relative_url
+    expect(page).to have_css(
+      ".post-action-menu__fiber-link-tip[data-fiber-link-tip-button='post-menu']",
+      minimum: 2,
+    )
+
+    all(".post-action-menu__fiber-link-tip[data-fiber-link-tip-button='post-menu']").last.click
+
+    within("[data-fiber-link-tip-modal='summary']") do
+      expect(page).to have_content("REPLY CONTEXT")
+      expect(page).to have_content("Reply tip context should appear in the payment dialog.")
+      expect(page).to have_content("NETWORK")
+      expect(page).to have_content("Fiber Link · Mainnet")
+      expect(page).to have_no_content("TOPIC")
+    end
   end
 end

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb
@@ -201,6 +201,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
     expect(page).to have_button("Open Fiber Wallet", disabled: true)
     expect(page).to have_no_link("Open Fiber Wallet")
     expect(page).to have_no_content("Expires in")
+    expect(page).to have_css("[data-fiber-link-tip-modal='invoice-value'][data-fiber-link-invoice='inv-tip-2']")
 
     page.execute_script(<<~JS)
       Object.defineProperty(navigator, "clipboard", {

--- a/scripts/playwright-workflow-author-withdrawal.test.sh
+++ b/scripts/playwright-workflow-author-withdrawal.test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_CODE_FILE="${ROOT_DIR}/scripts/playwright/workflow-author-withdrawal.run-code.js"
+
+grep -q 'data-fiber-link-withdrawal-result="id"' "${RUN_CODE_FILE}"
+
+if grep -q 'data-fiber-link-withdrawal-result="success"' "${RUN_CODE_FILE}"; then
+  echo "author withdrawal workflow should wait for the persisted request id, not the removed success banner" >&2
+  exit 1
+fi

--- a/scripts/playwright-workflow-flow12.test.sh
+++ b/scripts/playwright-workflow-flow12.test.sh
@@ -59,6 +59,7 @@ FNN2_RPC_PORT=9227 \
 
 grep -q '"baseUrl":"http://127.0.0.1:4200"' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 grep -q '"payerRpcUrl":"http://172.17.0.1:9227"' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
+grep -q 'review & pay' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 
 rm -f "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 
@@ -80,3 +81,4 @@ FNN2_RPC_PORT=9227 \
 
 grep -q '"baseUrl":"http://127.0.0.1:4200"' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 grep -q '"payerRpcUrl":"http://127.0.0.1:9227"' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
+grep -q 'review & pay' "${CAPTURE_DIR}/playwright-flow12.run-code.js"

--- a/scripts/playwright-workflow-flow12.test.sh
+++ b/scripts/playwright-workflow-flow12.test.sh
@@ -60,6 +60,7 @@ FNN2_RPC_PORT=9227 \
 grep -q '"baseUrl":"http://127.0.0.1:4200"' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 grep -q '"payerRpcUrl":"http://172.17.0.1:9227"' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 grep -q 'review & pay' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
+grep -q 'invoice-value' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 
 rm -f "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 
@@ -82,3 +83,4 @@ FNN2_RPC_PORT=9227 \
 grep -q '"baseUrl":"http://127.0.0.1:4200"' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 grep -q '"payerRpcUrl":"http://127.0.0.1:9227"' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
 grep -q 'review & pay' "${CAPTURE_DIR}/playwright-flow12.run-code.js"
+grep -q 'invoice-value' "${CAPTURE_DIR}/playwright-flow12.run-code.js"

--- a/scripts/playwright/workflow-author-withdrawal.run-code.js
+++ b/scripts/playwright/workflow-author-withdrawal.run-code.js
@@ -199,7 +199,11 @@ async (page) => {
       throw new Error(`withdrawal.request failed: ${responsePayload.error.message || "unknown error"}`);
     }
 
-    await page.locator('[data-fiber-link-withdrawal-result="success"]').first().waitFor({ timeout: 15_000 });
+    const requestedId = responsePayload?.result?.id ?? "";
+    const requestIdLocator = requestedId
+      ? page.locator('[data-fiber-link-withdrawal-result="id"]', { hasText: requestedId }).first()
+      : page.locator('[data-fiber-link-withdrawal-result="id"]').first();
+    await requestIdLocator.waitFor({ timeout: 15_000 });
 
     return {
       id: responsePayload?.result?.id ?? null,

--- a/scripts/playwright/workflow-flow12.run-code.js
+++ b/scripts/playwright/workflow-flow12.run-code.js
@@ -532,7 +532,7 @@ async (page) => {
 
   await modal.screenshot({ path: tipModalStepGenerateScreenshotPath });
 
-  await page.getByRole("button", { name: /continue to payment|generate invoice/i }).first().click();
+  await page.getByRole("button", { name: /review & pay|continue to payment|generate invoice/i }).first().click();
   await payStep.waitFor({ timeout: 30_000 });
   if (await generateStep.isVisible().catch(() => false)) {
     throw new Error("generate step should not remain visible after invoice generation");

--- a/scripts/playwright/workflow-flow12.run-code.js
+++ b/scripts/playwright/workflow-flow12.run-code.js
@@ -48,6 +48,44 @@ async (page) => {
     return `0x${BigInt(normalized).toString(16)}`;
   }
 
+  async function readGeneratedInvoice(payStep) {
+    const invoiceValue = payStep.locator("[data-fiber-link-tip-modal='invoice-value']").first();
+    const invoiceFromValue = await invoiceValue
+      .waitFor({ timeout: 30_000 })
+      .then(async () => {
+        const dataInvoice = (await invoiceValue.getAttribute("data-fiber-link-invoice"))?.trim() ?? "";
+        if (dataInvoice) {
+          return dataInvoice;
+        }
+        const titleInvoice = (await invoiceValue.getAttribute("title"))?.trim() ?? "";
+        if (titleInvoice) {
+          return titleInvoice;
+        }
+        const text = (await invoiceValue.innerText()).trim();
+        const match = text.match(/\bfib[a-z0-9]{40,}\b/i);
+        return match ? match[0] : null;
+      })
+      .catch(() => null);
+    if (invoiceFromValue) {
+      return invoiceFromValue;
+    }
+
+    const walletLink = page.locator("[data-fiber-link-tip-modal='wallet-link']").first();
+    return walletLink
+      .waitFor({ timeout: 5_000 })
+      .then(async () => {
+        const href = (await walletLink.getAttribute("href"))?.trim() ?? "";
+        if (href.startsWith("fiber://invoice/")) {
+          const value = href.slice("fiber://invoice/".length).trim();
+          if (value) {
+            return value;
+          }
+        }
+        return null;
+      })
+      .catch(() => null);
+  }
+
   async function rpcCall(method, params) {
     return page.evaluate(async ({ method, params }) => {
       let csrfToken = null;
@@ -541,20 +579,7 @@ async (page) => {
     throw new Error("confirmed step should not be visible before settlement");
   }
 
-  const walletLink = page.locator("[data-fiber-link-tip-modal='wallet-link']").first();
-  const invoice = await walletLink
-    .waitFor({ timeout: 30_000 })
-    .then(async () => {
-      const href = (await walletLink.getAttribute("href"))?.trim() ?? "";
-      if (href.startsWith("fiber://invoice/")) {
-        const value = href.slice("fiber://invoice/".length).trim();
-        if (value) {
-          return value;
-        }
-      }
-      return null;
-    })
-    .catch(() => null);
+  const invoice = await readGeneratedInvoice(payStep);
 
   if (!invoice) {
     throw new Error("generated invoice is empty");

--- a/scripts/playwright/workflow-step4.run-code.js
+++ b/scripts/playwright/workflow-step4.run-code.js
@@ -44,7 +44,7 @@ async (page) => {
   await amountInput.waitFor({ timeout: 15_000 });
   await amountInput.fill(tipAmount);
 
-  await page.getByRole("button", { name: /generate invoice/i }).first().click();
+  await page.getByRole("button", { name: /review & pay|generate invoice/i }).first().click();
   const payStep = page.locator(payStepSelector).first();
   await payStep.waitFor({ timeout: 30_000 });
   await payStep.locator(".fiber-link-tip-status-badge").first().waitFor({ timeout: 30_000 });

--- a/scripts/playwright/workflow-step4.run-code.js
+++ b/scripts/playwright/workflow-step4.run-code.js
@@ -12,6 +12,51 @@ async (page) => {
   const screenshotPath = `${artifactDir}/playwright-step4-tip-modal.png`;
   const payStepSelector = '[data-fiber-link-tip-modal-step="pay"]';
 
+  async function readGeneratedInvoice(payStep) {
+    const invoiceValue = payStep.locator('[data-fiber-link-tip-modal="invoice-value"]').first();
+    const invoiceFromValue = await invoiceValue
+      .waitFor({ timeout: 30_000 })
+      .then(async () => {
+        const dataInvoice = (await invoiceValue.getAttribute("data-fiber-link-invoice"))?.trim() ?? "";
+        if (dataInvoice) {
+          return dataInvoice;
+        }
+        const titleInvoice = (await invoiceValue.getAttribute("title"))?.trim() ?? "";
+        if (titleInvoice) {
+          return titleInvoice;
+        }
+        const text = (await invoiceValue.innerText()).trim();
+        const match = text.match(/\bfib[a-z0-9]{40,}\b/i);
+        return match ? match[0] : null;
+      })
+      .catch(() => null);
+    if (invoiceFromValue) {
+      return invoiceFromValue;
+    }
+
+    const walletLink = payStep.locator('[data-fiber-link-tip-modal="wallet-link"]').first();
+    const invoiceFromWalletHref = await walletLink
+      .waitFor({ timeout: 5_000 })
+      .then(async () => {
+        const href = (await walletLink.getAttribute("href")) || "";
+        const match = href.match(/fiber:\/\/invoice\/(fib[a-z0-9]{40,})/i);
+        return match ? match[1] : null;
+      })
+      .catch(() => null);
+    if (invoiceFromWalletHref) {
+      return invoiceFromWalletHref;
+    }
+
+    return page.evaluate(() => {
+      const modal =
+        document.querySelector(".fiber-link-tip-modal") ||
+        document.querySelector(".d-modal");
+      const text = modal?.textContent || "";
+      const match = text.match(/\bfib[a-z0-9]{40,}\b/i);
+      return match ? match[0] : null;
+    });
+  }
+
   await page.goto(`${baseUrl}/login`, { waitUntil: "domcontentloaded" });
 
   const openLoginButton = page.getByRole("button", { name: /log in/i }).first();
@@ -49,54 +94,7 @@ async (page) => {
   await payStep.waitFor({ timeout: 30_000 });
   await payStep.locator(".fiber-link-tip-status-badge").first().waitFor({ timeout: 30_000 });
 
-  let invoice = null;
-
-  const invoiceFromWalletHref = await payStep
-    .locator('[data-fiber-link-tip-modal="wallet-link"]')
-    .waitFor({ timeout: 15_000 })
-    .then(async () => {
-      const href = (await payStep
-        .locator('[data-fiber-link-tip-modal="wallet-link"]')
-        .first()
-        .getAttribute("href")) || "";
-      const match = href.match(/fiber:\/\/invoice\/(fib[a-z0-9]{40,})/i);
-      return match ? match[1] : null;
-    })
-    .catch(() => null);
-
-  if (invoiceFromWalletHref) {
-    invoice = invoiceFromWalletHref;
-  } else {
-    const advancedToggle = payStep.locator(".fiber-link-tip-advanced-toggle").first();
-    const advancedPanel = payStep.locator(".fiber-link-tip-advanced-panel").first();
-    await advancedToggle.waitFor({ timeout: 15_000 });
-    await advancedToggle.click();
-    await advancedPanel.waitFor({ timeout: 15_000 });
-
-    const invoiceLocator = advancedPanel.locator(".fiber-link-tip-invoice").first();
-    const invoiceFromLocator = await invoiceLocator
-      .waitFor({ timeout: 15_000 })
-      .then(async () => {
-        const text = (await invoiceLocator.innerText()).trim();
-        const match = text.match(/\bfib[a-z0-9]{40,}\b/i);
-        return match ? match[0] : null;
-      })
-      .catch(() => null);
-
-    if (invoiceFromLocator) {
-      invoice = invoiceFromLocator;
-    } else {
-      // Backward-compatible fallback if modal markup changes but invoice still renders in dialog text.
-      invoice = await page.evaluate(() => {
-        const modal =
-          document.querySelector(".fiber-link-tip-modal") ||
-          document.querySelector(".d-modal");
-        const text = modal?.textContent || "";
-        const match = text.match(/\bfib[a-z0-9]{40,}\b/i);
-        return match ? match[0] : null;
-      });
-    }
-  }
+  const invoice = await readGeneratedInvoice(payStep);
 
   await page.screenshot({ path: screenshotPath, fullPage: false });
 


### PR DESCRIPTION
## What changed

- Refined the Discourse tip dialog into a compact two-step Fiber Link payment flow.
- Matched the Dashboard closer to the provided standalone comp while keeping it embedded in Discourse.
- Added the logged-in user menu profile entry for `Fiber Link Dashboard` linking to `/fiber-link`.
- Added the auto-refresh interval select, withdrawal UX refinements, copy feedback, reply-context labeling, QR decoration, and hidden invoice expiration UI until real expiration data exists.
- Updated system coverage and the implementation plan notes for the confirmed UI behavior.

## Why

The previous plugin UI exposed the core payment and dashboard functions, but the product surface was not aligned with the provided visual direction and the dashboard was only reachable by direct URL.

## Validation

- `git diff --check`
- `docker exec discourse_dev sh -lc "cd /src && LOAD_PLUGINS=1 EMBER_ENV=development script/assemble_ember_build.rb"`
- `docker exec discourse_dev sh -lc "cd /src && chpst -u discourse:discourse env HOME=/home/discourse LOAD_PLUGINS=1 bundle exec rspec plugins/fiber-link/spec/system/fiber_link_dashboard_spec.rb"`
- `docker exec discourse_dev sh -lc "cd /src && chpst -u discourse:discourse env HOME=/home/discourse LOAD_PLUGINS=1 bundle exec rspec plugins/fiber-link/spec/system/fiber_link_tip_spec.rb"`

## Visual checks

- `.tmp/fiber-link-user-menu-dashboard-entry.png`
- `.tmp/tip-modal-close-button-default.png`
- `.tmp/tip-modal-close-button-adjustment.png`
- `.tmp/tip-modal-step1-standalone-alignment.png`
- `.tmp/tip-modal-step2-standalone-alignment.png`
