### PR TITLE
Fix withdrawal request idempotency

### DIFF
--- a/fiber-link-service/apps/rpc/src/contracts.test.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.test.ts
@@ -86,6 +86,7 @@ describe("rpc contracts", () => {
         userId: "u1",
         asset: "USDI",
         amount: "1",
+        clientRequestId: "withdrawal-retry-1",
         destination: {
           kind: "PAYMENT_REQUEST",
           paymentRequest: "fiber:invoice:example",
@@ -105,17 +106,17 @@ describe("rpc contracts", () => {
       }).state,
     ).toBe("LIQUIDITY_PENDING");
     expect(
-      WithdrawalRequestResultSchema.safeParse({
+      WithdrawalRequestResultSchema.parse({
         id: "w2",
         state: "RETRY_PENDING",
-      }).success,
-    ).toBe(false);
+      }).state,
+    ).toBe("RETRY_PENDING");
     expect(
-      WithdrawalRequestResultSchema.safeParse({
+      WithdrawalRequestResultSchema.parse({
         id: "w3",
         state: "COMPLETED",
-      }).success,
-    ).toBe(false);
+      }).state,
+    ).toBe("COMPLETED");
     expect(DashboardWithdrawalStateFilterSchema.options).toContain("LIQUIDITY_PENDING");
     expect(
       DashboardSummaryResultSchema.safeParse({

--- a/fiber-link-service/apps/rpc/src/contracts.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.ts
@@ -42,6 +42,7 @@ const WithdrawalRequestBaseParamsSchema = z.object({
   userId: z.string().min(1),
   asset: z.enum(["CKB", "USDI"]),
   amount: PositiveAmountStringSchema,
+  clientRequestId: z.string().trim().min(1).max(128).optional(),
 });
 export const WithdrawalDestinationSchema = z.discriminatedUnion("kind", [
   z.object({
@@ -85,11 +86,10 @@ export const WithdrawalRequestParamsSchema = z
       userId: value.userId,
       asset: value.asset,
       amount: value.amount,
+      clientRequestId: value.clientRequestId,
       destination: inferWithdrawalDestinationFromLegacyToAddress(value.toAddress),
     };
   });
-
-const WithdrawalRequestAcceptedStateSchema = z.enum(["LIQUIDITY_PENDING", "PENDING"]);
 
 const WithdrawalStateSchema = z.enum([
   "LIQUIDITY_PENDING",
@@ -103,7 +103,7 @@ const WithdrawalStateSchema = z.enum([
 
 export const WithdrawalRequestResultSchema = z.object({
   id: z.string().min(1),
-  state: WithdrawalRequestAcceptedStateSchema,
+  state: WithdrawalStateSchema,
 });
 
 export const WithdrawalQuoteParamsSchema = z.object({

--- a/fiber-link-service/apps/rpc/src/methods/withdrawal-policy.ts
+++ b/fiber-link-service/apps/rpc/src/methods/withdrawal-policy.ts
@@ -19,6 +19,7 @@ export type RequestWithdrawalInput = {
   userId: string;
   asset: Asset;
   amount: string;
+  clientRequestId?: string;
   destination: WithdrawalDestination;
 };
 

--- a/fiber-link-service/apps/rpc/src/methods/withdrawal.test.ts
+++ b/fiber-link-service/apps/rpc/src/methods/withdrawal.test.ts
@@ -134,6 +134,75 @@ describe("requestWithdrawal", () => {
     expect(saved.nextRetryAt).toBeNull();
   });
 
+  it("returns the same withdrawal when a clientRequestId is retried", async () => {
+    const ledger = createInMemoryLedgerRepo();
+    await ledger.creditOnce({
+      appId: "app1",
+      userId: "u1",
+      asset: "USDI",
+      amount: "10",
+      refId: "t1",
+      idempotencyKey: "credit:t1",
+    });
+
+    const input = {
+      appId: "app1",
+      userId: "u1",
+      asset: "USDI" as const,
+      amount: "10",
+      clientRequestId: "withdrawal-retry-1",
+      destination: {
+        kind: "PAYMENT_REQUEST" as const,
+        paymentRequest: "fiber:invoice:idempotent",
+      },
+    };
+
+    const first = await requestWithdrawal(input, { repo, ledgerRepo: ledger });
+    const second = await requestWithdrawal(input, { repo, ledgerRepo: ledger });
+
+    expect(second).toEqual(first);
+    expect(await repo.getPendingTotal({ appId: "app1", userId: "u1", asset: "USDI" })).toBe("10");
+  });
+
+  it("returns the current withdrawal state when a completed clientRequestId is retried", async () => {
+    const ledger = createInMemoryLedgerRepo();
+    await ledger.creditOnce({
+      appId: "app1",
+      userId: "u1",
+      asset: "USDI",
+      amount: "10",
+      refId: "t1",
+      idempotencyKey: "credit:t1",
+    });
+
+    const input = {
+      appId: "app1",
+      userId: "u1",
+      asset: "USDI" as const,
+      amount: "10",
+      clientRequestId: "withdrawal-retry-completed",
+      destination: {
+        kind: "PAYMENT_REQUEST" as const,
+        paymentRequest: "fiber:invoice:idempotent-completed",
+      },
+    };
+
+    const first = await requestWithdrawal(input, { repo, ledgerRepo: ledger });
+    await repo.markProcessing(first.id, new Date("2026-02-27T12:00:00.000Z"));
+    await repo.markCompletedWithDebit(
+      first.id,
+      {
+        now: new Date("2026-02-27T12:01:00.000Z"),
+        txHash: "0xcompleted",
+      },
+      { ledgerRepo: ledger },
+    );
+
+    const second = await requestWithdrawal(input, { repo, ledgerRepo: ledger });
+
+    expect(second).toEqual({ id: first.id, state: "COMPLETED" });
+  });
+
   it("rejects request when available balance is insufficient", async () => {
     const ledger = createInMemoryLedgerRepo();
     await ledger.creditOnce({

--- a/fiber-link-service/apps/rpc/src/methods/withdrawal.ts
+++ b/fiber-link-service/apps/rpc/src/methods/withdrawal.ts
@@ -215,6 +215,17 @@ export async function requestWithdrawal(input: RequestWithdrawalInput, options: 
   const ledgerRepo = options.ledgerRepo ?? getDefaultLedgerRepo();
   const policyRepo = options.policyRepo === undefined ? getDefaultPolicyRepo() : options.policyRepo;
 
+  if (input.clientRequestId) {
+    const existing = await repo.findByClientRequestId({
+      appId: input.appId,
+      userId: input.userId,
+      clientRequestId: input.clientRequestId,
+    });
+    if (existing) {
+      return { id: existing.id, state: existing.state };
+    }
+  }
+
   const policy = (policyRepo ? await policyRepo.getByAppId(input.appId) : null) ?? defaultPolicyForApp(input.appId);
   const usage = policyRepo
     ? await policyRepo.getUsage({
@@ -234,6 +245,7 @@ export async function requestWithdrawal(input: RequestWithdrawalInput, options: 
     userId: input.userId,
     asset: input.asset,
     amount: input.amount,
+    clientRequestId: input.clientRequestId,
     ...mapDestinationForStorage(input.destination),
   };
 

--- a/fiber-link-service/packages/db/drizzle/0009_withdrawal_client_request_id.sql
+++ b/fiber-link-service/packages/db/drizzle/0009_withdrawal_client_request_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "withdrawals"
+  ADD COLUMN IF NOT EXISTS "client_request_id" text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "withdrawals_app_user_client_request_unique"
+  ON "withdrawals" ("app_id", "user_id", "client_request_id")
+  WHERE "client_request_id" IS NOT NULL;

--- a/fiber-link-service/packages/db/src/schema.ts
+++ b/fiber-link-service/packages/db/src/schema.ts
@@ -227,11 +227,15 @@ export const withdrawals = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
     completedAt: timestamp("completed_at"),
     txHash: text("tx_hash"),
+    clientRequestId: text("client_request_id"),
     liquidityRequestId: uuid("liquidity_request_id").references(() => liquidityRequests.id),
     liquidityPendingReason: text("liquidity_pending_reason"),
     liquidityCheckedAt: timestamp("liquidity_checked_at"),
   },
   (table) => ({
+    clientRequestUnique: uniqueIndex("withdrawals_app_user_client_request_unique")
+      .on(table.appId, table.userId, table.clientRequestId)
+      .where(sql`${table.clientRequestId} IS NOT NULL`),
     byStateRetryAt: index("withdrawals_state_next_retry_at_idx").on(table.state, table.nextRetryAt, table.createdAt),
     byAccountAssetState: index("withdrawals_account_asset_state_idx").on(table.appId, table.userId, table.asset, table.state),
     liquidityPendingFieldsCheck: check(

--- a/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
@@ -583,6 +583,47 @@ describe("createInMemoryWithdrawalRepo balance gating", () => {
     expect(created.state).toBe("PENDING");
   });
 
+  it("returns the existing withdrawal for duplicate client request ids without reserving funds twice", async () => {
+    const ledger = createInMemoryLedgerRepo();
+    const repo = createInMemoryWithdrawalRepo();
+
+    await ledger.creditOnce({
+      appId: "app1",
+      userId: "u1",
+      asset: "USDI",
+      amount: "10",
+      refId: "credit-1",
+      idempotencyKey: "credit-1",
+    });
+
+    const first = await repo.createWithBalanceCheck(
+      {
+        appId: "app1",
+        userId: "u1",
+        asset: "USDI",
+        amount: "10",
+        toAddress: "fiber:invoice:idempotent",
+        clientRequestId: "withdrawal-retry-1",
+      },
+      { ledgerRepo: ledger },
+    );
+    const second = await repo.createWithBalanceCheck(
+      {
+        appId: "app1",
+        userId: "u1",
+        asset: "USDI",
+        amount: "10",
+        toAddress: "fiber:invoice:idempotent",
+        clientRequestId: "withdrawal-retry-1",
+      },
+      { ledgerRepo: ledger },
+    );
+
+    expect(second.id).toBe(first.id);
+    expect(second.clientRequestId).toBe("withdrawal-retry-1");
+    expect(await repo.getPendingTotal({ appId: "app1", userId: "u1", asset: "USDI" })).toBe("10");
+  });
+
   it("creates a withdrawal in LIQUIDITY_PENDING with linked liquidity request", async () => {
     const repo = createInMemoryWithdrawalRepo();
 

--- a/fiber-link-service/packages/db/src/withdrawal-repo.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.ts
@@ -184,6 +184,29 @@ async function findByClientRequestIdWithClient(
   return row ? toRecord(row) : null;
 }
 
+async function acquireClientRequestLock(
+  client: DbClient,
+  input: { appId: string; userId: string; clientRequestId?: string },
+): Promise<void> {
+  if (!input.clientRequestId) return;
+
+  const clientRequestLockKey = `${input.appId}:${input.userId}:client-request:${input.clientRequestId}`;
+  await client.execute(sql`select pg_advisory_xact_lock(hashtext(${clientRequestLockKey}))`);
+}
+
+async function findExistingClientRequestWithdrawal(
+  client: DbClient,
+  input: { appId: string; userId: string; clientRequestId?: string },
+): Promise<WithdrawalRecord | null> {
+  if (!input.clientRequestId) return null;
+
+  return findByClientRequestIdWithClient(client, {
+    appId: input.appId,
+    userId: input.userId,
+    clientRequestId: input.clientRequestId,
+  });
+}
+
 function sumAmounts(amounts: string[]): string {
   if (amounts.length === 0) return "0";
   const parsed = amounts.map(parseDecimal);
@@ -360,19 +383,10 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
       return db.transaction(async (tx) => {
         const lockKey = `${input.appId}:${input.userId}:${input.asset}`;
         await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${lockKey}))`);
-        if (input.clientRequestId) {
-          const clientRequestLockKey = `${input.appId}:${input.userId}:client-request:${input.clientRequestId}`;
-          await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${clientRequestLockKey}))`);
-        }
+        await acquireClientRequestLock(tx, input);
 
-        if (input.clientRequestId) {
-          const existing = await findByClientRequestIdWithClient(tx, {
-            appId: input.appId,
-            userId: input.userId,
-            clientRequestId: input.clientRequestId,
-          });
-          if (existing) return existing;
-        }
+        const existing = await findExistingClientRequestWithdrawal(tx, input);
+        if (existing) return existing;
 
         const ledgerRepo = createDbLedgerRepo(tx);
         const balance = await ledgerRepo.getBalance({
@@ -423,19 +437,10 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
       return db.transaction(async (tx) => {
         const lockKey = `${input.appId}:${input.userId}:${input.asset}`;
         await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${lockKey}))`);
-        if (input.clientRequestId) {
-          const clientRequestLockKey = `${input.appId}:${input.userId}:client-request:${input.clientRequestId}`;
-          await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${clientRequestLockKey}))`);
-        }
+        await acquireClientRequestLock(tx, input);
 
-        if (input.clientRequestId) {
-          const existing = await findByClientRequestIdWithClient(tx, {
-            appId: input.appId,
-            userId: input.userId,
-            clientRequestId: input.clientRequestId,
-          });
-          if (existing) return existing;
-        }
+        const existing = await findExistingClientRequestWithdrawal(tx, input);
+        if (existing) return existing;
 
         const ledgerRepo = createDbLedgerRepo(tx);
         const balance = await ledgerRepo.getBalance({
@@ -721,6 +726,22 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
     };
   }
 
+  function findExistingClientRequest(input: {
+    appId: string;
+    userId: string;
+    clientRequestId?: string;
+  }): WithdrawalRecord | null {
+    if (!input.clientRequestId) return null;
+
+    const record = records.find(
+      (item) =>
+        item.appId === input.appId &&
+        item.userId === input.userId &&
+        item.clientRequestId === input.clientRequestId,
+    );
+    return record ? clone(record) : null;
+  }
+
   return {
     async create(input) {
       assertPositiveAmount(input.amount);
@@ -789,14 +810,8 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
     },
 
     async createLiquidityPendingWithBalanceCheck(input, deps) {
-      if (input.clientRequestId) {
-        const existing = await this.findByClientRequestId({
-          appId: input.appId,
-          userId: input.userId,
-          clientRequestId: input.clientRequestId,
-        });
-        if (existing) return existing;
-      }
+      const existing = findExistingClientRequest(input);
+      if (existing) return existing;
       const pending = await this.getPendingTotal({
         appId: input.appId,
         userId: input.userId,
@@ -814,14 +829,8 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
     },
 
     async createWithBalanceCheck(input, deps) {
-      if (input.clientRequestId) {
-        const existing = await this.findByClientRequestId({
-          appId: input.appId,
-          userId: input.userId,
-          clientRequestId: input.clientRequestId,
-        });
-        if (existing) return existing;
-      }
+      const existing = findExistingClientRequest(input);
+      if (existing) return existing;
       const pending = await this.getPendingTotal({
         appId: input.appId,
         userId: input.userId,

--- a/fiber-link-service/packages/db/src/withdrawal-repo.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.ts
@@ -15,6 +15,7 @@ export type CreateWithdrawalInput = {
   amount: string;
   toAddress: string;
   destinationKind?: WithdrawalDestinationKind;
+  clientRequestId?: string;
 };
 
 export type CreateLiquidityPendingWithdrawalInput = CreateWithdrawalInput & {
@@ -33,6 +34,7 @@ export type WithdrawalRecord = CreateWithdrawalInput & {
   updatedAt: Date;
   completedAt: Date | null;
   txHash: string | null;
+  clientRequestId: string | null;
   liquidityRequestId: string | null;
   liquidityPendingReason: string | null;
   liquidityCheckedAt: Date | null;
@@ -84,6 +86,12 @@ export type ActiveCkbAddressReservationTotalInput = {
   network: "AGGRON4" | "LINA";
 };
 
+export type FindByClientRequestIdInput = {
+  appId: string;
+  userId: string;
+  clientRequestId: string;
+};
+
 export type CompletionDeps = {
   ledgerRepo: LedgerRepo;
 };
@@ -98,6 +106,7 @@ export type WithdrawalRepo = {
   createWithBalanceCheck(input: CreateWithdrawalInput, deps: BalanceCheckDeps): Promise<WithdrawalRecord>;
   getPendingTotal(input: PendingTotalInput): Promise<string>;
   getActiveCkbAddressReservationTotal(input: ActiveCkbAddressReservationTotalInput): Promise<string>;
+  findByClientRequestId(input: FindByClientRequestIdInput): Promise<WithdrawalRecord | null>;
   findByIdOrThrow(id: string): Promise<WithdrawalRecord>;
   listLiquidityPending(): Promise<WithdrawalRecord[]>;
   listReadyForProcessing(now: Date): Promise<WithdrawalRecord[]>;
@@ -133,6 +142,7 @@ function toRecord(row: WithdrawalRow): WithdrawalRecord {
     updatedAt: row.updatedAt,
     completedAt: row.completedAt,
     txHash: row.txHash,
+    clientRequestId: row.clientRequestId,
     liquidityRequestId: row.liquidityRequestId,
     liquidityPendingReason: row.liquidityPendingReason,
     liquidityCheckedAt: row.liquidityCheckedAt,
@@ -145,6 +155,33 @@ function inferDestinationKind(toAddress: string): WithdrawalDestinationKind {
     return "CKB_ADDRESS";
   }
   return "PAYMENT_REQUEST";
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return Boolean(
+    err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: unknown }).code === "23505",
+  );
+}
+
+async function findByClientRequestIdWithClient(
+  client: DbClient,
+  input: FindByClientRequestIdInput,
+): Promise<WithdrawalRecord | null> {
+  const [row] = await client
+    .select()
+    .from(withdrawals)
+    .where(
+      and(
+        eq(withdrawals.appId, input.appId),
+        eq(withdrawals.userId, input.userId),
+        eq(withdrawals.clientRequestId, input.clientRequestId),
+      ),
+    )
+    .limit(1);
+  return row ? toRecord(row) : null;
 }
 
 function sumAmounts(amounts: string[]): string {
@@ -223,55 +260,99 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
   return {
     async create(input) {
       assertPositiveAmount(input.amount);
-      const now = new Date();
-      const [row] = await db
-        .insert(withdrawals)
-        .values({
+      if (input.clientRequestId) {
+        const existing = await findByClientRequestIdWithClient(db, {
           appId: input.appId,
           userId: input.userId,
-          asset: input.asset,
-          amount: input.amount,
-          destinationKind: input.destinationKind ?? inferDestinationKind(input.toAddress),
-          toAddress: input.toAddress,
-          state: "PENDING",
-          retryCount: 0,
-          nextRetryAt: null,
-          lastError: null,
-          createdAt: now,
-          updatedAt: now,
-          completedAt: null,
-          txHash: null,
-        })
-        .returning();
-      return toRecord(row);
+          clientRequestId: input.clientRequestId,
+        });
+        if (existing) return existing;
+      }
+      const now = new Date();
+      try {
+        const [row] = await db
+          .insert(withdrawals)
+          .values({
+            appId: input.appId,
+            userId: input.userId,
+            asset: input.asset,
+            amount: input.amount,
+            destinationKind: input.destinationKind ?? inferDestinationKind(input.toAddress),
+            toAddress: input.toAddress,
+            state: "PENDING",
+            retryCount: 0,
+            nextRetryAt: null,
+            lastError: null,
+            createdAt: now,
+            updatedAt: now,
+            completedAt: null,
+            txHash: null,
+            clientRequestId: input.clientRequestId ?? null,
+          })
+          .returning();
+        return toRecord(row);
+      } catch (error) {
+        if (!input.clientRequestId || !isUniqueViolation(error)) {
+          throw error;
+        }
+        const existing = await findByClientRequestIdWithClient(db, {
+          appId: input.appId,
+          userId: input.userId,
+          clientRequestId: input.clientRequestId,
+        });
+        if (existing) return existing;
+        throw error;
+      }
     },
 
     async createLiquidityPending(input) {
       assertPositiveAmount(input.amount);
-      const now = new Date();
-      const [row] = await db
-        .insert(withdrawals)
-        .values({
+      if (input.clientRequestId) {
+        const existing = await findByClientRequestIdWithClient(db, {
           appId: input.appId,
           userId: input.userId,
-          asset: input.asset,
-          amount: input.amount,
-          destinationKind: input.destinationKind ?? inferDestinationKind(input.toAddress),
-          toAddress: input.toAddress,
-          state: "LIQUIDITY_PENDING",
-          retryCount: 0,
-          nextRetryAt: null,
-          lastError: null,
-          createdAt: now,
-          updatedAt: now,
-          completedAt: null,
-          txHash: null,
-          liquidityRequestId: input.liquidityRequestId,
-          liquidityPendingReason: input.liquidityPendingReason,
-          liquidityCheckedAt: now,
-        })
-        .returning();
-      return toRecord(row);
+          clientRequestId: input.clientRequestId,
+        });
+        if (existing) return existing;
+      }
+      const now = new Date();
+      try {
+        const [row] = await db
+          .insert(withdrawals)
+          .values({
+            appId: input.appId,
+            userId: input.userId,
+            asset: input.asset,
+            amount: input.amount,
+            destinationKind: input.destinationKind ?? inferDestinationKind(input.toAddress),
+            toAddress: input.toAddress,
+            state: "LIQUIDITY_PENDING",
+            retryCount: 0,
+            nextRetryAt: null,
+            lastError: null,
+            createdAt: now,
+            updatedAt: now,
+            completedAt: null,
+            txHash: null,
+            clientRequestId: input.clientRequestId ?? null,
+            liquidityRequestId: input.liquidityRequestId,
+            liquidityPendingReason: input.liquidityPendingReason,
+            liquidityCheckedAt: now,
+          })
+          .returning();
+        return toRecord(row);
+      } catch (error) {
+        if (!input.clientRequestId || !isUniqueViolation(error)) {
+          throw error;
+        }
+        const existing = await findByClientRequestIdWithClient(db, {
+          appId: input.appId,
+          userId: input.userId,
+          clientRequestId: input.clientRequestId,
+        });
+        if (existing) return existing;
+        throw error;
+      }
     },
 
     async createLiquidityPendingWithBalanceCheck(input, _deps) {
@@ -279,6 +360,19 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
       return db.transaction(async (tx) => {
         const lockKey = `${input.appId}:${input.userId}:${input.asset}`;
         await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${lockKey}))`);
+        if (input.clientRequestId) {
+          const clientRequestLockKey = `${input.appId}:${input.userId}:client-request:${input.clientRequestId}`;
+          await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${clientRequestLockKey}))`);
+        }
+
+        if (input.clientRequestId) {
+          const existing = await findByClientRequestIdWithClient(tx, {
+            appId: input.appId,
+            userId: input.userId,
+            clientRequestId: input.clientRequestId,
+          });
+          if (existing) return existing;
+        }
 
         const ledgerRepo = createDbLedgerRepo(tx);
         const balance = await ledgerRepo.getBalance({
@@ -313,6 +407,7 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
             updatedAt: now,
             completedAt: null,
             txHash: null,
+            clientRequestId: input.clientRequestId ?? null,
             liquidityRequestId: input.liquidityRequestId,
             liquidityPendingReason: input.liquidityPendingReason,
             liquidityCheckedAt: now,
@@ -328,6 +423,19 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
       return db.transaction(async (tx) => {
         const lockKey = `${input.appId}:${input.userId}:${input.asset}`;
         await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${lockKey}))`);
+        if (input.clientRequestId) {
+          const clientRequestLockKey = `${input.appId}:${input.userId}:client-request:${input.clientRequestId}`;
+          await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${clientRequestLockKey}))`);
+        }
+
+        if (input.clientRequestId) {
+          const existing = await findByClientRequestIdWithClient(tx, {
+            appId: input.appId,
+            userId: input.userId,
+            clientRequestId: input.clientRequestId,
+          });
+          if (existing) return existing;
+        }
 
         const ledgerRepo = createDbLedgerRepo(tx);
         const balance = await ledgerRepo.getBalance({
@@ -362,6 +470,7 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
             updatedAt: now,
             completedAt: null,
             txHash: null,
+            clientRequestId: input.clientRequestId ?? null,
           })
           .returning();
 
@@ -375,6 +484,10 @@ export function createDbWithdrawalRepo(db: DbClient): WithdrawalRepo {
 
     async getActiveCkbAddressReservationTotal(input) {
       return getActiveCkbAddressReservationTotalWithClient(db, input);
+    },
+
+    async findByClientRequestId(input) {
+      return findByClientRequestIdWithClient(db, input);
     },
 
     async findByIdOrThrow(id) {
@@ -611,6 +724,15 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
   return {
     async create(input) {
       assertPositiveAmount(input.amount);
+      if (input.clientRequestId) {
+        const existing = records.find(
+          (item) =>
+            item.appId === input.appId &&
+            item.userId === input.userId &&
+            item.clientRequestId === input.clientRequestId,
+        );
+        if (existing) return clone(existing);
+      }
       const now = new Date();
       const record: WithdrawalRecord = {
         ...input,
@@ -624,6 +746,7 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
         updatedAt: now,
         completedAt: null,
         txHash: null,
+        clientRequestId: input.clientRequestId ?? null,
         liquidityRequestId: null,
         liquidityPendingReason: null,
         liquidityCheckedAt: null,
@@ -634,6 +757,15 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
 
     async createLiquidityPending(input) {
       assertPositiveAmount(input.amount);
+      if (input.clientRequestId) {
+        const existing = records.find(
+          (item) =>
+            item.appId === input.appId &&
+            item.userId === input.userId &&
+            item.clientRequestId === input.clientRequestId,
+        );
+        if (existing) return clone(existing);
+      }
       const now = new Date();
       const record: WithdrawalRecord = {
         ...input,
@@ -647,6 +779,7 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
         updatedAt: now,
         completedAt: null,
         txHash: null,
+        clientRequestId: input.clientRequestId ?? null,
         liquidityRequestId: input.liquidityRequestId,
         liquidityPendingReason: input.liquidityPendingReason,
         liquidityCheckedAt: now,
@@ -656,6 +789,14 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
     },
 
     async createLiquidityPendingWithBalanceCheck(input, deps) {
+      if (input.clientRequestId) {
+        const existing = await this.findByClientRequestId({
+          appId: input.appId,
+          userId: input.userId,
+          clientRequestId: input.clientRequestId,
+        });
+        if (existing) return existing;
+      }
       const pending = await this.getPendingTotal({
         appId: input.appId,
         userId: input.userId,
@@ -673,6 +814,14 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
     },
 
     async createWithBalanceCheck(input, deps) {
+      if (input.clientRequestId) {
+        const existing = await this.findByClientRequestId({
+          appId: input.appId,
+          userId: input.userId,
+          clientRequestId: input.clientRequestId,
+        });
+        if (existing) return existing;
+      }
       const pending = await this.getPendingTotal({
         appId: input.appId,
         userId: input.userId,
@@ -714,6 +863,14 @@ export function createInMemoryWithdrawalRepo(): WithdrawalRepo {
             item.state === "RETRY_PENDING"),
       );
       return sumAmounts(active.map((item) => item.amount));
+    },
+
+    async findByClientRequestId(input) {
+      const record = records.find(
+        (item) =>
+          item.appId === input.appId && item.userId === input.userId && item.clientRequestId === input.clientRequestId,
+      );
+      return record ? clone(record) : null;
     },
 
     async findByIdOrThrow(id) {


### PR DESCRIPTION
## Summary
- Add optional clientRequestId support to withdrawal.request and persist it on withdrawals
- Enforce app/user/clientRequestId uniqueness with a new DB migration and repo lookup paths
- Return existing withdrawal records for retried request IDs, including completed/current states, without rechecking policy or reserving balance twice

## Test Plan
- bunx vitest run apps/rpc/src/contracts.test.ts apps/rpc/src/methods/withdrawal.test.ts packages/db/src/withdrawal-repo.test.ts
- bun run --cwd packages/db db:validate

Closes #387