### PR TITLE
Fix Fiber Link UI backpressure states

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
@@ -166,8 +166,38 @@ export default class FiberLinkWithdrawalPanel extends Component {
         this.isQuoteLoading ||
         this.amountErrorMessage ||
         this.addressErrorMessage ||
+        this.quoteErrorMessage ||
+        this.quote?.destinationValid === false ||
         !this.destination,
     );
+  }
+
+  get submitDisabledReason() {
+    if (!this.isSubmitDisabled) {
+      return null;
+    }
+    if (this.isSubmitting) {
+      return "Withdrawal request is being submitted.";
+    }
+    if (this.isQuoteLoading) {
+      return "Calculating withdrawal quote and network fee.";
+    }
+    if (this.amountErrorMessage) {
+      return this.amountErrorMessage;
+    }
+    if (!this.destination) {
+      return "Enter a destination address to enable withdrawal.";
+    }
+    if (this.addressErrorMessage) {
+      return this.addressErrorMessage;
+    }
+    if (this.quote?.destinationValid === false) {
+      return normalizeValue(this.quote?.validationMessage) || "Destination address is not valid for withdrawal.";
+    }
+    if (this.quoteErrorMessage) {
+      return this.quoteErrorMessage;
+    }
+    return "Withdrawal is temporarily unavailable. Retry after the dashboard refreshes.";
   }
 
   get submitLabel() {
@@ -293,7 +323,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
         destination: this.destination,
       });
     } catch (error) {
-      this.quoteErrorMessage = error?.message ?? "Failed to calculate withdrawal quote.";
+      this.quoteErrorMessage = error?.message ?? "Failed to calculate withdrawal quote. Please retry.";
     } finally {
       this.isQuoteLoading = false;
     }
@@ -313,6 +343,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
       this.errorMessage =
         this.amountErrorMessage ||
         this.addressErrorMessage ||
+        this.submitDisabledReason ||
         this.quoteErrorMessage ||
         "Enter a valid CKB withdrawal address.";
       return;
