### PR TITLE
Enforce open liquidity request uniqueness

### DIFF
--- a/fiber-link-service/packages/db/drizzle/0009_liquidity_requests_open_unique.sql
+++ b/fiber-link-service/packages/db/drizzle/0009_liquidity_requests_open_unique.sql
@@ -1,0 +1,65 @@
+WITH ranked_open_liquidity_requests AS (
+  SELECT
+    "id",
+    "app_id",
+    "asset",
+    "network",
+    "source_kind",
+    "required_amount",
+    ROW_NUMBER() OVER (
+      PARTITION BY "app_id", "asset", "network", "source_kind"
+      ORDER BY "created_at" ASC, "id" ASC
+    ) AS "rank"
+  FROM "liquidity_requests"
+  WHERE "state" IN ('REQUESTED', 'REBALANCING')
+), open_liquidity_request_groups AS (
+  SELECT
+    "app_id",
+    "asset",
+    "network",
+    "source_kind",
+    MAX("required_amount") AS "required_amount"
+  FROM ranked_open_liquidity_requests
+  GROUP BY "app_id", "asset", "network", "source_kind"
+)
+UPDATE "liquidity_requests" AS keepers
+SET
+  "required_amount" = groups."required_amount",
+  "updated_at" = now()
+FROM open_liquidity_request_groups AS groups
+WHERE keepers."app_id" = groups."app_id"
+  AND keepers."asset" = groups."asset"
+  AND keepers."network" = groups."network"
+  AND keepers."source_kind" = groups."source_kind"
+  AND keepers."state" IN ('REQUESTED', 'REBALANCING')
+  AND keepers."id" IN (
+    SELECT "id"
+    FROM ranked_open_liquidity_requests
+    WHERE "rank" = 1
+  );
+
+WITH ranked_open_liquidity_requests AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "app_id", "asset", "network", "source_kind"
+      ORDER BY "created_at" ASC, "id" ASC
+    ) AS "rank"
+  FROM "liquidity_requests"
+  WHERE "state" IN ('REQUESTED', 'REBALANCING')
+)
+UPDATE "liquidity_requests"
+SET
+  "state" = 'FAILED',
+  "last_error" = 'deduplicated before adding liquidity_requests_open_key_unique',
+  "updated_at" = now(),
+  "completed_at" = now()
+WHERE "id" IN (
+  SELECT "id"
+  FROM ranked_open_liquidity_requests
+  WHERE "rank" > 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "liquidity_requests_open_key_unique"
+  ON "liquidity_requests" ("app_id", "asset", "network", "source_kind")
+  WHERE "state" IN ('REQUESTED', 'REBALANCING');

--- a/fiber-link-service/packages/db/src/liquidity-request-repo.test.ts
+++ b/fiber-link-service/packages/db/src/liquidity-request-repo.test.ts
@@ -29,7 +29,8 @@ function mockRow(overrides: Record<string, unknown> = {}) {
 
 function createDbMock() {
   const insertReturning = vi.fn();
-  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insertOnConflictDoUpdate = vi.fn(() => ({ returning: insertReturning }));
+  const insertValues = vi.fn(() => ({ returning: insertReturning, onConflictDoUpdate: insertOnConflictDoUpdate }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
   const selectLimit = vi.fn();
@@ -49,7 +50,7 @@ function createDbMock() {
     update,
   } as unknown as DbClient;
 
-  return { db, insertValues, insertReturning, selectLimit, updateSet, updateReturning };
+  return { db, insertValues, insertOnConflictDoUpdate, insertReturning, selectLimit, updateSet, updateReturning };
 }
 
 describe("createInMemoryLiquidityRequestRepo", () => {
@@ -343,6 +344,47 @@ describe("createDbLiquidityRequestRepo", () => {
     });
 
     expect(found?.id).toBe("liq1");
+  });
+
+  it("uses a single upsert to ensure an open liquidity request by key", async () => {
+    const mock = createDbMock();
+    const repo = createDbLiquidityRequestRepo(mock.db);
+    mock.insertReturning.mockResolvedValueOnce([
+      mockRow({
+        id: "liq1",
+        requiredAmount: "125",
+        metadata: { existing: "keep", next: "merge" },
+      }),
+    ]);
+
+    const ensured = await repo.ensureOpen({
+      appId: "app1",
+      asset: "CKB",
+      network: "AGGRON4",
+      sourceKind: "FIBER_TO_CKB_CHAIN",
+      requiredAmount: "125",
+      metadata: { next: "merge" },
+    });
+
+    expect(ensured.id).toBe("liq1");
+    expect(mock.selectLimit).not.toHaveBeenCalled();
+    expect(mock.insertOnConflictDoUpdate).toHaveBeenCalledTimes(1);
+    expect(mock.insertOnConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: [
+          expect.objectContaining({ name: "app_id" }),
+          expect.objectContaining({ name: "asset" }),
+          expect.objectContaining({ name: "network" }),
+          expect.objectContaining({ name: "source_kind" }),
+        ],
+        set: expect.objectContaining({
+          requiredAmount: expect.anything(),
+          metadata: expect.anything(),
+          updatedAt: expect.anything(),
+        }),
+        targetWhere: expect.anything(),
+      }),
+    );
   });
 
   it("marks a liquidity request REBALANCING and merges metadata", async () => {

--- a/fiber-link-service/packages/db/src/liquidity-request-repo.ts
+++ b/fiber-link-service/packages/db/src/liquidity-request-repo.ts
@@ -122,10 +122,10 @@ const OPEN_LIQUIDITY_REQUEST_KEY_CONFLICT_TARGET = [
   liquidityRequests.network,
   liquidityRequests.sourceKind,
 ] as const;
-const OPEN_LIQUIDITY_REQUEST_KEY_CONFLICT_WHERE = sql`${liquidityRequests.state} IN (
-  'REQUESTED',
-  'REBALANCING'
-)`;
+const OPEN_LIQUIDITY_REQUEST_KEY_CONFLICT_WHERE = inArray(
+  liquidityRequests.state,
+  [...OPEN_LIQUIDITY_REQUEST_STATES],
+);
 
 function normalizeMetadata(metadata: unknown): LiquidityRequestMetadata | null {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {

--- a/fiber-link-service/packages/db/src/liquidity-request-repo.ts
+++ b/fiber-link-service/packages/db/src/liquidity-request-repo.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import type { DbClient } from "./client";
 import { assertPositiveAmount, compareDecimalStrings, formatDecimal, parseDecimal } from "./amount";
 import {
@@ -116,6 +116,16 @@ export type LiquidityRequestRepo = {
 
 type LiquidityRequestRow = typeof liquidityRequests.$inferSelect;
 const OPEN_LIQUIDITY_REQUEST_STATES = ["REQUESTED", "REBALANCING"] as const;
+const OPEN_LIQUIDITY_REQUEST_KEY_CONFLICT_TARGET = [
+  liquidityRequests.appId,
+  liquidityRequests.asset,
+  liquidityRequests.network,
+  liquidityRequests.sourceKind,
+] as const;
+const OPEN_LIQUIDITY_REQUEST_KEY_CONFLICT_WHERE = sql`${liquidityRequests.state} IN (
+  'REQUESTED',
+  'REBALANCING'
+)`;
 
 function normalizeMetadata(metadata: unknown): LiquidityRequestMetadata | null {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
@@ -284,48 +294,41 @@ export function createDbLiquidityRequestRepo(db: DbClient): LiquidityRequestRepo
     findOpenByKey,
 
     async ensureOpen(input) {
+      const now = new Date();
       const requiredAmount = normalizeAmount(input.requiredAmount);
-      const existing = await findOpenByKey(input);
-      if (!existing) {
-        return createRequested({
-          ...input,
-          requiredAmount,
-        });
-      }
+      const conflictSet: Record<string, unknown> = {
+        requiredAmount: sql`GREATEST(${liquidityRequests.requiredAmount}, EXCLUDED.required_amount)`,
+        updatedAt: now,
+      };
 
-      const nextRequiredAmount = maxRequiredAmount(existing.requiredAmount, requiredAmount);
-      if (
-        nextRequiredAmount === existing.requiredAmount &&
-        input.metadata === undefined
-      ) {
-        return existing;
+      if (input.metadata !== undefined) {
+        conflictSet.metadata = input.metadata === null
+          ? null
+          : sql`COALESCE(${liquidityRequests.metadata}, '{}'::jsonb) || EXCLUDED.metadata`;
       }
 
       const [row] = await db
-        .update(liquidityRequests)
-        .set({
-          requiredAmount: nextRequiredAmount,
-          metadata: mergeMetadata(existing.metadata, input.metadata),
-          updatedAt: new Date(),
+        .insert(liquidityRequests)
+        .values({
+          appId: input.appId,
+          asset: input.asset,
+          network: input.network,
+          state: "REQUESTED",
+          sourceKind: input.sourceKind,
+          requiredAmount,
+          fundedAmount: "0",
+          metadata: input.metadata ?? null,
+          lastError: null,
+          createdAt: now,
+          updatedAt: now,
+          completedAt: null,
         })
-        .where(
-          and(
-            eq(liquidityRequests.id, existing.id),
-            inArray(liquidityRequests.state, [...OPEN_LIQUIDITY_REQUEST_STATES]),
-          ),
-        )
+        .onConflictDoUpdate({
+          target: [...OPEN_LIQUIDITY_REQUEST_KEY_CONFLICT_TARGET],
+          targetWhere: OPEN_LIQUIDITY_REQUEST_KEY_CONFLICT_WHERE,
+          set: conflictSet,
+        })
         .returning();
-
-      if (!row) {
-        const latest = await findById(existing.id);
-        if (!latest || !isOpenState(latest.state)) {
-          return createRequested({
-            ...input,
-            requiredAmount,
-          });
-        }
-        throw new LiquidityRequestStateTransitionError(existing.id, latest.state, latest.state);
-      }
 
       return toRecord(row);
     },

--- a/fiber-link-service/packages/db/src/schema.test.ts
+++ b/fiber-link-service/packages/db/src/schema.test.ts
@@ -133,6 +133,25 @@ describe("schema", () => {
     expect(notificationRules.channelId.name).toBe("channel_id");
   });
 
+  it("defines a partial unique index for one open liquidity request per key", () => {
+    const config = getTableConfig(liquidityRequests);
+    const openUnique = config.indexes.find(
+      (index) => index.config.name === "liquidity_requests_open_key_unique",
+    );
+
+    expect(openUnique).toBeDefined();
+    expect(openUnique?.config.unique).toBe(true);
+    expect(openUnique?.config.columns.map((column) => column.name)).toEqual([
+      "app_id",
+      "asset",
+      "network",
+      "source_kind",
+    ]);
+    const whereTokens = collectSqlTokens(openUnique?.config.where);
+    expect(whereTokens.some((token) => token.includes("REQUESTED"))).toBe(true);
+    expect(whereTokens.some((token) => token.includes("REBALANCING"))).toBe(true);
+  });
+
   it("defines liquidity gating constraints on withdrawals", () => {
     const config = getTableConfig(withdrawals);
     const liquidityRequestFk = config.foreignKeys.find(

--- a/fiber-link-service/packages/db/src/schema.ts
+++ b/fiber-link-service/packages/db/src/schema.ts
@@ -272,6 +272,9 @@ export const liquidityRequests = pgTable(
       table.createdAt,
       table.id,
     ),
+    openKeyUnique: uniqueIndex("liquidity_requests_open_key_unique")
+      .on(table.appId, table.asset, table.network, table.sourceKind)
+      .where(sql`${table.state} IN ('REQUESTED', 'REBALANCING')`),
   }),
 );
 


### PR DESCRIPTION
## Summary
- Add a partial unique index for open liquidity requests keyed by app, asset, network, and source kind.
- Convert DB ensureOpen() to a single conflict-targeted upsert that reuses the existing open row and keeps the max required amount/merged metadata.
- Add a migration to deduplicate existing open rows before creating the unique index and cover the schema/upsert behavior with tests.

## Test Plan
- bun test packages/db/src/schema.test.ts packages/db/src/liquidity-request-repo.test.ts
- bun run --cwd packages/db db:validate
- bun test packages/db/src

Closes #388