### PR TITLE
fix(withdrawals): reap stale processing withdrawals

### DIFF
--- a/fiber-link-service/apps/worker/src/withdrawal-batch.test.ts
+++ b/fiber-link-service/apps/worker/src/withdrawal-batch.test.ts
@@ -206,6 +206,61 @@ describe("runWithdrawalBatch", () => {
     expect(secondSaved.state).toBe("COMPLETED");
   });
 
+  it("reaps stale PROCESSING withdrawals to RETRY_PENDING without executing them in the same batch", async () => {
+    const created = await repo.create({
+      appId: "app1",
+      userId: "u1",
+      asset: "USDI",
+      amount: "10",
+      toAddress: "fiber:invoice:stale-processing",
+    });
+    await repo.markProcessing(created.id, new Date("2026-02-07T12:00:00.000Z"));
+    const executeWithdrawal = vi.fn(async () => ({ ok: true, txHash: "0xshould-not-run" }) as const);
+
+    const res = await runWithdrawalBatch({
+      now: new Date("2026-02-07T12:10:00.000Z"),
+      processingLeaseMs: 5 * 60_000,
+      retryDelayMs: 60_000,
+      executeWithdrawal,
+      repo,
+    });
+
+    expect(res.processed).toBe(0);
+    expect(res.reapedProcessing).toBe(1);
+    expect(executeWithdrawal).not.toHaveBeenCalled();
+    const saved = await repo.findByIdOrThrow(created.id);
+    expect(saved.state).toBe("RETRY_PENDING");
+    expect(saved.retryCount).toBe(1);
+    expect(saved.lastError).toBe("processing lease expired");
+    expect(saved.nextRetryAt?.toISOString()).toBe("2026-02-07T12:11:00.000Z");
+  });
+
+  it("does not reap fresh PROCESSING withdrawals", async () => {
+    const created = await repo.create({
+      appId: "app1",
+      userId: "u1",
+      asset: "USDI",
+      amount: "10",
+      toAddress: "fiber:invoice:fresh-processing",
+    });
+    await repo.markProcessing(created.id, new Date("2026-02-07T12:09:00.000Z"));
+    const executeWithdrawal = vi.fn(async () => ({ ok: true, txHash: "0xshould-not-run" }) as const);
+
+    const res = await runWithdrawalBatch({
+      now: new Date("2026-02-07T12:10:00.000Z"),
+      processingLeaseMs: 5 * 60_000,
+      retryDelayMs: 60_000,
+      executeWithdrawal,
+      repo,
+    });
+
+    expect(res.processed).toBe(0);
+    expect(res.reapedProcessing).toBe(0);
+    expect(executeWithdrawal).not.toHaveBeenCalled();
+    const saved = await repo.findByIdOrThrow(created.id);
+    expect(saved.state).toBe("PROCESSING");
+  });
+
   it("persists txHash evidence when withdrawal execution succeeds", async () => {
     const ledger = createInMemoryLedgerRepo();
     const created = await repo.create({

--- a/fiber-link-service/apps/worker/src/withdrawal-batch.test.ts
+++ b/fiber-link-service/apps/worker/src/withdrawal-batch.test.ts
@@ -214,6 +214,12 @@ describe("runWithdrawalBatch", () => {
       amount: "10",
       toAddress: "fiber:invoice:stale-processing",
     });
+    await repo.markProcessing(created.id, new Date("2026-02-07T11:58:00.000Z"));
+    await repo.markRetryPending(created.id, {
+      now: new Date("2026-02-07T11:59:00.000Z"),
+      nextRetryAt: new Date("2026-02-07T12:00:00.000Z"),
+      error: "previous transient failure",
+    });
     await repo.markProcessing(created.id, new Date("2026-02-07T12:00:00.000Z"));
     const executeWithdrawal = vi.fn(async () => ({ ok: true, txHash: "0xshould-not-run" }) as const);
 
@@ -230,9 +236,9 @@ describe("runWithdrawalBatch", () => {
     expect(executeWithdrawal).not.toHaveBeenCalled();
     const saved = await repo.findByIdOrThrow(created.id);
     expect(saved.state).toBe("RETRY_PENDING");
-    expect(saved.retryCount).toBe(1);
+    expect(saved.retryCount).toBe(2);
     expect(saved.lastError).toBe("processing lease expired");
-    expect(saved.nextRetryAt?.toISOString()).toBe("2026-02-07T12:11:00.000Z");
+    expect(saved.nextRetryAt?.toISOString()).toBe("2026-02-07T12:12:00.000Z");
   });
 
   it("does not reap fresh PROCESSING withdrawals", async () => {

--- a/fiber-link-service/apps/worker/src/withdrawal-batch.ts
+++ b/fiber-link-service/apps/worker/src/withdrawal-batch.ts
@@ -38,6 +38,7 @@ export type RunWithdrawalBatchOptions = {
   now?: Date;
   maxRetries?: number;
   retryDelayMs?: number;
+  processingLeaseMs?: number;
   executeWithdrawal?: (withdrawal: WithdrawalRecord) => Promise<WithdrawalExecutionResult>;
   confirmWithdrawal?: (withdrawal: WithdrawalRecord) => Promise<WithdrawalConfirmationResult>;
   ledgerRepo?: LedgerRepo;
@@ -227,6 +228,7 @@ export async function runWithdrawalBatch(options: RunWithdrawalBatchOptions = {}
   // maxRetries counts retry attempts after the initial processing attempt.
   const maxRetries = options.maxRetries ?? 3;
   const retryDelayMs = options.retryDelayMs ?? 60_000;
+  const processingLeaseMs = options.processingLeaseMs ?? 5 * 60_000;
   const executeWithdrawal = options.executeWithdrawal ?? defaultExecuteWithdrawal;
   const confirmWithdrawal = options.confirmWithdrawal ?? defaultConfirmWithdrawal;
   const repo = options.repo ?? getDefaultRepo();
@@ -381,5 +383,14 @@ export async function runWithdrawalBatch(options: RunWithdrawalBatchOptions = {}
     }
   }
 
-  return { processed, broadcasted, completed, retryPending, failed, skipped };
+  const reapedProcessing = (
+    await repo.reapStaleProcessing({
+      now,
+      staleBefore: new Date(now.getTime() - processingLeaseMs),
+      nextRetryAt: new Date(now.getTime() + retryDelayMs),
+      error: "processing lease expired",
+    })
+  ).length;
+
+  return { processed, broadcasted, completed, retryPending, failed, skipped, reapedProcessing };
 }

--- a/fiber-link-service/apps/worker/src/withdrawal-batch.ts
+++ b/fiber-link-service/apps/worker/src/withdrawal-batch.ts
@@ -387,7 +387,7 @@ export async function runWithdrawalBatch(options: RunWithdrawalBatchOptions = {}
     await repo.reapStaleProcessing({
       now,
       staleBefore: new Date(now.getTime() - processingLeaseMs),
-      nextRetryAt: new Date(now.getTime() + retryDelayMs),
+      baseRetryDelayMs: retryDelayMs,
       error: "processing lease expired",
     })
   ).length;

--- a/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
@@ -512,6 +512,38 @@ describe("createDbWithdrawalRepo", () => {
     const ready = await repo.listReadyForProcessing(new Date("2026-02-07T00:01:00.000Z"));
     expect(ready.map((item) => item.id)).toEqual(["p1", "r1"]);
   });
+
+  it("reaps stale PROCESSING rows atomically into RETRY_PENDING", async () => {
+    const mock = createDbMock();
+    const repo = createDbWithdrawalRepo(mock.db);
+    const now = new Date("2026-02-07T12:10:00.000Z");
+    const nextRetryAt = new Date("2026-02-07T12:11:00.000Z");
+
+    mock.updateReturning.mockResolvedValueOnce([
+      mockRow({
+        id: "stale1",
+        state: "RETRY_PENDING",
+        retryCount: 2,
+        nextRetryAt,
+        lastError: "processing lease expired",
+        updatedAt: now,
+      }),
+    ]);
+
+    const reaped = await repo.reapStaleProcessing({
+      now,
+      staleBefore: new Date("2026-02-07T12:05:00.000Z"),
+      nextRetryAt,
+      error: "processing lease expired",
+    });
+
+    expect(reaped.map((item) => item.id)).toEqual(["stale1"]);
+    const setArg = mock.updateSet.mock.calls[0][0] as Record<string, unknown>;
+    expect(setArg.state).toBe("RETRY_PENDING");
+    expect(setArg.retryCount).not.toBe(2);
+    expect(setArg.nextRetryAt).toBe(nextRetryAt);
+    expect(setArg.lastError).toBe("processing lease expired");
+  });
 });
 
 describe("createInMemoryWithdrawalRepo balance gating", () => {

--- a/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
@@ -517,14 +517,13 @@ describe("createDbWithdrawalRepo", () => {
     const mock = createDbMock();
     const repo = createDbWithdrawalRepo(mock.db);
     const now = new Date("2026-02-07T12:10:00.000Z");
-    const nextRetryAt = new Date("2026-02-07T12:11:00.000Z");
 
     mock.updateReturning.mockResolvedValueOnce([
       mockRow({
         id: "stale1",
         state: "RETRY_PENDING",
         retryCount: 2,
-        nextRetryAt,
+        nextRetryAt: new Date("2026-02-07T12:12:00.000Z"),
         lastError: "processing lease expired",
         updatedAt: now,
       }),
@@ -533,7 +532,7 @@ describe("createDbWithdrawalRepo", () => {
     const reaped = await repo.reapStaleProcessing({
       now,
       staleBefore: new Date("2026-02-07T12:05:00.000Z"),
-      nextRetryAt,
+      baseRetryDelayMs: 60_000,
       error: "processing lease expired",
     });
 
@@ -541,7 +540,8 @@ describe("createDbWithdrawalRepo", () => {
     const setArg = mock.updateSet.mock.calls[0][0] as Record<string, unknown>;
     expect(setArg.state).toBe("RETRY_PENDING");
     expect(setArg.retryCount).not.toBe(2);
-    expect(setArg.nextRetryAt).toBe(nextRetryAt);
+    expect(setArg.nextRetryAt).toBeDefined();
+    expect(setArg.nextRetryAt).not.toBeInstanceOf(Date);
     expect(setArg.lastError).toBe("processing lease expired");
   });
 });

--- a/fiber-link-service/packages/db/src/withdrawal-repo.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.ts
@@ -88,6 +88,13 @@ export type CompletionDeps = {
   ledgerRepo: LedgerRepo;
 };
 
+export type ReapStaleProcessingInput = {
+  now: Date;
+  staleBefore: Date;
+  nextRetryAt: Date;
+  error: string;
+};
+
 export type WithdrawalRepo = {
   create(input: CreateWithdrawalInput): Promise<WithdrawalRecord>;
   createLiquidityPending(input: CreateLiquidityPendingWithdrawalInput): Promise<WithdrawalRecord>;
@@ -102,6 +109,7 @@ export type WithdrawalRepo = {
   listLiquidityPending(): Promise<WithdrawalRecord[]>;
   listReadyForProcessing(now: Date): Promise<WithdrawalRecord[]>;
   listBroadcastedForConfirmation(): Promise<WithdrawalRecord[]>;
+  reapStaleProcessing(input: ReapStaleProcessingInput): Promise<WithdrawalRecord[]>;
   markPendingFromLiquidity(id: string, now: Date): Promise<WithdrawalRecord>;
   markProcessing(id: string, now: Date): Promise<WithdrawalRecord>;
   markBroadcastedWithDebit(id: string, params: { now: Date; txHash: string }, deps: CompletionDeps): Promise<WithdrawalRecord>;
@@ -406,6 +414,21 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
         .select()
         .from(withdrawals)
         .where(eq(withdrawals.state, "BROADCASTED"));
+      return rows.map(toRecord);
+    },
+
+    async reapStaleProcessing(input) {
+      const rows = await db
+        .update(withdrawals)
+        .set({
+          state: "RETRY_PENDING",
+          retryCount: sql`${withdrawals.retryCount} + 1`,
+          nextRetryAt: input.nextRetryAt,
+          lastError: input.error,
+          updatedAt: input.now,
+        })
+        .where(and(eq(withdrawals.state, "PROCESSING"), lte(withdrawals.updatedAt, input.staleBefore)))
+        .returning();
       return rows.map(toRecord);
     },
 
@@ -740,6 +763,22 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
 
     async listBroadcastedForConfirmation() {
       return records.filter((item) => item.state === "BROADCASTED").map(clone);
+    },
+
+    async reapStaleProcessing(input) {
+      const reaped: WithdrawalRecord[] = [];
+      for (const record of records) {
+        if (record.state !== "PROCESSING" || record.updatedAt > input.staleBefore) {
+          continue;
+        }
+        record.state = "RETRY_PENDING";
+        record.retryCount += 1;
+        record.nextRetryAt = input.nextRetryAt;
+        record.lastError = input.error;
+        record.updatedAt = input.now;
+        reaped.push(clone(record));
+      }
+      return reaped;
     },
 
     async markPendingFromLiquidity(id, now) {

--- a/fiber-link-service/packages/db/src/withdrawal-repo.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.ts
@@ -4,6 +4,7 @@ import type { DbClient } from "./client";
 import { assertPositiveAmount, formatDecimal, parseDecimal, pow10 } from "./amount";
 import { withdrawalDebitIdempotencyKey } from "./idempotency";
 import { createDbLedgerRepo, type LedgerRepo } from "./ledger-repo";
+import { computeRetryDelay } from "./retry";
 import { withdrawals, type Asset, type WithdrawalDestinationKind, type WithdrawalState } from "./schema";
 
 export type WithdrawalAsset = Asset;
@@ -91,7 +92,7 @@ export type CompletionDeps = {
 export type ReapStaleProcessingInput = {
   now: Date;
   staleBefore: Date;
-  nextRetryAt: Date;
+  baseRetryDelayMs: number;
   error: string;
 };
 
@@ -423,7 +424,7 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
         .set({
           state: "RETRY_PENDING",
           retryCount: sql`${withdrawals.retryCount} + 1`,
-          nextRetryAt: input.nextRetryAt,
+          nextRetryAt: sql`${input.now} + ((${input.baseRetryDelayMs} * pow(2, least(${withdrawals.retryCount}, 8))) || ' milliseconds')::interval`,
           lastError: input.error,
           updatedAt: input.now,
         })
@@ -771,9 +772,10 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
         if (record.state !== "PROCESSING" || record.updatedAt > input.staleBefore) {
           continue;
         }
+        const computedRetryDelayMs = computeRetryDelay(input.baseRetryDelayMs, record.retryCount);
         record.state = "RETRY_PENDING";
         record.retryCount += 1;
-        record.nextRetryAt = input.nextRetryAt;
+        record.nextRetryAt = new Date(input.now.getTime() + computedRetryDelayMs);
         record.lastError = input.error;
         record.updatedAt = input.now;
         reaped.push(clone(record));


### PR DESCRIPTION
## Summary
- add a withdrawal repo reaper that moves stale PROCESSING rows back to RETRY_PENDING with retry metadata
- run the reaper from the worker batch using a processing lease so fresh PROCESSING rows are not double-executed
- cover stale/fresh PROCESSING recovery paths and the atomic db update with tests

## Test Plan
- bunx vitest run packages/db/src/withdrawal-repo.test.ts apps/worker/src/withdrawal-batch.test.ts
- bunx vitest run packages/db apps/worker/src/withdrawal-batch.test.ts apps/worker/src/withdrawal-reconciliation.test.ts

Closes #385