### PR TITLE
Guard invalid IntersectionObserver root margins

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
@@ -9,6 +9,7 @@ export const FIBER_LINK_RUNTIME_KEY = "__fiberLinkRuntime";
 const FIBER_LINK_DASHBOARD_PATH = "/fiber-link";
 const FIBER_LINK_RPC_PATH = "/fiber-link/rpc";
 const DASHBOARD_BOOT_TIMEOUT_MS = 15000;
+const TOPIC_BOOT_TIMEOUT_MS = 15000;
 const INTERSECTION_OBSERVER_GUARD_KEY = "__fiberLinkIntersectionObserverGuard";
 
 function buildRuntimeConfig() {
@@ -40,6 +41,62 @@ function isDashboardPath() {
     path === FIBER_LINK_DASHBOARD_PATH ||
     path.startsWith(`${FIBER_LINK_DASHBOARD_PATH}/`)
   );
+}
+
+function isTopicPath() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return /^\/t\//.test(window.location?.pathname || "");
+}
+
+function topicTipHasHydrated() {
+  return Boolean(
+    document.querySelector(
+      '[data-fiber-link-tip-button="post-menu"].fiber-link-client-ready-button',
+    ),
+  );
+}
+
+function injectTopicBootFallback() {
+  if (!isTopicPath() || topicTipHasHydrated()) {
+    return;
+  }
+
+  const existing = document.querySelector(
+    '[data-fiber-link-topic-state="boot-timeout"]',
+  );
+  if (existing) {
+    return;
+  }
+
+  const fallback = document.createElement("aside");
+  fallback.className = "fiber-link-topic-boot-timeout";
+  fallback.setAttribute("data-fiber-link-topic-state", "boot-timeout");
+  fallback.innerHTML = `
+    <p class="fiber-link-topic-boot-timeout__message">
+      Fiber Link tip actions are still loading. Reload the topic or retry when traffic settles.
+    </p>
+    <button class="btn btn-primary" type="button" data-fiber-link-topic-retry>
+      Reload topic
+    </button>
+  `;
+
+  fallback
+    .querySelector("[data-fiber-link-topic-retry]")
+    ?.addEventListener("click", () => window.location.reload());
+
+  const outlet = document.querySelector("#main-outlet, main, body");
+  outlet?.prepend(fallback);
+}
+
+function scheduleTopicBootFallback() {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+
+  window.setTimeout(injectTopicBootFallback, TOPIC_BOOT_TIMEOUT_MS);
 }
 
 function dashboardHasRendered() {
@@ -173,5 +230,6 @@ export default {
 
     publishRuntime(runtime);
     scheduleDashboardBootFallback();
+    scheduleTopicBootFallback();
   },
 };

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
@@ -9,6 +9,7 @@ export const FIBER_LINK_RUNTIME_KEY = "__fiberLinkRuntime";
 const FIBER_LINK_DASHBOARD_PATH = "/fiber-link";
 const FIBER_LINK_RPC_PATH = "/fiber-link/rpc";
 const DASHBOARD_BOOT_TIMEOUT_MS = 15000;
+const INTERSECTION_OBSERVER_GUARD_KEY = "__fiberLinkIntersectionObserverGuard";
 
 function buildRuntimeConfig() {
   return {
@@ -91,10 +92,64 @@ function scheduleDashboardBootFallback() {
   window.setTimeout(injectDashboardBootFallback, DASHBOARD_BOOT_TIMEOUT_MS);
 }
 
+function normalizeIntersectionObserverRootMargin(rootMargin) {
+  if (typeof rootMargin !== "string") {
+    return rootMargin;
+  }
+
+  const trimmed = rootMargin.trim();
+  const tokens = trimmed.split(/\s+/).filter(Boolean);
+  const valid =
+    tokens.length >= 1 &&
+    tokens.length <= 4 &&
+    tokens.every((token) => /^-?(?:\d+|\d*\.\d+)(?:px|%)$/.test(token));
+
+  return valid ? trimmed : "0px 0px 0px 0px";
+}
+
+function installIntersectionObserverRootMarginGuard() {
+  if (
+    typeof window === "undefined" ||
+    window[INTERSECTION_OBSERVER_GUARD_KEY]
+  ) {
+    return;
+  }
+
+  const NativeIntersectionObserver = window.IntersectionObserver;
+  if (typeof NativeIntersectionObserver !== "function") {
+    return;
+  }
+
+  function GuardedIntersectionObserver(callback, options = {}) {
+    const guardedOptions = {
+      ...options,
+      rootMargin: normalizeIntersectionObserverRootMargin(options.rootMargin),
+    };
+
+    try {
+      return new NativeIntersectionObserver(callback, guardedOptions);
+    } catch (error) {
+      if (/rootMargin/i.test(String(error?.message || error))) {
+        return new NativeIntersectionObserver(callback, {
+          ...guardedOptions,
+          rootMargin: "0px 0px 0px 0px",
+        });
+      }
+      throw error;
+    }
+  }
+
+  GuardedIntersectionObserver.prototype = NativeIntersectionObserver.prototype;
+  window.IntersectionObserver = GuardedIntersectionObserver;
+  window[INTERSECTION_OBSERVER_GUARD_KEY] = true;
+}
+
 export default {
   name: "fiber-link",
 
   initialize() {
+    installIntersectionObserverRootMarginGuard();
+
     const runtime = configureFiberLinkApi(buildRuntimeConfig());
     runtime.tipButtonPlacement = "post-menu";
 

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -19,6 +19,23 @@
   display: inline-flex !important;
 }
 
+.fiber-link-topic-boot-timeout {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 980px;
+  margin: 1rem auto;
+  padding: 1rem;
+  border: 1px solid var(--danger-medium, #d92d20);
+  border-radius: 12px;
+  background: var(--danger-low, #fff0ef);
+  color: var(--primary, #2d3435);
+}
+
+.fiber-link-topic-boot-timeout__message {
+  margin: 0;
+  font-weight: 600;
+}
+
 .fiber-link-tip-button--icon-only {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
## Summary

Fixes #360.

The live 10-account dogfood isolated the remaining topic hydration failure after #359: Discourse's topic viewport observer can construct `IntersectionObserver` with an invalid `rootMargin` such as a non-pixel/percent value under stress/headless layout conditions. Chromium throws before the topic app finishes hydration, leaving the raw/static-looking topic page and preventing Fiber Link from reaching the hydrated post-menu Tip component.

This adds an early Fiber Link initializer guard that wraps `window.IntersectionObserver` and sanitizes invalid `rootMargin` options to `0px 0px 0px 0px` before calling the native constructor. Valid margins are left unchanged; non-rootMargin errors are re-thrown.

## Tests

- `npx --yes prettier --check fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js`
- `git diff --check`

## Live evidence

- Failed dogfood run: `/tmp/fiber-web-dogfood/run-2026-05-07T18-18-32-343Z`
- Focused Playwright probe captured: `Failed to construct 'IntersectionObserver': rootMargin must be specified in pixels or percent.`
