### PR TITLE
Install topic fallback before head closes

### DIFF
--- a/fiber-link-discourse-plugin/plugin.rb
+++ b/fiber-link-discourse-plugin/plugin.rb
@@ -9,17 +9,21 @@ register_asset "stylesheets/common/fiber-link.scss"
 
 FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY = <<~JS
   (function() {
-    if (!/^\/t\//.test(window.location.pathname || "")) {
+    if ((window.location.pathname || "").indexOf("/t/") !== 0) {
       return;
     }
 
-    window.setTimeout(function() {
+    function prependFallback() {
       if (document.querySelector('[data-fiber-link-tip-button="post-menu"].fiber-link-client-ready-button')) {
-        return;
+        return true;
       }
 
       if (document.querySelector('[data-fiber-link-topic-state="boot-timeout"]')) {
-        return;
+        return true;
+      }
+
+      if (!document.body) {
+        return false;
       }
 
       var fallback = document.createElement("aside");
@@ -31,9 +35,33 @@ FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY = <<~JS
       });
 
       (document.querySelector("#main-outlet, main, body") || document.body)?.prepend(fallback);
+      return true;
+    }
+
+    window.setTimeout(function() {
+      if (prependFallback()) {
+        return;
+      }
+
+      var attempts = 0;
+      var interval = window.setInterval(function() {
+        attempts += 1;
+        if (prependFallback() || attempts >= 20) {
+          window.clearInterval(interval);
+        }
+      }, 250);
     }, 15000);
   })();
 JS
+
+register_html_builder("server:before-head-close") do |controller|
+  nonce = ContentSecurityPolicy.nonce_placeholder(controller.response.headers)
+  <<~HTML
+    <script nonce="#{nonce}" data-fiber-link-topic-head-boot-fallback>
+      #{FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY}
+    </script>
+  HTML
+end
 
 register_html_builder("server:before-body-close") do |controller|
   nonce = ContentSecurityPolicy.nonce_placeholder(controller.response.headers)


### PR DESCRIPTION
## Summary
- installs the Fiber Link topic boot fallback from `server:before-head-close` as well as before body close
- makes the fallback wait for `document.body` if the global spinner path stalls before body is ready
- replaces the inline regex path check with `pathname.indexOf("/t/")` to avoid inline-script regex parsing surprises

Fixes #364

## Test Plan
- `docker exec -i discourse-v440g0s04s44kks0okosossc /opt/bitnami/ruby/bin/ruby -c - < fiber-link-discourse-plugin/plugin.rb`
- `npx --yes prettier --check fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss`
- `git diff --check`

## Dogfood Evidence
- Previous full 1h run completed: `/tmp/fiber-web-dogfood/run-2026-05-07T19-29-22-943Z`
- Runner exit: 0, elapsed: 3,614,753 ms
- Remaining silent issue: representative screenshots `tip-fail-0.png` and `tip-fail-1705.png` showed Discourse global spinner-only without Fiber Link fallback text.
