### PR TITLE
Fix tip button hydration no-op

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
@@ -1,15 +1,32 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import { scheduleOnce } from "@ember/runloop";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 
 import FiberLinkTipModal from "../modal/fiber-link-tip-modal";
-import { buildTipPostSummary, buildTipTopicTitle } from "../../lib/fiber-link-tip-context";
+import {
+  buildTipPostSummary,
+  buildTipTopicTitle,
+} from "../../lib/fiber-link-tip-context";
 
 export default class FiberLinkTipPostMenuButton extends Component {
   @service modal;
   @service siteSettings;
   @service currentUser;
+
+  @tracked clientReady = false;
+
+  constructor() {
+    super(...arguments);
+    scheduleOnce("afterRender", this, this.markClientReady);
+  }
+
+  @action
+  markClientReady() {
+    this.clientReady = true;
+  }
 
   get post() {
     return this.args?.post ?? null;
@@ -89,6 +106,7 @@ export default class FiberLinkTipPostMenuButton extends Component {
 
   get shouldShow() {
     return (
+      this.clientReady &&
       this.siteSettings.fiber_link_enabled &&
       !!this.currentUser &&
       !!this.postId &&
@@ -98,7 +116,7 @@ export default class FiberLinkTipPostMenuButton extends Component {
 
   @action
   openTipModal() {
-    if (!this.postId) {
+    if (!this.postId || !this.clientReady) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #356.

Prevents the post-menu Fiber Link Tip button from rendering until the Glimmer component has reached the browser `afterRender` phase. During stress navigation, Discourse can expose static/unstyled topic markup before the interactive client is ready; that static markup showed a visible gift button whose click had no live handler. Hiding the button until hydration avoids the silent no-op state.

## Verification

- `git diff --check`
- Focused demo dogfood evidence for #356: `/tmp/fiber-web-dogfood/run-2026-05-07T17-29-48-740Z`
  - unhydrated/static topic pages were detected before click
  - no longer treated as ready for Tip clicking

## Notes

Host lacks a local Discourse/Ruby test harness, so plugin smoke/visual acceptance CI are the authoritative integration checks.