### PR TITLE
feat(discourse): nudge Tip button after appreciation actions

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/post-menu/fiber-link-tip-post-menu-button.gjs
@@ -145,6 +145,7 @@ export default class FiberLinkTipPostMenuButton extends Component {
         @icon="gift"
         @action={{this.openTipModal}}
         data-fiber-link-tip-button="post-menu"
+        data-fiber-link-tip-post-id={{this.postId}}
         ...attributes
       />
     {{/if}}

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js
@@ -10,7 +10,20 @@ const FIBER_LINK_DASHBOARD_PATH = "/fiber-link";
 const FIBER_LINK_RPC_PATH = "/fiber-link/rpc";
 const DASHBOARD_BOOT_TIMEOUT_MS = 15000;
 const TOPIC_BOOT_TIMEOUT_MS = 15000;
+const TIP_NUDGE_DURATION_MS = 1400;
+const TIP_NUDGE_EVENT_DELAY_MS = 180;
 const INTERSECTION_OBSERVER_GUARD_KEY = "__fiberLinkIntersectionObserverGuard";
+const TIP_NUDGE_SESSION_KEY = "__fiberLinkTipNudgedPosts";
+const TIP_NUDGE_ACTION_SELECTOR = [
+  ".toggle-like",
+  ".post-action-menu__like",
+  ".post-action-menu__bookmark",
+  ".bookmark",
+  "[data-post-action='like']",
+  "[data-post-action='bookmark']",
+  "[data-action-name='like']",
+  "[data-action-name='bookmark']",
+].join(", ");
 
 function buildRuntimeConfig() {
   return {
@@ -227,6 +240,101 @@ function installIntersectionObserverRootMarginGuard() {
   window[INTERSECTION_OBSERVER_GUARD_KEY] = true;
 }
 
+function installTipNudgeListener() {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+
+  if (window.__fiberLinkTipNudgeListenerInstalled) {
+    return;
+  }
+
+  window.__fiberLinkTipNudgeListenerInstalled = true;
+  window[TIP_NUDGE_SESSION_KEY] = window[TIP_NUDGE_SESSION_KEY] || new Set();
+
+  document.addEventListener(
+    "click",
+    (event) => {
+      const action = event.target?.closest?.(TIP_NUDGE_ACTION_SELECTOR);
+      if (
+        !action ||
+        action.closest?.('[data-fiber-link-tip-button="post-menu"]')
+      ) {
+        return;
+      }
+
+      const postElement = action.closest?.(
+        "[data-post-id], article[data-post-id], article[id^='post_'], .topic-post, .boxed",
+      );
+      if (!postElement) {
+        return;
+      }
+
+      const postId =
+        postElement?.dataset?.postId || postElement?.id?.replace(/^post_/, "");
+
+      window.setTimeout(
+        () => triggerTipNudge(postId, postElement),
+        TIP_NUDGE_EVENT_DELAY_MS,
+      );
+    },
+    true,
+  );
+}
+
+function escapeCssIdentifier(value) {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+
+  return value.replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+}
+
+function triggerTipNudge(postId, postElement) {
+  const sessionKey = postId ? String(postId) : null;
+  const nudgedPosts = window[TIP_NUDGE_SESSION_KEY];
+
+  if (sessionKey && nudgedPosts.has(sessionKey)) {
+    return;
+  }
+
+  const scopedSelector = postId
+    ? `[data-fiber-link-tip-button="post-menu"][data-fiber-link-tip-post-id="${escapeCssIdentifier(String(postId))}"]`
+    : '[data-fiber-link-tip-button="post-menu"]';
+  const tipButton = postElement?.querySelector?.(scopedSelector);
+
+  if (
+    !tipButton ||
+    tipButton.disabled ||
+    tipButton.getAttribute("aria-disabled") === "true"
+  ) {
+    return;
+  }
+
+  if (sessionKey) {
+    nudgedPosts.add(sessionKey);
+  }
+
+  tipButton.classList.remove("fiber-link-tip-nudge");
+  tipButton.removeAttribute("data-fiber-link-tip-nudge");
+  tipButton.removeAttribute("data-fiber-link-tip-nudge-text");
+
+  window.requestAnimationFrame(() => {
+    tipButton.classList.add("fiber-link-tip-nudge");
+    tipButton.setAttribute("data-fiber-link-tip-nudge", "active");
+    tipButton.setAttribute(
+      "data-fiber-link-tip-nudge-text",
+      i18n("fiber_link.tip_nudge_text"),
+    );
+
+    window.setTimeout(() => {
+      tipButton.classList.remove("fiber-link-tip-nudge");
+      tipButton.removeAttribute("data-fiber-link-tip-nudge");
+      tipButton.removeAttribute("data-fiber-link-tip-nudge-text");
+    }, TIP_NUDGE_DURATION_MS);
+  });
+}
+
 export default {
   name: "fiber-link",
 
@@ -258,5 +366,6 @@ export default {
     scheduleDashboardBootFallback();
     scheduleTopicBootFallback();
     monitorBootFallbacks();
+    installTipNudgeListener();
   },
 };

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -19,6 +19,55 @@
   display: inline-flex !important;
 }
 
+@keyframes fiber-link-tip-nudge-pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(15, 143, 68, 0);
+  }
+
+  38% {
+    transform: scale(1.045);
+    box-shadow: 0 0 0 5px rgba(15, 143, 68, 0.18);
+  }
+
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 10px rgba(15, 143, 68, 0);
+  }
+}
+
+[data-fiber-link-tip-button="post-menu"].fiber-link-tip-nudge {
+  animation: fiber-link-tip-nudge-pulse 1.2s ease-out 1;
+  color: var(--success, #0f8f44);
+}
+
+[data-fiber-link-tip-button="post-menu"].fiber-link-tip-nudge::after {
+  content: attr(data-fiber-link-tip-nudge-text);
+  position: absolute;
+  z-index: 2;
+  bottom: calc(100% + 0.35rem);
+  left: 50%;
+  width: max-content;
+  max-width: 10rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  background: var(--primary, #2d3435);
+  color: var(--secondary, #fff);
+  font-size: 0.75rem;
+  font-weight: 650;
+  line-height: 1.2;
+  pointer-events: none;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-fiber-link-tip-button="post-menu"].fiber-link-tip-nudge {
+    animation: none;
+    box-shadow: 0 0 0 3px rgba(15, 143, 68, 0.18);
+  }
+}
+
 .fiber-link-topic-boot-timeout {
   display: grid;
   gap: 0.75rem;

--- a/fiber-link-discourse-plugin/config/locales/client.en.yml
+++ b/fiber-link-discourse-plugin/config/locales/client.en.yml
@@ -8,5 +8,6 @@ en:
       dashboard:
         user_menu_link: "Fiber Link Dashboard"
       tip_received_notification: "<p><span>%{username}</span> tipped you <span>%{amount} %{asset}</span>.</p>"
+      tip_nudge_text: "Send a small tip"
       notification:
         title: "you received a tip"

--- a/fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb
+++ b/fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb
@@ -219,6 +219,38 @@ RSpec.describe "Fiber Link Tip", type: :system do
     expect(page).to have_css("[data-fiber-link-tip-modal='copy-invoice'] .d-icon-copy")
   end
 
+  it "nudges the matching post Tip button after an appreciation action" do
+    visit topic.relative_url
+
+    expect(page).to have_css(".post-action-menu__fiber-link-tip[data-fiber-link-tip-button='post-menu']")
+
+    page.execute_script(<<~JS)
+      const tipButton = document.querySelector(
+        ".post-action-menu__fiber-link-tip[data-fiber-link-tip-button='post-menu']",
+      );
+      const post = tipButton.closest("[data-post-id], article[id^='post_'], .topic-post, .boxed");
+      const action = document.createElement("button");
+      action.type = "button";
+      action.className = "toggle-like";
+      action.textContent = "Like";
+      post.appendChild(action);
+      action.click();
+    JS
+
+    expect(page).to have_css(
+      ".post-action-menu__fiber-link-tip[data-fiber-link-tip-nudge='active'][data-fiber-link-tip-nudge-text='Send a small tip']",
+      wait: 2,
+    )
+    expect(page).to have_no_css(
+      ".post-action-menu__fiber-link-tip[data-fiber-link-tip-nudge='active']",
+      wait: 3,
+    )
+    expect(page).to have_no_css(
+      ".post-action-menu__fiber-link-tip[data-fiber-link-tip-nudge-text]",
+      wait: 1,
+    )
+  end
+
   it "labels the context as a reply when opened from a reply tip button" do
     visit topic.relative_url
     expect(page).to have_css(


### PR DESCRIPTION
## Summary

- [x] Add a low-frequency post-level Tip button nudge after Like/Bookmark-style appreciation clicks.
- [x] Add transient `data-fiber-link-tip-nudge="active"` / `.fiber-link-tip-nudge` state to the matching post-menu Tip button only.
- [x] Add subtle pulse + tooltip styling with a `prefers-reduced-motion` static-highlight fallback.
- [x] Cover the DOM contract in the Fiber Link tip system spec.

Closes #378

## Scope

- [x] Filesystem scope is limited to the Fiber Link Discourse plugin Tip button initializer, post-menu button data attributes, shared SCSS, and the related system spec.

## Verification

- [x] `bunx prettier --check fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss`
- [x] `git diff --check`
- [x] `node --check fiber-link-discourse-plugin/assets/javascripts/discourse/initializers/fiber-link.js`
- [x] Synced plugin into `discourse_dev` and ran `LOAD_PLUGINS=1 RAILS_ENV=test bundle exec rake assets:precompile`
- [x] `LOAD_PLUGINS=1 RAILS_ENV=test bundle exec rspec plugins/fiber-link/spec/system/fiber_link_tip_spec.rb --format progress` — 4 examples, 0 failures

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided
- [x] Required discussions or follow-ups are documented

## Notes

- The nudge never opens the tip modal automatically; it only adds a short-lived visual state to the existing post action button.
- The implementation is session-scoped so the same post is nudged at most once per browser session.
