### PR TITLE
fix(discourse): link payment details to tipped posts

### DIFF
--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -230,9 +230,19 @@ module ::FiberLink
 
       user_ids = tips.filter_map { |tip| tip["counterpartyUserId"].presence }.uniq
       usernames = User.where(id: user_ids).pluck(:id, :username).to_h.transform_keys(&:to_s)
+
+      post_ids = tips.filter_map { |tip| Integer(tip["postId"], exception: false) }.uniq
+      posts = Post.includes(:topic).where(id: post_ids).index_by { |post| post.id.to_s }
+
       tips.each do |tip|
         username = usernames[tip["counterpartyUserId"].to_s]
         tip["counterpartyUsername"] = username if username.present?
+
+        post = posts[tip["postId"].to_s]
+        next unless post
+
+        tip["postUrl"] = post.url
+        tip["postContextLabel"] = post.post_number.to_i > 1 ? "View the Reply" : "View the Post"
       end
       payload.to_json
     end

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-feed.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-feed.gjs
@@ -249,7 +249,7 @@ export default class FiberLinkTipFeed extends Component {
                 <button
                   type="button"
                   class="fiber-link-transaction-dialog__close"
-                  aria-label="Close transaction details"
+                  aria-label="Close payment details"
                   {{on "click" this.closeDetails}}
                 >
                   <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
@@ -259,7 +259,7 @@ export default class FiberLinkTipFeed extends Component {
               </div>
 
               <div class="fiber-link-transaction-dialog__hero">
-                <h4 id="fiber-link-transaction-dialog-title">Transaction details</h4>
+                <h4 id="fiber-link-transaction-dialog-title">{{this.selectedTip.detailTitle}}</h4>
                 <div class="fiber-link-transaction-dialog__summary">
                   <span class={{this.selectedTip.transactionSummaryStatusClassName}}>
                     {{this.selectedTip.statusLabel}}
@@ -377,14 +377,14 @@ export default class FiberLinkTipFeed extends Component {
                   <span class="fiber-link-transaction-dialog__meta-mark"></span>
                   {{this.selectedTip.confirmationLabel}}
                 </div>
-                {{#if this.selectedTip.explorerUrl}}
+                {{#if this.selectedTip.detailActionUrl}}
                   <a
                     class="fiber-link-transaction-dialog__explorer-link"
-                    href={{this.selectedTip.explorerUrl}}
+                    href={{this.selectedTip.detailActionUrl}}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    Open in CKB Explorer <span class="fiber-link-transaction-dialog__arrow">↗</span>
+                    {{this.selectedTip.detailActionLabel}} <span class="fiber-link-transaction-dialog__arrow">↗</span>
                   </a>
                 {{else}}
                   <button
@@ -392,7 +392,7 @@ export default class FiberLinkTipFeed extends Component {
                     class="fiber-link-transaction-dialog__explorer-link is-disabled"
                     disabled
                   >
-                    Open in CKB Explorer <span class="fiber-link-transaction-dialog__arrow">↗</span>
+                    {{this.selectedTip.detailActionUnavailableLabel}} <span class="fiber-link-transaction-dialog__arrow">↗</span>
                   </button>
                 {{/if}}
               </div>

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
@@ -182,11 +182,32 @@ function buildConfirmationLabel(tip, status) {
     return "Pending · awaiting confirmation";
   }
 
+  if (tip?.activityType === "TIP" || tip?.direction === "IN") {
+    return "Confirmed · Discourse post";
+  }
+
   if (tip?.txHash) {
     return "Confirmed · CKB explorer";
   }
 
   return "Confirmed · recorded";
+}
+
+function normalizePostUrl(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.startsWith("/") || /^https?:\/\//.test(trimmed) ? trimmed : null;
+}
+
+function normalizePostContextLabel(value) {
+  return value === "View the Reply" ? "View the Reply" : "View the Post";
 }
 
 function normalizeTips(tips) {
@@ -201,6 +222,11 @@ function normalizeTips(tips) {
         : typeof tip?.counterpartyUserId === "string"
           ? tip.counterpartyUserId
           : "unknown";
+
+    const activityType = tip?.activityType === "WITHDRAWAL" ? "WITHDRAWAL" : "TIP";
+    const postUrl = activityType === "TIP" ? normalizePostUrl(tip?.postUrl) : null;
+    const postContextLabel = normalizePostContextLabel(tip?.postContextLabel);
+    const explorerUrl = typeof tip?.explorerUrl === "string" && tip.explorerUrl.trim() ? tip.explorerUrl.trim() : null;
 
     return {
       id: typeof tip?.id === "string" ? tip.id : "unknown",
@@ -224,9 +250,15 @@ function normalizeTips(tips) {
       shortTimeLabel: formatShortTimestamp(tip?.createdAt),
       relativeTimeLabel: formatCompactRelativeTime(tip?.createdAt),
       message: typeof tip?.message === "string" && tip.message.trim() ? tip.message.trim() : null,
-      activityType: tip?.activityType === "WITHDRAWAL" ? "WITHDRAWAL" : "TIP",
+      activityType,
+      postUrl,
+      postContextLabel,
+      detailTitle: activityType === "TIP" ? "Payment details" : "Transaction details",
+      detailActionUrl: activityType === "TIP" ? postUrl : explorerUrl,
+      detailActionLabel: activityType === "TIP" ? postContextLabel : "Open in CKB Explorer",
+      detailActionUnavailableLabel: activityType === "TIP" ? "Post unavailable" : "Open in CKB Explorer",
       txHash: typeof tip?.txHash === "string" && tip.txHash.trim() ? tip.txHash.trim() : null,
-      explorerUrl: typeof tip?.explorerUrl === "string" && tip.explorerUrl.trim() ? tip.explorerUrl.trim() : null,
+      explorerUrl,
       destinationKind: typeof tip?.destinationKind === "string" && tip.destinationKind.trim() ? tip.destinationKind.trim() : null,
       destination: typeof tip?.destination === "string" && tip.destination.trim() ? tip.destination.trim() : null,
       transactionTagClassName: [

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
@@ -7,6 +7,8 @@ require "timeout"
 RSpec.describe "Fiber Link Dashboard", type: :system do
   fab!(:user)
   fab!(:tipper) { Fabricate(:user, username: "fiber_tipper") }
+  fab!(:tipped_topic) { Fabricate(:topic, user: user) }
+  fab!(:tipped_reply) { Fabricate(:post, topic: tipped_topic, user: user, post_number: 2) }
 
   before do
     SiteSetting.fiber_link_enabled = true
@@ -96,7 +98,7 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
               {
                 id: "tip-live-1",
                 invoice: "inv-live-1",
-                postId: "p1",
+                postId: tipped_reply.id.to_s,
                 amount: "31",
                 asset: "CKB",
                 state: "SETTLED",
@@ -183,7 +185,14 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
     expect(page).to have_content("On-chain withdrawal completed")
     expect(page).to have_no_content("Nice reply")
 
+    find("tr[data-tip-id='tip-live-1']").click
+    expect(page).to have_content("Payment details")
+    expect(page).to have_content("Confirmed · Discourse post")
+    expect(page).to have_link("View the Reply ↗", href: tipped_reply.url)
+    find("button[aria-label='Close payment details']").click
+
     find("tr[data-tip-id='wd-live-1']").click
+    expect(page).to have_content("Transaction details")
     expect(page).to have_content("Record ID")
     expect(page).to have_content("0xabc123")
     expect(page).to have_link("Open in CKB Explorer ↗", href: "https://pudge.explorer.nervos.org/transaction/0xabc123")


### PR DESCRIPTION
## Summary
- rename received-tip dialogs to Payment details
- enrich dashboard tip rows with Discourse post/reply URLs
- show View the Post / View the Reply actions for received tips while keeping CKB explorer actions for withdrawals

## Test Plan
- git diff --check
- node --check fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
- bun install --frozen-lockfile && bunx vitest run apps/rpc/src/methods/dashboard.test.ts apps/rpc/src/contracts.test.ts
- /opt/bitnami/ruby/bin/ruby -c rpc_controller.rb and fiber_link_dashboard_spec.rb in live Discourse container