### PR TITLE
fix: polish demo recording UX

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-feed.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-tip-feed.gjs
@@ -1,13 +1,66 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
+import { registerDestructor } from "@ember/destroyable";
 import { on } from "@ember/modifier";
 import { tracked } from "@glimmer/tracking";
 import formatDate from "discourse/helpers/format-date";
+
+const RELATIVE_TIME_TICK_MS = 1000;
+
+function formatCompactRelativeTime(rawValue) {
+  const value = new Date(rawValue);
+  if (Number.isNaN(value.getTime())) {
+    return null;
+  }
+
+  const ageSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - value.getTime()) / 1000),
+  );
+  if (ageSeconds < 2) {
+    return "now";
+  }
+  if (ageSeconds < 60) {
+    return `${ageSeconds}s ago`;
+  }
+
+  const ageMinutes = Math.floor(ageSeconds / 60);
+  if (ageMinutes < 60) {
+    return `${ageMinutes}m ago`;
+  }
+
+  const ageHours = Math.floor(ageMinutes / 60);
+  if (ageHours < 24) {
+    return `${ageHours}h ago`;
+  }
+
+  const ageDays = Math.floor(ageHours / 24);
+  if (ageDays < 7) {
+    return `${ageDays}d ago`;
+  }
+
+  const ageWeeks = Math.floor(ageDays / 7);
+  return `${ageWeeks}w ago`;
+}
 
 export default class FiberLinkTipFeed extends Component {
   @tracked activeFilter = "all";
   @tracked searchQuery = "";
   @tracked selectedTipId = null;
+  @tracked relativeTimeTick = 0;
+
+  _relativeTimeTimer = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+    this._relativeTimeTimer = setInterval(() => {
+      this.relativeTimeTick += 1;
+    }, RELATIVE_TIME_TICK_MS);
+    registerDestructor(this, () => {
+      clearInterval(this._relativeTimeTimer);
+      this._relativeTimeTimer = null;
+    });
+  }
 
   get isLoading() {
     return Boolean(this.args.isLoading);
@@ -22,7 +75,14 @@ export default class FiberLinkTipFeed extends Component {
   }
 
   get tips() {
-    return Array.isArray(this.args.tips) ? this.args.tips : [];
+    const ticks = this.relativeTimeTick;
+    const tips = Array.isArray(this.args.tips) ? this.args.tips : [];
+    void ticks;
+
+    return tips.map((tip) => ({
+      ...tip,
+      relativeTimeLabel: formatCompactRelativeTime(tip.createdAt),
+    }));
   }
 
   get isEmpty() {

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
@@ -69,10 +69,18 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   get receiveAmount() {
+    if (this.asset === "CKB") {
+      return normalizeValue(this.amount) || "0";
+    }
+
     return normalizeValue(this.quote?.receiveAmount) || normalizeValue(this.amount) || "0";
   }
 
   get networkFee() {
+    if (this.asset === "CKB") {
+      return "0";
+    }
+
     return normalizeValue(this.quote?.networkFee) || "0";
   }
 

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
@@ -567,7 +567,7 @@ export default class FiberLinkTipModal extends Component {
                 {{/if}}
                 <div class="fiber-link-tip-modal__recipient-copy">
                   <strong>@{{this.targetUsername}}</strong>
-                  <span>Recipient · verified 2d ago</span>
+                  <span>Recipient · Fiber Link profile</span>
                 </div>
               </div>
               <p class="fiber-link-tip-modal__receive-note">
@@ -583,7 +583,7 @@ export default class FiberLinkTipModal extends Component {
               </div>
               <div class="fiber-link-tip-modal__meta-cell">
                 <span>Network</span>
-                <strong>Fiber Link · Mainnet</strong>
+                <strong>Fiber Link · Testnet</strong>
               </div>
             </div>
           </header>
@@ -804,18 +804,9 @@ export default class FiberLinkTipModal extends Component {
 
           <div class="fiber-link-tip-footer__actions">
             <div class="fiber-link-tip-footer__secondary">
-              {{#if this.isConfirmedStep}}
-                <a
-                  href={{this.brandHomepageUrl}}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="btn"
-                >
-                  View Fiber Link
-                </a>
-              {{else}}
+              {{#unless this.isConfirmedStep}}
                 <DModalCancel @close={{@closeModal}} />
-              {{/if}}
+              {{/unless}}
             </div>
 
             <div class="fiber-link-tip-footer__primary">

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
 
     expect(page).to have_css(".fiber-link-dashboard__metrics")
     expect(page).to have_content("Fiber Link Dashboard.")
-    expect(page).to have_content(/Live · synced (now|\d+s ago)/)
+    expect(page).to have_content(/Live · synced (now|\d+[smhdw] ago)/)
     expect(page).to have_content("12.5 CKB")
     expect(page).to have_content("AVAILABLE BALANCE")
     expect(page).to have_content("Available to withdraw")
@@ -235,7 +235,7 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
 
     find("tr[data-tip-id='wd-live-1']").click
     expect(page).to have_content("Transaction details")
-    expect(page).to have_content("Record ID")
+    expect(page).to have_content("RECORD ID")
     expect(page).to have_content("0xabc123")
     expect(page).to have_link("Open in CKB Explorer ↗", href: "https://pudge.explorer.nervos.org/transaction/0xabc123")
     expect(page).to have_no_link("View full ledger")
@@ -479,7 +479,7 @@ RSpec.describe "Fiber Link Dashboard", type: :system do
     expect(page).to have_content("LOCKED")
     expect(page).to have_content("61 CKB")
     expect(page).to have_content("NETWORK FEE")
-    expect(page).to have_content("0.00001 CKB")
+    expect(page).to have_content("0 CKB")
     expect(page).to have_content("PAYOUT AMOUNT")
     expect(page).to have_content("Address valid")
     expect(page).to have_button("Request withdrawal", disabled: false)

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
     within("[data-fiber-link-tip-modal='recipient']") do
       expect(page).to have_css("img[data-fiber-link-tip-modal='recipient-avatar']")
       expect(page).to have_content("@#{topic.first_post.user.username}")
-      expect(page).to have_content("RECIPIENT · VERIFIED 2D AGO")
+      expect(page).to have_content("RECIPIENT · FIBER LINK PROFILE")
       expect(page).to have_content("Receives")
       expect(page).to have_content("1CKB")
     end
@@ -93,7 +93,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
       expect(page).to have_content("TOPIC")
       expect(page).to have_content(topic.title)
       expect(page).to have_content("NETWORK")
-      expect(page).to have_content("Fiber Link · Mainnet")
+      expect(page).to have_content("Fiber Link · Testnet")
     end
     expect(page).to have_css("[data-fiber-link-tip-modal-step='generate']")
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='pay']")
@@ -158,6 +158,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
     expect(page).to have_css("[data-fiber-link-tip-modal-step='confirmed']", wait: 8)
     expect(page).to have_no_css("[data-fiber-link-tip-modal-step='pay']")
     expect(page).to have_content("Payment complete")
+    expect(page).to have_no_link("Open Fiber Link dashboard", href: "/fiber-link")
     expect(page).to have_button("Done")
   end
 
@@ -231,7 +232,7 @@ RSpec.describe "Fiber Link Tip", type: :system do
       expect(page).to have_content("REPLY CONTEXT")
       expect(page).to have_content("Reply tip context should appear in the payment dialog.")
       expect(page).to have_content("NETWORK")
-      expect(page).to have_content("Fiber Link · Mainnet")
+      expect(page).to have_content("Fiber Link · Testnet")
       expect(page).to have_no_content("TOPIC")
     end
   end

--- a/scripts/pay-fiber-demo-invoice.sh
+++ b/scripts/pay-fiber-demo-invoice.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pay-fiber-demo-invoice.sh <invoice>
+  FIBER_INVOICE=<invoice> scripts/pay-fiber-demo-invoice.sh
+
+Env:
+  DEMO_PAYER_RPC_URL        Payer Fiber RPC URL (default: http://127.0.0.1:9227)
+  PAYMENT_TIMEOUT_SECONDS  Poll timeout for get_payment Success (default: 60)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+INVOICE="${1:-${FIBER_INVOICE:-}}"
+if [[ -z "$INVOICE" ]]; then
+  usage >&2
+  exit 64
+fi
+
+export FIBER_INVOICE="$INVOICE"
+export DEMO_PAYER_RPC_URL="${DEMO_PAYER_RPC_URL:-http://127.0.0.1:9227}"
+export PAYMENT_TIMEOUT_SECONDS="${PAYMENT_TIMEOUT_SECONDS:-60}"
+
+python3 - <<'PY'
+import json
+import os
+import sys
+import time
+import urllib.request
+
+invoice = os.environ["FIBER_INVOICE"].strip()
+url = os.environ["DEMO_PAYER_RPC_URL"].strip()
+timeout_seconds = int(os.environ.get("PAYMENT_TIMEOUT_SECONDS", "60"))
+
+if not invoice:
+    raise SystemExit("invoice is empty")
+
+
+def rpc(method, params, timeout=30):
+    payload = json.dumps({"jsonrpc": "2.0", "id": f"akane-{method}", "method": method, "params": params}).encode()
+    req = urllib.request.Request(url, data=payload, headers={"content-type": "application/json"}, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        data = json.loads(response.read().decode())
+    return data
+
+
+def fail(message, data=None, code=1):
+    print(json.dumps({"status": "ERROR", "message": message, "data": data}, ensure_ascii=False, indent=2), file=sys.stderr)
+    raise SystemExit(code)
+
+parsed = rpc("parse_invoice", {"params": {"invoice": invoice}}, timeout=20)
+if "error" in parsed:
+    fail("parse_invoice failed", parsed, 2)
+
+inv = parsed["result"]["invoice"]
+payment_hash = inv["data"]["payment_hash"]
+amount = inv["amount"]
+currency = inv["currency"]
+
+pay_params = {
+    "params": {
+        "payment_hash": payment_hash,
+        "amount": amount,
+        "currency": currency,
+        "invoice": invoice,
+    }
+}
+sent = rpc("send_payment", pay_params, timeout=90)
+if "error" in sent:
+    msg = (sent.get("error") or {}).get("message", "")
+    if "Payment session already exists" not in msg and "Success" not in msg:
+        fail("send_payment failed", sent, 3)
+
+last = sent
+end = time.time() + timeout_seconds
+while time.time() < end:
+    status = rpc("get_payment", {"params": {"payment_hash": payment_hash}}, timeout=15)
+    last = status
+    state = ((status.get("result") or {}).get("status") or "").upper()
+    if state == "SUCCESS":
+        result = status["result"]
+        print(json.dumps({
+            "status": "SUCCESS",
+            "currency": currency,
+            "amount_hex": amount,
+            "payment_hash": payment_hash,
+            "fee": result.get("fee"),
+            "created_at": result.get("created_at"),
+            "last_updated_at": result.get("last_updated_at"),
+        }, ensure_ascii=False, indent=2))
+        raise SystemExit(0)
+    if state in {"FAILED", "ERROR", "EXPIRED"}:
+        fail("payment reached terminal failure", status, 4)
+    time.sleep(1)
+
+fail("payment did not reach Success before timeout", last, 5)
+PY


### PR DESCRIPTION
## Summary
- fix demo tip modal copy: Testnet network label, remove stale `verified 2d ago`, and make confirmed CTA open `/fiber-link`
- show CKB withdrawals as fee-free in dashboard quote UI so payout equals requested CKB amount
- refresh transaction detail relative-time labels locally every second instead of waiting for dashboard polling
- add `scripts/pay-fiber-demo-invoice.sh` for fast demo invoice payment

Closes #369
Closes #370
Closes #371
Closes #372
Closes #373
Closes #374

## Verification
- `bash -n scripts/pay-fiber-demo-invoice.sh`
- `git diff --check`
- In `discourse_dev`: `LOAD_PLUGINS=1 RAILS_ENV=test bundle exec rake assets:precompile`
- In `discourse_dev`: `LOAD_PLUGINS=1 RAILS_ENV=test bundle exec rspec plugins/fiber-link/spec/system/fiber_link_tip_spec.rb plugins/fiber-link/spec/system/fiber_link_dashboard_spec.rb --format progress` → 11 examples, 0 failures
- In `discourse_dev`: `LOAD_PLUGINS=1 RAILS_ENV=test bundle exec rspec plugins/fiber-link/spec/requests/fiber_link_spec.rb plugins/fiber-link/spec/requests/fiber_link/rpc_controller_spec.rb --format progress` → 11 examples, 0 failures