### PR TITLE
Install dashboard fallback before head closes

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
@@ -48,7 +48,7 @@ function isTopicPath() {
     return false;
   }
 
-  return /^\/t\//.test(window.location?.pathname || "");
+  return (window.location?.pathname || "").indexOf("/t/") === 0;
 }
 
 function topicTipHasHydrated() {
@@ -149,6 +149,32 @@ function scheduleDashboardBootFallback() {
   window.setTimeout(injectDashboardBootFallback, DASHBOARD_BOOT_TIMEOUT_MS);
 }
 
+function monitorBootFallbacks() {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+
+  let observedPath = window.location?.pathname || "";
+  let observedAt = Date.now();
+
+  window.setInterval(() => {
+    const currentPath = window.location?.pathname || "";
+    if (currentPath !== observedPath) {
+      observedPath = currentPath;
+      observedAt = Date.now();
+    }
+
+    const elapsed = Date.now() - observedAt;
+    if (isDashboardPath() && elapsed >= DASHBOARD_BOOT_TIMEOUT_MS) {
+      injectDashboardBootFallback();
+    }
+
+    if (isTopicPath() && elapsed >= TOPIC_BOOT_TIMEOUT_MS) {
+      injectTopicBootFallback();
+    }
+  }, 1000);
+}
+
 function normalizeIntersectionObserverRootMargin(rootMargin) {
   if (typeof rootMargin !== "string") {
     return rootMargin;
@@ -231,5 +257,6 @@ export default {
     publishRuntime(runtime);
     scheduleDashboardBootFallback();
     scheduleTopicBootFallback();
+    monitorBootFallbacks();
   },
 };

--- a/fiber-link-discourse-plugin/plugin.rb
+++ b/fiber-link-discourse-plugin/plugin.rb
@@ -54,11 +54,67 @@ FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY = <<~JS
   })();
 JS
 
+FIBER_LINK_DASHBOARD_BOOT_FALLBACK_BODY = <<~JS
+  (function() {
+    if ((window.location.pathname || "") !== "/fiber-link") {
+      return;
+    }
+
+    function dashboardHasRendered() {
+      return Boolean(
+        document.querySelector('.fiber-link-dashboard, [data-fiber-link-dashboard-state="error"], [data-fiber-link-withdrawal-input="amount"]')
+      );
+    }
+
+    function appendFallback() {
+      if (dashboardHasRendered()) {
+        return true;
+      }
+
+      if (document.querySelector('[data-fiber-link-dashboard-state="boot-timeout"]')) {
+        return true;
+      }
+
+      if (!document.body) {
+        return false;
+      }
+
+      var fallback = document.createElement("main");
+      fallback.className = "fiber-link-dashboard fiber-link-dashboard__boot-timeout";
+      fallback.setAttribute("data-fiber-link-dashboard-state", "boot-timeout");
+      fallback.innerHTML = '<section class="fiber-link-dashboard__boot-timeout-card"><p class="fiber-link-dashboard__alert is-error">Fiber Link dashboard is still loading. The service may be busy; retry when traffic settles.</p><button class="btn btn-primary" type="button" data-fiber-link-dashboard-retry>Retry dashboard</button></section>';
+      fallback.querySelector("[data-fiber-link-dashboard-retry]")?.addEventListener("click", function() {
+        window.location.reload();
+      });
+
+      (document.querySelector("#main-outlet, main, body") || document.body)?.appendChild(fallback);
+      return true;
+    }
+
+    window.setTimeout(function() {
+      if (appendFallback()) {
+        return;
+      }
+
+      var attempts = 0;
+      var interval = window.setInterval(function() {
+        attempts += 1;
+        if (appendFallback() || attempts >= 20) {
+          window.clearInterval(interval);
+        }
+      }, 250);
+    }, 15000);
+  })();
+JS
+
 register_html_builder("server:before-head-close") do |controller|
   nonce = ContentSecurityPolicy.nonce_placeholder(controller.response.headers)
   <<~HTML
     <script nonce="#{nonce}" data-fiber-link-topic-head-boot-fallback>
       #{FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY}
+    </script>
+    <script nonce="#{nonce}" data-fiber-link-dashboard-head-boot-fallback>
+      #{FIBER_LINK_DASHBOARD_BOOT_FALLBACK_BODY}
     </script>
   HTML
 end
