### PR TITLE
fix(worker): retry transient withdrawal network errors

### DIFF
--- a/fiber-link-service/apps/worker/src/withdrawal-batch.test.ts
+++ b/fiber-link-service/apps/worker/src/withdrawal-batch.test.ts
@@ -559,22 +559,27 @@ describe("runWithdrawalBatch", () => {
     expect(saved.retryCount).toBe(1);
   });
 
-  it("does not use string heuristics for non-Fiber errors", async () => {
-    const created = await createPendingWithdrawal("non-fiber-timeout");
+  it.each([
+    ["AbortError", Object.assign(new Error("aborted"), { name: "AbortError" })],
+    ["ECONNRESET", Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })],
+    ["ETIMEDOUT", Object.assign(new Error("request timed out"), { code: "ETIMEDOUT" })],
+    ["timeout message", new Error("network timeout")],
+  ])("maps non-Fiber %s withdrawal exception to transient retry", async (label, error) => {
+    const created = await createPendingWithdrawal(`non-fiber-${label}`);
 
     const res = await runWithdrawalBatch({
       now: new Date("2026-02-07T12:46:00.000Z"),
+      retryDelayMs: 60_000,
       executeWithdrawal: async () => {
-        throw new Error("network timeout");
+        throw error;
       },
       repo,
     });
 
-    expect(res.failed).toBe(1);
+    expect(res.retryPending).toBe(1);
     const saved = await repo.findByIdOrThrow(created.id);
-    expect(saved.state).toBe("FAILED");
-    expect(saved.retryCount).toBe(0);
-    expect(saved.nextRetryAt).toBeNull();
+    expect(saved.state).toBe("RETRY_PENDING");
+    expect(saved.retryCount).toBe(1);
   });
 
   it("uses adapter execution for USDI withdrawals to CKB addresses by default", async () => {

--- a/fiber-link-service/apps/worker/src/withdrawal-batch.ts
+++ b/fiber-link-service/apps/worker/src/withdrawal-batch.ts
@@ -158,6 +158,17 @@ const FIBER_WITHDRAWAL_ERROR_CONTRACT = {
     kind: "transient" as const,
   },
   transientHttpStatus: new Set([408, 425, 429, 500, 502, 503, 504]),
+  transientErrorCodes: new Set([
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "ECONNABORTED",
+    "ETIMEDOUT",
+    "ENOTFOUND",
+    "EAI_AGAIN",
+    "EPIPE",
+  ]),
+  transientMessagePattern:
+    /\b(?:abort(?:ed)?|fetch failed|network error|timeout|timed out|ECONNRESET|ECONNREFUSED|ECONNABORTED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|EPIPE)\b/i,
   defaultFiberKind: "transient" as const,
   defaultUnknownKind: "permanent" as const,
 };
@@ -200,6 +211,27 @@ function classifyFiberRpcError(error: FiberRpcError): ExecutionFailureKind {
   return FIBER_WITHDRAWAL_ERROR_CONTRACT.defaultFiberKind;
 }
 
+function getErrorCode(error: unknown): string | null {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return null;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}
+
+function isTransientNetworkError(error: unknown, message: string): boolean {
+  if (error instanceof Error && error.name === "AbortError") {
+    return true;
+  }
+
+  const code = getErrorCode(error);
+  if (code && FIBER_WITHDRAWAL_ERROR_CONTRACT.transientErrorCodes.has(code)) {
+    return true;
+  }
+
+  return FIBER_WITHDRAWAL_ERROR_CONTRACT.transientMessagePattern.test(message);
+}
+
 function classifyExecutionError(error: unknown): { kind: "transient" | "permanent"; reason: string } {
   const message = toErrorMessage(error);
   if (error instanceof WithdrawalExecutionError) {
@@ -207,6 +239,9 @@ function classifyExecutionError(error: unknown): { kind: "transient" | "permanen
   }
   if (error instanceof FiberRpcError) {
     return { kind: classifyFiberRpcError(error), reason: message };
+  }
+  if (isTransientNetworkError(error, message)) {
+    return { kind: "transient", reason: message };
   }
   return { kind: FIBER_WITHDRAWAL_ERROR_CONTRACT.defaultUnknownKind, reason: message };
 }

--- a/fiber-link-service/apps/worker/src/withdrawal-batch.ts
+++ b/fiber-link-service/apps/worker/src/withdrawal-batch.ts
@@ -167,8 +167,7 @@ const FIBER_WITHDRAWAL_ERROR_CONTRACT = {
     "EAI_AGAIN",
     "EPIPE",
   ]),
-  transientMessagePattern:
-    /\b(?:abort(?:ed)?|fetch failed|network error|timeout|timed out|ECONNRESET|ECONNREFUSED|ECONNABORTED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|EPIPE)\b/i,
+  transientMessagePattern: /\b(?:abort(?:ed)?|fetch failed|network error|timeout|timed out)\b/i,
   defaultFiberKind: "transient" as const,
   defaultUnknownKind: "permanent" as const,
 };
@@ -212,10 +211,7 @@ function classifyFiberRpcError(error: FiberRpcError): ExecutionFailureKind {
 }
 
 function getErrorCode(error: unknown): string | null {
-  if (!error || typeof error !== "object" || !("code" in error)) {
-    return null;
-  }
-  const code = (error as { code?: unknown }).code;
+  const code = (error as { code?: unknown } | null | undefined)?.code;
   return typeof code === "string" ? code : null;
 }
 


### PR DESCRIPTION
Summary
- Classify AbortError, timeout, and common network error-code withdrawal exceptions as transient retryable failures.
- Preserve permanent handling for invalid/policy-style unknown errors and existing Fiber RPC 4xx/JSON-RPC invalid param mappings.
- Add regression coverage for non-Fiber network/timeout withdrawal exceptions.

Test Plan
- bunx vitest run apps/worker/src/withdrawal-batch.test.ts -t 'maps non-Fiber'
- bunx vitest run apps/worker/src/withdrawal-batch.test.ts packages/fiber-adapter/src/fiber-client.test.ts

Closes #386