### PR TITLE
Hide crawler fallback tip action

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
@@ -25,6 +25,7 @@ export default class FiberLinkTipPostMenuButton extends Component {
 
   @action
   markClientReady() {
+    document?.body?.classList?.add("fiber-link-client-ready");
     this.clientReady = true;
   }
 

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -11,6 +11,10 @@
   font-weight: 650;
 }
 
+body.crawler [data-fiber-link-tip-button="post-menu"] {
+  display: none !important;
+}
+
 .fiber-link-tip-button--icon-only {
   position: relative;
   display: inline-flex;

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -11,7 +11,7 @@
   font-weight: 650;
 }
 
-body.crawler [data-fiber-link-tip-button="post-menu"] {
+body:not(.fiber-link-client-ready) [data-fiber-link-tip-button="post-menu"] {
   display: none !important;
 }
 


### PR DESCRIPTION
## Summary

Follow-up for #356.

Hides the post-menu Fiber Link Tip action in Discourse crawler/static fallback markup. The first hydration guard in #357 prevents the client component from rendering the action before `afterRender`, but live stress dogfood showed the static/crawler HTML can still contain the gift button until a full rebuild catches up. This CSS guard prevents that static button from being visible/clickable, so the dogfood harness and users do not see a no-op Tip control before the Discourse client is interactive.

## Verification

- `npx --yes prettier --check fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss`
- `git diff --check`
- Live dogfood evidence for the remaining crawler/static fallback: `/tmp/fiber-web-dogfood/run-2026-05-07T17-43-21-765Z/tip-fail-0.png`

Refs #356.