### PR TITLE
Require hydrated tip button marker

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
@@ -25,7 +25,6 @@ export default class FiberLinkTipPostMenuButton extends Component {
 
   @action
   markClientReady() {
-    document?.body?.classList?.add("fiber-link-client-ready");
     this.clientReady = true;
   }
 
@@ -140,7 +139,7 @@ export default class FiberLinkTipPostMenuButton extends Component {
   <template>
     {{#if this.shouldShow}}
       <DButton
-        @class="post-action-menu__fiber-link-tip fiber-link-tip-button--icon-only"
+        @class="post-action-menu__fiber-link-tip fiber-link-tip-button--icon-only fiber-link-client-ready-button"
         @translatedTitle="Tip"
         @translatedAriaLabel="Tip"
         @icon="gift"

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -11,8 +11,12 @@
   font-weight: 650;
 }
 
-body:not(.fiber-link-client-ready) [data-fiber-link-tip-button="post-menu"] {
+[data-fiber-link-tip-button="post-menu"] {
   display: none !important;
+}
+
+[data-fiber-link-tip-button="post-menu"].fiber-link-client-ready-button {
+  display: inline-flex !important;
 }
 
 .fiber-link-tip-button--icon-only {


### PR DESCRIPTION
## Summary

Follow-up for #356 after the live 10-account dogfood proved #358's body-level readiness class was too broad: the body can keep `fiber-link-client-ready` after earlier hydrated pages, so static/crawler fallback markup can still leak a clickable Tip button.

This change makes the guard instance-scoped instead:

- hide every post-menu Fiber Link Tip button by default
- show only buttons with the hydrated component marker class `fiber-link-client-ready-button`
- add that marker only to the rendered hydrated component path, not to static fallback markup
- remove the global body readiness marker so readiness cannot leak across navigations

Fixes #356

## Tests

- `npx --yes prettier --check fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss`
- `git diff --check`

## Live dogfood evidence

Failed run proving #358 was insufficient:

- `/tmp/fiber-web-dogfood/run-2026-05-07T18-01-30-291Z`
- `tip-fail-0.png` still showed raw/static Discourse fallback with a visible gift/Tip button and no modal/error after click.
