### PR TITLE
Fix dashboard boot timeout fallback

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
@@ -7,7 +7,8 @@ import { configureFiberLinkApi } from "../services/fiber-link-api";
 export const FIBER_LINK_BOOT_EVENT = "fiber-link:bootstrapped";
 export const FIBER_LINK_RUNTIME_KEY = "__fiberLinkRuntime";
 const FIBER_LINK_DASHBOARD_PATH = "/fiber-link";
-const FIBER_LINK_RPC_PATH = `${FIBER_LINK_DASHBOARD_PATH}/rpc`;
+const FIBER_LINK_RPC_PATH = "/fiber-link/rpc";
+const DASHBOARD_BOOT_TIMEOUT_MS = 15000;
 
 function buildRuntimeConfig() {
   return {
@@ -26,6 +27,68 @@ function publishRuntime(runtime) {
       detail: runtime,
     }),
   );
+}
+
+function isDashboardPath() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const path = window.location?.pathname || "";
+  return (
+    path === FIBER_LINK_DASHBOARD_PATH ||
+    path.startsWith(`${FIBER_LINK_DASHBOARD_PATH}/`)
+  );
+}
+
+function dashboardHasRendered() {
+  return Boolean(
+    document.querySelector(
+      '.fiber-link-dashboard, [data-fiber-link-dashboard-state="error"], [data-fiber-link-withdrawal-input="amount"]',
+    ),
+  );
+}
+
+function injectDashboardBootFallback() {
+  if (!isDashboardPath() || dashboardHasRendered()) {
+    return;
+  }
+
+  const existing = document.querySelector(
+    '[data-fiber-link-dashboard-state="boot-timeout"]',
+  );
+  if (existing) {
+    return;
+  }
+
+  const fallback = document.createElement("main");
+  fallback.className =
+    "fiber-link-dashboard fiber-link-dashboard__boot-timeout";
+  fallback.setAttribute("data-fiber-link-dashboard-state", "boot-timeout");
+  fallback.innerHTML = `
+    <section class="fiber-link-dashboard__boot-timeout-card">
+      <p class="fiber-link-dashboard__alert is-error">
+        Fiber Link dashboard is still loading. The service may be busy; retry when traffic settles.
+      </p>
+      <button class="btn btn-primary" type="button" data-fiber-link-dashboard-retry>
+        Retry dashboard
+      </button>
+    </section>
+  `;
+
+  fallback
+    .querySelector("[data-fiber-link-dashboard-retry]")
+    ?.addEventListener("click", () => window.location.reload());
+
+  document.body?.appendChild(fallback);
+}
+
+function scheduleDashboardBootFallback() {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+
+  window.setTimeout(injectDashboardBootFallback, DASHBOARD_BOOT_TIMEOUT_MS);
 }
 
 export default {
@@ -54,5 +117,6 @@ export default {
     });
 
     publishRuntime(runtime);
+    scheduleDashboardBootFallback();
   },
 };

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -46,8 +46,25 @@
   color: var(--primary);
 }
 
+.fiber-link-dashboard__boot-timeout {
+  max-width: 980px;
+  margin: 2rem auto;
+  padding: 1rem;
+}
+
+.fiber-link-dashboard__boot-timeout-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid var(--fl-border);
+  border-radius: 14px;
+  background: var(--fl-surface-lowest);
+  box-shadow: var(--fl-shadow-soft);
+}
+
 .fiber-link-tip-modal,
-.fiber-link-dashboard {
+.fiber-link-dashboard,
+.fiber-link-dashboard__boot-timeout {
   --fl-primary: hsl(211, 100%, 45%);
   --fl-primary-hover: hsl(211, 100%, 35%);
   --fl-primary-active: hsl(211, 100%, 25%);


### PR DESCRIPTION
## Summary

Fixes #354.

Adds a browser-side boot timeout fallback for `/fiber-link` so stress navigation cannot leave users with only Discourse's global loading dots. If the dashboard route has not rendered after 15s on a Fiber Link dashboard URL, the plugin injects a visible retryable fallback with a stable selector:

- `data-fiber-link-dashboard-state="boot-timeout"`
- `data-fiber-link-dashboard-retry`

This complements #351's dashboard summary error state and #353's tip invoice watchdog. The goal is product observability under demo stress: render the dashboard, or show an explicit retryable state — never an indefinite spinner-only page.

## Evidence

Observed during 10-account / 30 tips-min / 1 withdrawal-min dogfood:

- Run: `/tmp/fiber-web-dogfood/run-2026-05-07T16-39-55-709Z`
- Screenshot: `withdraw-fail-1.png`
- Visual state: blank white page with only loading dots, no Fiber Link UI or retry message.

## Validation

- `node --check fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js`
- `npx --yes prettier --write ...`
- `git diff --check`

## Notes

The live demo is already hotpatched for #353. After this PR is green/merged, demo should be redeployed or hotpatched with this initializer + stylesheet change before the next full dogfood run.