@@ -459,6 +490,14 @@ export default class FiberLinkWithdrawalPanel extends Component {
           @disabled={{this.isSubmitDisabled}}
           @translatedLabel={{this.submitLabel}}
         />
+        {{#if this.submitDisabledReason}}
+          <p
+            class="fiber-link-dashboard__withdrawal-disabled-reason"
+            data-fiber-link-withdrawal-disabled-reason
+          >
+            {{this.submitDisabledReason}}
+          </p>
+        {{/if}}
         {{#if this.requestedId}}
           <p class="fiber-link-dashboard__withdrawal-meta">
             Latest request:

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
@@ -571,7 +571,13 @@ export default class FiberLinkTipModal extends Component {
           </header>
 
           {{#if this.errorMessage}}
-            <p class="fiber-link-tip-alert is-error">{{this.errorMessage}}</p>
+            <p class="fiber-link-tip-alert is-error" data-fiber-link-tip-modal="error">{{this.errorMessage}}</p>
+          {{/if}}
+
+          {{#if this.isGenerating}}
+            <p class="fiber-link-tip-alert is-info" data-fiber-link-tip-modal="invoice-loading">
+              Preparing invoice… this will time out with a retryable error if Fiber Link is busy.
+            </p>
           {{/if}}
 
           {{#if this.isSelfTip}}

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/controllers/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/controllers/fiber-link-dashboard.js
@@ -1,8 +1,14 @@
 import Controller from "@ember/controller";
+import { action } from "@ember/object";
 
 export default class FiberLinkDashboardController extends Controller {
   queryParams = ["withdrawalState", "settlementState"];
 
   withdrawalState = "ALL";
   settlementState = "ALL";
+
+  @action
+  retryDashboardSummary() {
+    this.model?.retryDashboardSummary?.();
+  }
 }

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
@@ -8,13 +8,28 @@ const DASHBOARD_LIMIT = 20;
 const ALLOWED_POLL_INTERVALS = [10000, 30000, 60000];
 const SYNC_AGE_TICK_MS = 1000;
 
+function mapDashboardErrorToMessage(error) {
+  const message =
+    typeof error?.message === "string" ? error.message.trim() : "";
+  if (!message) {
+    return "Failed to load dashboard.summary. Please retry.";
+  }
+  if (message.toLowerCase().includes("timed out")) {
+    return "Dashboard data timed out. The service may be busy; retry when traffic settles.";
+  }
+  return message;
+}
+
 function formatSyncStatusLabel(rawValue) {
   const value = new Date(rawValue);
   if (Number.isNaN(value.getTime())) {
     return "Live · syncing";
   }
 
-  const ageSeconds = Math.max(0, Math.floor((Date.now() - value.getTime()) / 1000));
+  const ageSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - value.getTime()) / 1000),
+  );
   if (ageSeconds < 2) {
     return "Live · synced now";
   }
@@ -110,13 +125,15 @@ function buildAvatarInitials(username) {
     return "U";
   }
 
-  return value
-    .replace(/^@/, "")
-    .split(/[_\s-]+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((part) => part[0]?.toUpperCase())
-    .join("") || value.slice(0, 2).toUpperCase();
+  return (
+    value
+      .replace(/^@/, "")
+      .split(/[_\s-]+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase())
+      .join("") || value.slice(0, 2).toUpperCase()
+  );
 }
 
 function formatCountCaption(count, singular, plural = `${singular}s`) {
@@ -146,7 +163,10 @@ function formatCompactRelativeTime(rawValue) {
     return null;
   }
 
-  const ageSeconds = Math.max(0, Math.floor((Date.now() - value.getTime()) / 1000));
+  const ageSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - value.getTime()) / 1000),
+  );
   if (ageSeconds < 2) {
     return "now";
   }
@@ -203,7 +223,9 @@ function normalizePostUrl(value) {
     return null;
   }
 
-  return trimmed.startsWith("/") || /^https?:\/\//.test(trimmed) ? trimmed : null;
+  return trimmed.startsWith("/") || /^https?:\/\//.test(trimmed)
+    ? trimmed
+    : null;
 }
 
 function normalizePostContextLabel(value) {
@@ -217,16 +239,22 @@ function normalizeTips(tips) {
     const direction = mapDirectionPresentation(tip?.direction);
     const absoluteTime = formatIsoTimestamp(tip?.createdAt);
     const counterpartyUsername =
-      typeof tip?.counterpartyUsername === "string" && tip.counterpartyUsername.trim()
+      typeof tip?.counterpartyUsername === "string" &&
+      tip.counterpartyUsername.trim()
         ? tip.counterpartyUsername.trim()
         : typeof tip?.counterpartyUserId === "string"
           ? tip.counterpartyUserId
           : "unknown";
 
-    const activityType = tip?.activityType === "WITHDRAWAL" ? "WITHDRAWAL" : "TIP";
-    const postUrl = activityType === "TIP" ? normalizePostUrl(tip?.postUrl) : null;
+    const activityType =
+      tip?.activityType === "WITHDRAWAL" ? "WITHDRAWAL" : "TIP";
+    const postUrl =
+      activityType === "TIP" ? normalizePostUrl(tip?.postUrl) : null;
     const postContextLabel = normalizePostContextLabel(tip?.postContextLabel);
-    const explorerUrl = typeof tip?.explorerUrl === "string" && tip.explorerUrl.trim() ? tip.explorerUrl.trim() : null;
+    const explorerUrl =
+      typeof tip?.explorerUrl === "string" && tip.explorerUrl.trim()
+        ? tip.explorerUrl.trim()
+        : null;
 
     return {
       id: typeof tip?.id === "string" ? tip.id : "unknown",
@@ -249,28 +277,47 @@ function normalizeTips(tips) {
       absoluteTimeLabel: absoluteTime,
       shortTimeLabel: formatShortTimestamp(tip?.createdAt),
       relativeTimeLabel: formatCompactRelativeTime(tip?.createdAt),
-      message: typeof tip?.message === "string" && tip.message.trim() ? tip.message.trim() : null,
+      message:
+        typeof tip?.message === "string" && tip.message.trim()
+          ? tip.message.trim()
+          : null,
       activityType,
       postUrl,
       postContextLabel,
-      detailTitle: activityType === "TIP" ? "Payment details" : "Transaction details",
+      detailTitle:
+        activityType === "TIP" ? "Payment details" : "Transaction details",
       detailActionUrl: activityType === "TIP" ? postUrl : explorerUrl,
-      detailActionLabel: activityType === "TIP" ? postContextLabel : "Open in CKB Explorer",
-      detailActionUnavailableLabel: activityType === "TIP" ? "Post unavailable" : "Open in CKB Explorer",
-      txHash: typeof tip?.txHash === "string" && tip.txHash.trim() ? tip.txHash.trim() : null,
+      detailActionLabel:
+        activityType === "TIP" ? postContextLabel : "Open in CKB Explorer",
+      detailActionUnavailableLabel:
+        activityType === "TIP" ? "Post unavailable" : "Open in CKB Explorer",
+      txHash:
+        typeof tip?.txHash === "string" && tip.txHash.trim()
+          ? tip.txHash.trim()
+          : null,
       explorerUrl,
-      destinationKind: typeof tip?.destinationKind === "string" && tip.destinationKind.trim() ? tip.destinationKind.trim() : null,
-      destination: typeof tip?.destination === "string" && tip.destination.trim() ? tip.destination.trim() : null,
+      destinationKind:
+        typeof tip?.destinationKind === "string" && tip.destinationKind.trim()
+          ? tip.destinationKind.trim()
+          : null,
+      destination:
+        typeof tip?.destination === "string" && tip.destination.trim()
+          ? tip.destination.trim()
+          : null,
       transactionTagClassName: [
         "fiber-link-transaction-dialog__tag",
         direction.key === "received" ? "is-received" : "",
         status.key === "failed" ? "is-failed" : "",
-      ].filter(Boolean).join(" "),
+      ]
+        .filter(Boolean)
+        .join(" "),
       transactionSummaryStatusClassName: [
         "fiber-link-transaction-dialog__summary-status",
         status.key === "completed" ? "is-completed" : "",
         status.key === "failed" ? "is-failed" : "",
-      ].filter(Boolean).join(" "),
+      ]
+        .filter(Boolean)
+        .join(" "),
       transactionAmountClassName: [
         "fiber-link-transaction-dialog__summary-amount",
         direction.amountPrefix === "+" ? "is-positive" : "is-negative",
@@ -280,12 +327,16 @@ function normalizeTips(tips) {
         "fiber-link-transaction-dialog__activity",
         status.key === "completed" ? "is-completed" : "",
         status.key === "failed" ? "is-failed" : "",
-      ].filter(Boolean).join(" "),
+      ]
+        .filter(Boolean)
+        .join(" "),
       transactionConfirmationClassName: [
         "fiber-link-transaction-dialog__meta",
         status.key === "failed" ? "is-failed" : "",
         status.key === "pending" ? "is-pending" : "",
-      ].filter(Boolean).join(" "),
+      ]
+        .filter(Boolean)
+        .join(" "),
       confirmationLabel: buildConfirmationLabel(tip, status),
     };
   });
@@ -306,6 +357,7 @@ export default class FiberLinkDashboardRoute extends Route {
       isRefreshing: false,
       summaryErrorMessage: null,
       feedErrorMessage: null,
+      lastErrorAt: null,
       availableBalance: "0",
       pendingBalance: "0",
       lockedBalance: "0",
@@ -321,6 +373,12 @@ export default class FiberLinkDashboardRoute extends Route {
       syncStatusLabel: "Live · syncing",
       pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
       tipFeedItems: [],
+      retryDashboardSummary: () => {
+        if (!model.isRefreshing) {
+          model.set("isRefreshing", true);
+          void this._refreshSummary(model);
+        }
+      },
     });
 
     this._activeModel = model;
@@ -359,8 +417,11 @@ export default class FiberLinkDashboardRoute extends Route {
         return;
       }
 
-      const generatedAt = formatIsoTimestamp(result?.generatedAt) || new Date().toISOString();
-      const normalizedTips = normalizeTips(result?.tips).filter((tip) => tip.directionKey !== "sent");
+      const generatedAt =
+        formatIsoTimestamp(result?.generatedAt) || new Date().toISOString();
+      const normalizedTips = normalizeTips(result?.tips).filter(
+        (tip) => tip.directionKey !== "sent",
+      );
       const nextTipFeedSignature = buildTipFeedSignature(normalizedTips);
       const pendingCount = Number(result?.stats?.pendingCount ?? 0);
       const completedCount = Number(result?.stats?.completedCount ?? 0);
@@ -371,6 +432,7 @@ export default class FiberLinkDashboardRoute extends Route {
         isRefreshing: false,
         summaryErrorMessage: null,
         feedErrorMessage: null,
+        lastErrorAt: null,
         availableBalance:
           typeof result?.balances?.available === "string"
             ? result.balances.available
@@ -378,9 +440,13 @@ export default class FiberLinkDashboardRoute extends Route {
               ? result.balance
               : "0",
         pendingBalance:
-          typeof result?.balances?.pending === "string" ? result.balances.pending : "0",
+          typeof result?.balances?.pending === "string"
+            ? result.balances.pending
+            : "0",
         lockedBalance:
-          typeof result?.balances?.locked === "string" ? result.balances.locked : "0",
+          typeof result?.balances?.locked === "string"
+            ? result.balances.locked
+            : "0",
         balanceAsset: result?.balances?.asset === "USDI" ? "USDI" : "CKB",
         pendingCount,
         completedCount,
@@ -405,12 +471,13 @@ export default class FiberLinkDashboardRoute extends Route {
         return;
       }
 
-      const message = error?.message ?? "Failed to load dashboard.summary";
+      const message = mapDashboardErrorToMessage(error);
       model.setProperties({
         isInitialLoading: false,
         isRefreshing: false,
         summaryErrorMessage: message,
         feedErrorMessage: message,
+        lastErrorAt: new Date().toISOString(),
       });
     } finally {
       if (model === this._activeModel) {

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/services/fiber-link-api.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/services/fiber-link-api.js
@@ -1,6 +1,7 @@
 import { ajax } from "discourse/lib/ajax";
 
 const DEFAULT_RPC_PATH = "/fiber-link/rpc";
+const DEFAULT_RPC_TIMEOUT_MS = 15000;
 
 const runtimeConfig = {
   initialized: false,
@@ -37,24 +38,64 @@ function buildRequestId() {
 
 async function rpcCall(method, params = {}) {
   assertInitialized();
-  const data = await ajax(runtimeConfig.rpcPath, {
-    type: "POST",
-    contentType: "application/json",
-    dataType: "json",
-    data: JSON.stringify({
-      jsonrpc: "2.0",
-      id: buildRequestId(),
-      method,
-      params,
-    }),
-  });
+  let data;
+
+  try {
+    data = await ajax(runtimeConfig.rpcPath, {
+      type: "POST",
+      contentType: "application/json",
+      dataType: "json",
+      timeout: DEFAULT_RPC_TIMEOUT_MS,
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        id: buildRequestId(),
+        method,
+        params,
+      }),
+    });
+  } catch (error) {
+    const statusText =
+      typeof error?.statusText === "string" ? error.statusText : "";
+    const responseText =
+      typeof error?.responseText === "string" ? error.responseText : "";
+    const status = Number(error?.status);
+
+    if (statusText.toLowerCase() === "timeout") {
+      throw new Error(
+        `Fiber Link request timed out after ${DEFAULT_RPC_TIMEOUT_MS / 1000}s. Please retry.`,
+      );
+    }
+    if (status === 429) {
+      throw new Error(
+        "Fiber Link is rate limiting requests. Please wait a moment and retry.",
+      );
+    }
+    if (status >= 500) {
+      throw new Error(
+        "Fiber Link service is temporarily unavailable. Please retry in a moment.",
+      );
+    }
+
+    throw new Error(
+      responseText ||
+        error?.message ||
+        "Fiber Link request failed. Please retry.",
+    );
+  }
   if (data?.error) {
     throw data.error;
   }
   return data?.result;
 }
 
-export async function createTip({ amount, asset, postId, fromUserId, toUserId, message }) {
+export async function createTip({
+  amount,
+  asset,
+  postId,
+  fromUserId,
+  toUserId,
+  message,
+}) {
   return rpcCall("tip.create", {
     amount,
     asset,
@@ -69,7 +110,11 @@ export async function getTipStatus({ invoice }) {
   return rpcCall("tip.status", { invoice });
 }
 
-export async function getDashboardSummary({ limit = 20, includeAdmin = false, filters = {} } = {}) {
+export async function getDashboardSummary({
+  limit = 20,
+  includeAdmin = false,
+  filters = {},
+} = {}) {
   return rpcCall("dashboard.summary", { limit, includeAdmin, filters });
 }
 
@@ -81,7 +126,11 @@ export async function quoteWithdrawal({ amount, asset = "CKB", destination }) {
   });
 }
 
-export async function requestWithdrawal({ amount, asset = "CKB", destination }) {
+export async function requestWithdrawal({
+  amount,
+  asset = "CKB",
+  destination,
+}) {
   return rpcCall("withdrawal.request", {
     amount,
     asset,

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
@@ -20,9 +20,27 @@
   </header>
 
   {{#if this.model.summaryErrorMessage}}
-    <p class="fiber-link-dashboard__alert is-error">
-      Failed to load dashboard data:
-      {{this.model.summaryErrorMessage}}
+    <div
+      class="fiber-link-dashboard__alert is-error fiber-link-dashboard__load-error"
+      data-fiber-link-dashboard-state="error"
+    >
+      <p>
+        <strong>Dashboard data unavailable.</strong>
+        {{this.model.summaryErrorMessage}}
+      </p>
+      <DButton
+        class="btn-primary fiber-link-dashboard__retry"
+        data-fiber-link-dashboard-action="retry-summary"
+        @action={{this.retryDashboardSummary}}
+        @disabled={{this.model.isRefreshing}}
+        @translatedLabel="Retry dashboard"
+      />
+    </div>
+  {{/if}}
+
+  {{#if this.model.isInitialLoading}}
+    <p class="fiber-link-dashboard__alert is-info" data-fiber-link-dashboard-state="loading">
+      Loading dashboard data… If the service is busy, this will time out with a retry button instead of spinning indefinitely.
     </p>
   {{/if}}
 

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -240,6 +240,23 @@
   color: var(--fl-amber);
 }
 
+.fiber-link-tip-alert.is-info,
+.fiber-link-dashboard__alert.is-info {
+  background: var(--fl-primary-weak);
+  color: var(--fl-primary);
+}
+
+.fiber-link-dashboard__load-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.fiber-link-dashboard__load-error p {
+  margin: 0;
+}
+
 .fiber-link-tip-alert.is-success {
   background: var(--fl-green-weak);
   color: var(--fl-green);
@@ -660,9 +677,14 @@
 }
 
 .fiber-link-tip-input-error,
-.fiber-link-dashboard__withdrawal-validation {
+.fiber-link-dashboard__withdrawal-validation,
+.fiber-link-dashboard__withdrawal-disabled-reason {
   margin: 0;
   font-size: 0.86rem;
+}
+
+.fiber-link-dashboard__withdrawal-disabled-reason {
+  color: var(--fl-text-muted);
 }
 
 .fiber-link-tip-input-error,
@@ -1577,7 +1599,8 @@ body:has(.fiber-link-dashboard) .profiler-results {
   --fl-dashboard-green: #1f6f4a;
   --fl-dashboard-red: #8a1f1f;
   --fl-dashboard-bg: transparent;
-  --fl-dashboard-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --fl-dashboard-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
   --fl-dashboard-mono: "JetBrains Mono", ui-monospace, Menlo, Monaco, monospace;
   box-sizing: border-box;
   display: block;
@@ -1911,7 +1934,8 @@ body:has(.fiber-link-dashboard) .profiler-results {
   background: transparent;
 }
 
-.fiber-link-dashboard__withdrawal-summary-item + .fiber-link-dashboard__withdrawal-summary-item {
+.fiber-link-dashboard__withdrawal-summary-item
+  + .fiber-link-dashboard__withdrawal-summary-item {
   border-left: 1px solid var(--fl-dashboard-line);
   padding-left: 1.25rem;
 }
@@ -2388,8 +2412,6 @@ body:has(.fiber-link-dashboard) .profiler-results {
   line-height: 1.25;
 }
 
-
-
 .fiber-link-tip-feed-row {
   cursor: pointer;
   transition:
@@ -2461,11 +2483,13 @@ body:has(.fiber-link-dashboard) .profiler-results {
   background: var(--fl-dashboard-black);
 }
 
-.fiber-link-transaction-dialog__tag.is-received .fiber-link-transaction-dialog__tag-dot {
+.fiber-link-transaction-dialog__tag.is-received
+  .fiber-link-transaction-dialog__tag-dot {
   background: var(--fl-dashboard-green);
 }
 
-.fiber-link-transaction-dialog__tag.is-failed .fiber-link-transaction-dialog__tag-dot {
+.fiber-link-transaction-dialog__tag.is-failed
+  .fiber-link-transaction-dialog__tag-dot {
   background: var(--fl-dashboard-red);
 }
 
@@ -2661,11 +2685,13 @@ body:has(.fiber-link-dashboard) .profiler-results {
   background: var(--fl-dashboard-black);
 }
 
-.fiber-link-transaction-dialog__activity.is-completed .fiber-link-transaction-dialog__activity-dot {
+.fiber-link-transaction-dialog__activity.is-completed
+  .fiber-link-transaction-dialog__activity-dot {
   background: var(--fl-dashboard-green);
 }
 
-.fiber-link-transaction-dialog__activity.is-failed .fiber-link-transaction-dialog__activity-dot {
+.fiber-link-transaction-dialog__activity.is-failed
+  .fiber-link-transaction-dialog__activity-dot {
   background: var(--fl-dashboard-red);
 }
 
@@ -2740,11 +2766,13 @@ body:has(.fiber-link-dashboard) .profiler-results {
   background: var(--fl-dashboard-green);
 }
 
-.fiber-link-transaction-dialog__meta.is-failed .fiber-link-transaction-dialog__meta-mark {
+.fiber-link-transaction-dialog__meta.is-failed
+  .fiber-link-transaction-dialog__meta-mark {
   background: var(--fl-dashboard-red);
 }
 
-.fiber-link-transaction-dialog__meta.is-pending .fiber-link-transaction-dialog__meta-mark {
+.fiber-link-transaction-dialog__meta.is-pending
+  .fiber-link-transaction-dialog__meta-mark {
   background: var(--fl-dashboard-muted);
 }
 
@@ -2769,7 +2797,8 @@ body:has(.fiber-link-dashboard) .profiler-results {
 }
 
 .fiber-link-dashboard .fiber-link-transaction-dialog__explorer-link:hover,
-.fiber-link-dashboard .fiber-link-transaction-dialog__explorer-link:focus-visible {
+.fiber-link-dashboard
+  .fiber-link-transaction-dialog__explorer-link:focus-visible {
   background: var(--fl-dashboard-black);
   color: #fdfcfc !important;
   text-decoration: none;
@@ -2784,7 +2813,8 @@ body:has(.fiber-link-dashboard) .profiler-results {
   transition: transform 0.2s;
 }
 
-.fiber-link-transaction-dialog__explorer-link:hover .fiber-link-transaction-dialog__arrow {
+.fiber-link-transaction-dialog__explorer-link:hover
+  .fiber-link-transaction-dialog__arrow {
   transform: translate(2px, -2px);
 }
 
@@ -3051,7 +3081,8 @@ body:has(.fiber-link-dashboard) .profiler-results {
   padding: 18px 16px 18px 0;
 }
 
-.fiber-link-dashboard__withdrawal-summary-item + .fiber-link-dashboard__withdrawal-summary-item {
+.fiber-link-dashboard__withdrawal-summary-item
+  + .fiber-link-dashboard__withdrawal-summary-item {
   border-left-color: var(--fl-dashboard-line);
   padding-left: 16px;
 }
@@ -3469,7 +3500,8 @@ body:has(.fiber-link-dashboard) .profiler-results {
   }
 
   .fiber-link-dashboard__metric + .fiber-link-dashboard__metric,
-  .fiber-link-dashboard__withdrawal-summary-item + .fiber-link-dashboard__withdrawal-summary-item {
+  .fiber-link-dashboard__withdrawal-summary-item
+    + .fiber-link-dashboard__withdrawal-summary-item {
     border-left: 0;
     border-top: 1px solid var(--fl-dashboard-line);
     padding-left: 0;

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
@@ -58,6 +58,48 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
     expect(page).to have_content("Fiber Link Dashboard.")
   end
 
+  it "turns dashboard.summary failures into a visible retry state" do
+    request_count = 0
+    request_count_mutex = Mutex.new
+
+    stub_request(:post, "https://fiber-link.example/rpc")
+      .with { |request| JSON.parse(request.body).fetch("method") == "dashboard.summary" }
+      .to_return do
+        current_request = request_count_mutex.synchronize do
+          request_count += 1
+        end
+
+        if current_request == 1
+          {
+            status: 503,
+            body: "upstream overloaded",
+            headers: { "Content-Type" => "text/plain" },
+          }
+        else
+          {
+            status: 200,
+            body: {
+              jsonrpc: "2.0",
+              id: "dash-retry",
+              result: summary_result(balances: { available: "42", pending: "0", locked: "0", asset: "CKB" }),
+            }.to_json,
+            headers: { "Content-Type" => "application/json" },
+          }
+        end
+      end
+
+    visit "/fiber-link"
+
+    expect(page).to have_css("[data-fiber-link-dashboard-state='error']")
+    expect(page).to have_content("Dashboard data unavailable.")
+    expect(page).to have_button("Retry dashboard")
+
+    click_button "Retry dashboard"
+
+    expect(page).to have_no_css("[data-fiber-link-dashboard-state='error']")
+    expect(page).to have_content("42 CKB")
+  end
+
   it "links to the dashboard from the user menu profile panel" do
     visit "/"
 
@@ -405,6 +447,10 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
     expect(page).to have_button("Max · 124")
     expect(page).to have_no_content("Enter a valid CKB withdrawal address.")
     expect(page).to have_button("Request withdrawal", disabled: true)
+    expect(page).to have_css(
+      "[data-fiber-link-withdrawal-disabled-reason]",
+      text: "Enter a destination address to enable withdrawal.",
+    )
 
     click_button "25%"
     expect(find("[data-fiber-link-withdrawal-input='amount']").value).to eq("61")


### PR DESCRIPTION
## Summary

Fixes #350 by making the Fiber Link Discourse UI fail visibly under demo backpressure instead of silently hanging:

- adds a 15s JSON-RPC timeout with explicit timeout / 429 / 5xx messages
- turns `/fiber-link` dashboard load failures into a visible error state with a retry button and stable `data-*` hooks
- shows invoice-generation loading/error states with stable `data-*` hooks in the tip modal
- disables withdrawal submission when quote validation fails and shows a visible disabled reason
- adds a dashboard system spec for summary failure → retry recovery

## Validation

- `git diff --check`
- `node --check` on changed plain JS files
- `npx --yes prettier --check` on changed JS/SCSS files

Attempted focused plugin system specs, but the local Discourse dev container is not currently runnable:

- `scripts/plugin-smoke.sh` exits with `the input device is not a TTY`
- direct `bin/rspec` in `discourse_dev` exits with Bundler missing-gem errors

CI should provide the authoritative plugin smoke/system validation.