### PR TITLE
Fix tip invoice generation watchdog

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
@@ -14,6 +14,9 @@ import { createTip, getTipStatus } from "../../services/fiber-link-api";
 const AMOUNT_PATTERN = /^(?:\d+)(?:\.\d{1,8})?$/;
 const COPY_FEEDBACK_TIMEOUT_MS = 3000;
 const TIP_STATUS_AUTO_POLL_INTERVAL_MS = 1000;
+const TIP_GENERATION_WATCHDOG_MS = 15000;
+const TIP_GENERATION_WATCHDOG_MESSAGE =
+  "Fiber Link is busy while preparing invoice. Please retry.";
 const FIBER_LINK_HOMEPAGE_URL = "https://www.fiberlink.me";
 const FIBER_LINK_LOGO_URL = "https://fiberlink.me/brand/fiber-link-logo.png";
 const MAX_MESSAGE_LENGTH = 120;
@@ -34,6 +37,19 @@ function isTransientNetworkError(message) {
     value.includes("failed to fetch") ||
     value.includes("service unavailable")
   );
+}
+
+function withTipGenerationWatchdog(promise) {
+  let timeoutId;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(TIP_GENERATION_WATCHDOG_MESSAGE));
+    }, TIP_GENERATION_WATCHDOG_MS);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    clearTimeout(timeoutId);
+  });
 }
 
 function mapTipStateToLabel(state) {
@@ -422,14 +438,16 @@ export default class FiberLinkTipModal extends Component {
     this.isGenerating = true;
 
     try {
-      const result = await createTip({
-        amount: this.amount.trim(),
-        asset: "CKB",
-        postId: String(this.postId),
-        fromUserId: String(this.fromUserId),
-        toUserId: String(this.targetUserId),
-        message: normalizeMessage(this.message) || null,
-      });
+      const result = await withTipGenerationWatchdog(
+        createTip({
+          amount: this.amount.trim(),
+          asset: "CKB",
+          postId: String(this.postId),
+          fromUserId: String(this.fromUserId),
+          toUserId: String(this.targetUserId),
+          message: normalizeMessage(this.message) || null,
+        }),
+      );
 
       if (!normalizeMessage(result?.invoice)) {
         throw new Error("Invoice is empty");


### PR DESCRIPTION
## Summary

Fixes #352.

Adds a bounded client-side watchdog around tip invoice generation so the modal cannot remain indefinitely in `Preparing payment...` under browser/UI pressure. If invoice preparation does not complete in 15 seconds, the modal clears the generating state and surfaces a retryable error:

> Fiber Link is busy while preparing invoice. Please retry.

This keeps the stress-test contract explicit: under load, the UI either reaches an invoice or shows a terminal retryable error instead of a silent loading hang.

## What changed

- Added `TIP_GENERATION_WATCHDOG_MS = 15000` and a retryable timeout message in the tip modal.
- Wrapped `createTip(...)` in `withTipGenerationWatchdog(...)` using `Promise.race(...)`.
- Preserved the existing successful invoice path and auto status polling after invoice generation.

## Evidence

Follow-up issue #352 was opened after the post-#351 10-account UI dogfood reproduced the new failure mode:

- Run dir: `/tmp/fiber-web-dogfood/run-2026-05-07T15-36-19-186Z`
- Config: 10 tippers, 30 tips/min, 1 withdrawal/min, settlement poll skipped
- Observed before fix: tip modals stuck in `Preparing invoice...` / `Preparing payment...` until the automation timed out waiting for `[data-fiber-link-invoice]`.

## Validation

- `git diff --check` passed before commit.
- Watchdog patch sanity check passed by verifying the expected constants/helper/wrapper are present.
- Host Ruby/Bundler are unavailable in this environment (`ruby: command not found`), so local system specs could not be executed here; CI `plugin-smoke` should cover the plugin path.
- `prettier --check` cannot infer a parser for `.gjs` in this repo/tooling, so it was not a valid formatting signal for this file.