@@ -68,6 +124,9 @@ register_html_builder("server:before-body-close") do |controller|
   <<~HTML
     <script nonce="#{nonce}" data-fiber-link-topic-boot-fallback>
       #{FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY}
+    </script>
+    <script nonce="#{nonce}" data-fiber-link-dashboard-boot-fallback>
+      #{FIBER_LINK_DASHBOARD_BOOT_FALLBACK_BODY}
     </script>
   HTML
 end

--- a/fiber-link-discourse-plugin/plugin.rb
+++ b/fiber-link-discourse-plugin/plugin.rb
@@ -107,31 +107,31 @@ FIBER_LINK_DASHBOARD_BOOT_FALLBACK_BODY = <<~JS
   })();
 JS
 
-register_html_builder("server:before-head-close") do |controller|
-  nonce = ContentSecurityPolicy.nonce_placeholder(controller.response.headers)
-  <<~HTML
-    <script nonce="#{nonce}" data-fiber-link-topic-head-boot-fallback>
-      #{FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY}
-    </script>
-    <script nonce="#{nonce}" data-fiber-link-dashboard-head-boot-fallback>
-      #{FIBER_LINK_DASHBOARD_BOOT_FALLBACK_BODY}
-    </script>
-  HTML
-end
-
-register_html_builder("server:before-body-close") do |controller|
-  nonce = ContentSecurityPolicy.nonce_placeholder(controller.response.headers)
-  <<~HTML
-    <script nonce="#{nonce}" data-fiber-link-topic-boot-fallback>
-      #{FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY}
-    </script>
-    <script nonce="#{nonce}" data-fiber-link-dashboard-boot-fallback>
-      #{FIBER_LINK_DASHBOARD_BOOT_FALLBACK_BODY}
-    </script>
-  HTML
-end
-
 after_initialize do
+  register_html_builder("server:before-head-close") do |controller|
+    nonce = ContentSecurityPolicy.nonce_placeholder(controller.response.headers)
+    <<~HTML
+      <script nonce="#{nonce}" data-fiber-link-topic-head-boot-fallback>
+        #{FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY}
+      </script>
+      <script nonce="#{nonce}" data-fiber-link-dashboard-head-boot-fallback>
+        #{FIBER_LINK_DASHBOARD_BOOT_FALLBACK_BODY}
+      </script>
+    HTML
+  end
+
+  register_html_builder("server:before-body-close") do |controller|
+    nonce = ContentSecurityPolicy.nonce_placeholder(controller.response.headers)
+    <<~HTML
+      <script nonce="#{nonce}" data-fiber-link-topic-boot-fallback>
+        #{FIBER_LINK_TOPIC_BOOT_FALLBACK_BODY}
+      </script>
+      <script nonce="#{nonce}" data-fiber-link-dashboard-boot-fallback>
+        #{FIBER_LINK_DASHBOARD_BOOT_FALLBACK_BODY}
+      </script>
+    HTML
+  end
+
   require_dependency File.expand_path("lib/fiber_link/service_client.rb", __dir__)
   require_dependency File.expand_path("lib/fiber_link/tip_notification_sync.rb", __dir__)
   require_dependency File.expand_path("app/controllers/fiber_link/rpc_controller.rb", __dir__)


### PR DESCRIPTION
## Summary
- adds a server-side `/fiber-link` dashboard boot fallback alongside the existing topic fallback
- injects it from both `server:before-head-close` and `server:before-body-close`
- waits briefly for `document.body` before inserting the dashboard retry panel, avoiding a spinner-only page if Discourse/plugin boot stalls before the initializer runs

Fixes #366

## Test Plan
- `git diff --check`
- static plugin sanity: heredoc counts, builder count, and dashboard fallback markers present

## Dogfood Evidence
- Full post-#365 run completed: `/tmp/fiber-web-dogfood/run-2026-05-07T22-24-29-127Z`
- elapsed: 3,600,487 ms
- tip path: topic failures now show Fiber Link fallback/reload text instead of a clickable no-op
- remaining blocker: `/fiber-link` screenshots `withdraw-fail-0.png` and `withdraw-fail-59.png` are still pure Discourse global spinner-only
