### PR TITLE
Inject topic fallback before Ember boot

### DIFF
--- a/fiber-link-discourse-plugin/plugin.rb
+++ b/fiber-link-discourse-plugin/plugin.rb
@@ -7,6 +7,40 @@ require_relative "lib/fiber_link/engine"
 enabled_site_setting :fiber_link_enabled
 register_asset "stylesheets/common/fiber-link.scss"
 
+FIBER_LINK_TOPIC_BOOT_FALLBACK_SCRIPT = <<~HTML
+  <script data-fiber-link-topic-boot-fallback>
+    (function() {
+      if (!/^\/t\//.test(window.location.pathname || "")) {
+        return;
+      }
+
+      window.setTimeout(function() {
+        if (document.querySelector('[data-fiber-link-tip-button="post-menu"].fiber-link-client-ready-button')) {
+          return;
+        }
+
+        if (document.querySelector('[data-fiber-link-topic-state="boot-timeout"]')) {
+          return;
+        }
+
+        var fallback = document.createElement("aside");
+        fallback.className = "fiber-link-topic-boot-timeout";
+        fallback.setAttribute("data-fiber-link-topic-state", "boot-timeout");
+        fallback.innerHTML = '<p class="fiber-link-topic-boot-timeout__message">Fiber Link tip actions are still loading. Reload the topic or retry when traffic settles.</p><button class="btn btn-primary" type="button" data-fiber-link-topic-retry>Reload topic</button>';
+        fallback.querySelector("[data-fiber-link-topic-retry]")?.addEventListener("click", function() {
+          window.location.reload();
+        });
+
+        (document.querySelector("#main-outlet, main, body") || document.body)?.prepend(fallback);
+      }, 15000);
+    })();
+  </script>
+HTML
+
+register_html_builder("server:before-body-close") do
+  FIBER_LINK_TOPIC_BOOT_FALLBACK_SCRIPT
+end
+
 after_initialize do
   require_dependency File.expand_path("lib/fiber_link/service_client.rb", __dir__)
   require_dependency File.expand_path("lib/fiber_link/tip_notification_sync.rb", __dir__)

--- a/fiber-link-discourse-plugin/plugin.rb
+++ b/fiber-link-discourse-plugin/plugin.rb
@@ -7,38 +7,41 @@ require_relative "lib/fiber_link/engine"
 enabled_site_setting :fiber_link_enabled
 register_asset "stylesheets/common/fiber-link.scss"
 
-FIBER_LINK_TOPIC_BOOT_FALLBACK_SCRIPT = <<~HTML
-  <script data-fiber-link-topic-boot-fallback>
-    (function() {
-      if (!/^\/t\//.test(window.location.pathname || "")) {
+FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY = <<~JS
+  (function() {
+    if (!/^\/t\//.test(window.location.pathname || "")) {
+      return;
+    }
+
+    window.setTimeout(function() {
+      if (document.querySelector('[data-fiber-link-tip-button="post-menu"].fiber-link-client-ready-button')) {
         return;
       }
 
-      window.setTimeout(function() {
-        if (document.querySelector('[data-fiber-link-tip-button="post-menu"].fiber-link-client-ready-button')) {
-          return;
-        }
+      if (document.querySelector('[data-fiber-link-topic-state="boot-timeout"]')) {
+        return;
+      }
 
-        if (document.querySelector('[data-fiber-link-topic-state="boot-timeout"]')) {
-          return;
-        }
+      var fallback = document.createElement("aside");
+      fallback.className = "fiber-link-topic-boot-timeout";
+      fallback.setAttribute("data-fiber-link-topic-state", "boot-timeout");
+      fallback.innerHTML = '<p class="fiber-link-topic-boot-timeout__message">Fiber Link tip actions are still loading. Reload the topic or retry when traffic settles.</p><button class="btn btn-primary" type="button" data-fiber-link-topic-retry>Reload topic</button>';
+      fallback.querySelector("[data-fiber-link-topic-retry]")?.addEventListener("click", function() {
+        window.location.reload();
+      });
 
-        var fallback = document.createElement("aside");
-        fallback.className = "fiber-link-topic-boot-timeout";
-        fallback.setAttribute("data-fiber-link-topic-state", "boot-timeout");
-        fallback.innerHTML = '<p class="fiber-link-topic-boot-timeout__message">Fiber Link tip actions are still loading. Reload the topic or retry when traffic settles.</p><button class="btn btn-primary" type="button" data-fiber-link-topic-retry>Reload topic</button>';
-        fallback.querySelector("[data-fiber-link-topic-retry]")?.addEventListener("click", function() {
-          window.location.reload();
-        });
+      (document.querySelector("#main-outlet, main, body") || document.body)?.prepend(fallback);
+    }, 15000);
+  })();
+JS
 
-        (document.querySelector("#main-outlet, main, body") || document.body)?.prepend(fallback);
-      }, 15000);
-    })();
-  </script>
-HTML
-
-register_html_builder("server:before-body-close") do
-  FIBER_LINK_TOPIC_BOOT_FALLBACK_SCRIPT
+register_html_builder("server:before-body-close") do |controller|
+  nonce = ContentSecurityPolicy.nonce_placeholder(controller.response.headers)
+  <<~HTML
+    <script nonce="#{nonce}" data-fiber-link-topic-boot-fallback>
+      #{FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY}
+    </script>
+  HTML
 end
 
 after_initialize do


### PR DESCRIPTION
## Summary

Fixes #362.

Adds a server-injected topic boot fallback script in `plugin.rb` so raw/no-Ember Discourse topic pages can still show an explicit Fiber Link retry message even when the plugin initializer bundle does not execute.

The script only activates on `/t/...` paths, waits 15s, and no-ops when the hydrated Fiber Link Tip button is already present. Otherwise it injects:

> Fiber Link tip actions are still loading. Reload the topic or retry when traffic settles.

This complements #358/#359/#361:

- no Tip/gift button is exposed until the hydrated component is ready;
- initializer-level fallback handles normal plugin JS execution;
- this PR covers static/no-Ember fallback markup where the initializer may never run.

## Validation

- `ruby -c fiber-link-discourse-plugin/plugin.rb` via `ruby:3.3-alpine`: Syntax OK
- `npx --yes prettier --check fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js`
- `git diff --check`

## Dogfood evidence

Latest failing run before this patch:

- `/tmp/fiber-web-dogfood/run-2026-05-07T18-58-50-456Z`
- Static fallback page had no Tip no-op, but also no Fiber Link-specific fallback message.
