### PR TITLE
Robustness: add Fiber RPC timeout retry and abort handling

### DIFF
--- a/fiber-link-service/apps/worker/src/entry.ts
+++ b/fiber-link-service/apps/worker/src/entry.ts
@@ -15,22 +15,26 @@ async function main() {
   const config = parseWorkerConfig(process.env);
   const settlementSubscriptionUrl = (process.env.FIBER_SETTLEMENT_SUBSCRIPTION_URL ?? "").trim();
   const hasSettlementSubscriptionUrl = settlementSubscriptionUrl.length > 0;
-  const fiberAdapter = createAdapterProvider({
-    endpoint: config.fiberRpcUrl,
-    settlementSubscription:
-      config.settlementStrategy === "subscription"
-        ? {
-            enabled: hasSettlementSubscriptionUrl,
-            url: hasSettlementSubscriptionUrl ? settlementSubscriptionUrl : undefined,
-          }
-        : { enabled: false },
-  });
-  const channelAcceptAdapter =
+  const createFiberAdapter = (signal?: AbortSignal) =>
+    createAdapterProvider({
+      endpoint: config.fiberRpcUrl,
+      signal,
+      settlementSubscription:
+        config.settlementStrategy === "subscription"
+          ? {
+              enabled: hasSettlementSubscriptionUrl,
+              url: hasSettlementSubscriptionUrl ? settlementSubscriptionUrl : undefined,
+            }
+          : { enabled: false },
+    });
+  const createChannelAcceptAdapter = (signal?: AbortSignal) =>
     config.channelAcceptRpcUrl === config.fiberRpcUrl
-      ? fiberAdapter
+      ? createFiberAdapter(signal)
       : createAdapterProvider({
           endpoint: config.channelAcceptRpcUrl,
+          signal,
         });
+  const fiberAdapter = createFiberAdapter();
   const cursorStore = createFileSettlementCursorStore(config.settlementCursorFile);
   const inventoryProvider = createDefaultHotWalletInventoryProvider();
   let settlementCursor: TipIntentListCursor | undefined = await cursorStore.load();
@@ -46,34 +50,38 @@ async function main() {
   const runtime = createWorkerRuntime({
     intervalMs: Math.min(config.withdrawalIntervalMs, config.settlementIntervalMs),
     withdrawalIntervalMs: config.withdrawalIntervalMs,
-    runLiquidityBatch: () =>
-      runLiquidityBatch({
+    runLiquidityBatch: ({ signal }) => {
+      const cycleFiberAdapter = createFiberAdapter(signal);
+      const cycleChannelAcceptAdapter = createChannelAcceptAdapter(signal);
+      return runLiquidityBatch({
         liquidityProvider: {
-          getLiquidityCapabilities: fiberAdapter.getLiquidityCapabilities,
-          listChannels: fiberAdapter.listChannels,
-          openChannel: fiberAdapter.openChannel,
-          acceptChannel: channelAcceptAdapter.acceptChannel,
-          getCkbChannelAcceptancePolicy: channelAcceptAdapter.getCkbChannelAcceptancePolicy,
-          shutdownChannel: fiberAdapter.shutdownChannel,
-          ensureChainLiquidity: fiberAdapter.ensureChainLiquidity,
-          getRebalanceStatus: fiberAdapter.getRebalanceStatus,
+          getLiquidityCapabilities: cycleFiberAdapter.getLiquidityCapabilities,
+          listChannels: cycleFiberAdapter.listChannels,
+          openChannel: cycleFiberAdapter.openChannel,
+          acceptChannel: cycleChannelAcceptAdapter.acceptChannel,
+          getCkbChannelAcceptancePolicy: cycleChannelAcceptAdapter.getCkbChannelAcceptancePolicy,
+          shutdownChannel: cycleFiberAdapter.shutdownChannel,
+          ensureChainLiquidity: cycleFiberAdapter.ensureChainLiquidity,
+          getRebalanceStatus: cycleFiberAdapter.getRebalanceStatus,
         },
         fallbackMode: config.liquidityFallbackMode,
         channelRotationBootstrapReserve: config.channelRotationBootstrapReserve,
         channelRotationMinRecoverableAmount: config.channelRotationMinRecoverableAmount,
         inventoryProvider,
-      }),
+      });
+    },
     maxRetries: config.maxRetries,
     retryDelayMs: config.retryDelayMs,
     shutdownTimeoutMs: config.shutdownTimeoutMs,
     settlementIntervalMs: config.settlementIntervalMs,
     settlementBatchSize: config.settlementBatchSize,
-    runWithdrawalBatch: ({ maxRetries, retryDelayMs }) =>
-      runWithdrawalBatch({
+    runWithdrawalBatch: ({ maxRetries, retryDelayMs, signal }) => {
+      const cycleFiberAdapter = createFiberAdapter(signal);
+      return runWithdrawalBatch({
         maxRetries,
         retryDelayMs,
         executeWithdrawal: async (withdrawal) => {
-          const withdrawalResult = await fiberAdapter.executeWithdrawal({
+          const withdrawalResult = await cycleFiberAdapter.executeWithdrawal({
             amount: withdrawal.amount,
             asset: withdrawal.asset,
             destination:
@@ -87,12 +95,14 @@ async function main() {
             txHash: withdrawalResult.txHash,
           };
         },
-      }),
-    pollSettlements: async ({ limit }) => {
+      });
+    },
+    pollSettlements: async ({ limit, signal }) => {
+      const cycleFiberAdapter = createFiberAdapter(signal);
       const summary = await runSettlementDiscovery({
         limit,
         cursor: settlementCursor,
-        adapter: fiberAdapter,
+        adapter: cycleFiberAdapter,
         maxRetries: config.settlementMaxRetries,
         retryDelayMs: config.settlementRetryDelayMs,
         pendingTimeoutMs: config.settlementPendingTimeoutMs,

--- a/fiber-link-service/apps/worker/src/worker-runtime.test.ts
+++ b/fiber-link-service/apps/worker/src/worker-runtime.test.ts
@@ -10,6 +10,52 @@ function createDeferred<T>() {
 }
 
 describe("createWorkerRuntime", () => {
+  it("aborts in-flight work before waiting for graceful drain on shutdown", async () => {
+    const ticks: Array<() => void> = [];
+    const exitCodes: number[] = [];
+    let observedSignal: AbortSignal | undefined;
+    let resolveOnAbort!: () => void;
+    const aborted = new Promise<void>((resolve) => {
+      resolveOnAbort = resolve;
+    });
+    let calls = 0;
+
+    const runtime = createWorkerRuntime({
+      intervalMs: 1000,
+      maxRetries: 3,
+      retryDelayMs: 60_000,
+      shutdownTimeoutMs: 50,
+      runWithdrawalBatch: async ({ signal }) => {
+        calls += 1;
+        if (calls === 2) {
+          observedSignal = signal;
+          signal.addEventListener("abort", resolveOnAbort, { once: true });
+          await aborted;
+        }
+      },
+      setIntervalFn: (tick) => {
+        ticks.push(tick);
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      },
+      clearIntervalFn: () => {},
+      exitFn: (code) => {
+        exitCodes.push(code);
+      },
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+    });
+
+    await runtime.start();
+    ticks[0]?.();
+    await runtime.shutdown("SIGTERM");
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(exitCodes).toEqual([0]);
+  });
+
   it("waits for in-flight batch to finish before exiting on shutdown", async () => {
     const ticks: Array<() => void> = [];
     const exitCodes: number[] = [];

--- a/fiber-link-service/apps/worker/src/worker-runtime.ts
+++ b/fiber-link-service/apps/worker/src/worker-runtime.ts
@@ -7,9 +7,9 @@ type WorkerLogger = {
   error: (event: string, context?: WorkerLogContext) => void;
 };
 
-type RunLiquidityBatchFn = () => Promise<unknown>;
-type RunWithdrawalBatchFn = (options: { maxRetries: number; retryDelayMs: number }) => Promise<unknown>;
-type PollSettlementsFn = (options: { limit: number }) => Promise<unknown>;
+type RunLiquidityBatchFn = (options: { signal: AbortSignal }) => Promise<unknown>;
+type RunWithdrawalBatchFn = (options: { maxRetries: number; retryDelayMs: number; signal: AbortSignal }) => Promise<unknown>;
+type PollSettlementsFn = (options: { limit: number; signal: AbortSignal }) => Promise<unknown>;
 
 export type CreateWorkerRuntimeOptions = {
   intervalMs: number;
@@ -75,6 +75,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions): Worker
   let shutdownPromise: Promise<void> | null = null;
   let lastWithdrawalRunAtMs: number | null = null;
   let lastSettlementRunAtMs: number | null = null;
+  let cycleAbortController: AbortController | null = null;
 
   async function processCycle() {
     if (shuttingDown) {
@@ -100,12 +101,14 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions): Worker
       return;
     }
 
+    const abortController = new AbortController();
+    cycleAbortController = abortController;
     inFlightBatch = (async () => {
       try {
         if (shouldRunWithdrawal) {
           if (runLiquidityBatch) {
             try {
-              const liquidityResult = await runLiquidityBatch();
+              const liquidityResult = await runLiquidityBatch({ signal: abortController.signal });
               logger.info("worker.liquidity.batch.succeeded", {
                 result: liquidityResult,
               });
@@ -118,6 +121,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions): Worker
             const result = await runWithdrawalBatch({
               maxRetries: options.maxRetries,
               retryDelayMs: options.retryDelayMs,
+              signal: abortController.signal,
             });
             lastWithdrawalRunAtMs = nowMs;
             logger.info("worker.withdrawal.batch.succeeded", {
@@ -130,7 +134,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions): Worker
 
         if (shouldRunSettlements && pollSettlements) {
           try {
-            const result = await pollSettlements({ limit: settlementBatchSize });
+            const result = await pollSettlements({ limit: settlementBatchSize, signal: abortController.signal });
             lastSettlementRunAtMs = nowMs;
             logger.info("worker.settlement.polling.succeeded", {
               result,
@@ -141,6 +145,9 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions): Worker
           }
         }
       } finally {
+        if (cycleAbortController === abortController) {
+          cycleAbortController = null;
+        }
         inFlightBatch = null;
       }
     })();
@@ -181,6 +188,7 @@ export function createWorkerRuntime(options: CreateWorkerRuntimeOptions): Worker
       }
 
       let exitCode = 0;
+      cycleAbortController?.abort(new Error(`Worker shutdown requested by ${signal}`));
       if (inFlightBatch) {
         const drained = await waitForDrain(inFlightBatch, options.shutdownTimeoutMs);
         if (!drained) {

--- a/fiber-link-service/packages/fiber-adapter/src/fiber-client.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/fiber-client.test.ts
@@ -3,6 +3,7 @@ import { FiberRpcError, rpcCall } from "./fiber-client";
 
 describe("rpcCall", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -17,5 +18,65 @@ describe("rpcCall", () => {
 
     await expect(rpcCall("http://localhost:8119", "health", {})).rejects.toBeInstanceOf(FiberRpcError);
     await expect(rpcCall("http://localhost:8119", "health", {})).rejects.toThrow("Fiber RPC HTTP 502");
+  });
+
+  it("aborts a stuck request after the configured timeout", async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+      });
+    });
+
+    const pending = expect(
+      rpcCall("http://localhost:8119", "health", {}, { fetchFn, timeoutMs: 25 }),
+    ).rejects.toMatchObject({ name: "FiberRpcTimeoutError" });
+    await vi.advanceTimersByTimeAsync(25);
+
+    await pending;
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  it("propagates caller abort signals to the active fetch", async () => {
+    const controller = new AbortController();
+    const fetchFn = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+      });
+    });
+
+    const pending = rpcCall("http://localhost:8119", "health", {}, { fetchFn, signal: controller.signal });
+    controller.abort(new Error("shutdown"));
+
+    await expect(pending).rejects.toThrow("shutdown");
+    expect(fetchFn.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  it("retries retryable network failures with bounded backoff", async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("socket hang up"))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as Response);
+
+    const pending = rpcCall("http://localhost:8119", "health", {}, { fetchFn, retryCount: 1, retryDelayMs: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(pending).resolves.toBe("ok");
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry JSON-RPC application errors", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ error: { code: -32602, message: "invalid params" } }),
+    } as Response);
+
+    await expect(rpcCall("http://localhost:8119", "health", {}, { fetchFn, retryCount: 2 })).rejects.toMatchObject({
+      name: "FiberRpcError",
+      code: -32602,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/fiber-link-service/packages/fiber-adapter/src/fiber-client.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/fiber-client.test.ts
@@ -16,8 +16,25 @@ describe("rpcCall", () => {
       },
     } as Response);
 
-    await expect(rpcCall("http://localhost:8119", "health", {})).rejects.toBeInstanceOf(FiberRpcError);
-    await expect(rpcCall("http://localhost:8119", "health", {})).rejects.toThrow("Fiber RPC HTTP 502");
+    await expect(rpcCall("http://localhost:8119", "health", {}, { retryCount: 0 })).rejects.toBeInstanceOf(FiberRpcError);
+    await expect(rpcCall("http://localhost:8119", "health", {}, { retryCount: 0 })).rejects.toMatchObject({
+      code: 502,
+      message: "Fiber RPC HTTP 502",
+    });
+  });
+
+  it("retries transient HTTP failures", async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503 } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as Response);
+
+    const pending = rpcCall("http://localhost:8119", "health", {}, { fetchFn, retryCount: 1, retryDelayMs: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(pending).resolves.toBe("ok");
+    expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
   it("aborts a stuck request after the configured timeout", async () => {
@@ -29,13 +46,32 @@ describe("rpcCall", () => {
     });
 
     const pending = expect(
-      rpcCall("http://localhost:8119", "health", {}, { fetchFn, timeoutMs: 25 }),
+      rpcCall("http://localhost:8119", "health", {}, { fetchFn, timeoutMs: 25, retryCount: 0 }),
     ).rejects.toMatchObject({ name: "FiberRpcTimeoutError" });
     await vi.advanceTimersByTimeAsync(25);
 
     await pending;
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(fetchFn.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  it("retries timeouts", async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi
+      .fn()
+      .mockImplementationOnce((_input: RequestInfo | URL, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+        });
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as Response);
+
+    const pending = rpcCall("http://localhost:8119", "health", {}, { fetchFn, timeoutMs: 25, retryCount: 1, retryDelayMs: 10 });
+    await vi.advanceTimersByTimeAsync(25);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(pending).resolves.toBe("ok");
+    expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
   it("propagates caller abort signals to the active fetch", async () => {

--- a/fiber-link-service/packages/fiber-adapter/src/fiber-client.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/fiber-client.ts
@@ -45,8 +45,11 @@ function isAbortError(error: unknown) {
 }
 
 function isRetryableError(error: unknown) {
+  if (error instanceof FiberRpcTimeoutError) {
+    return true;
+  }
   if (error instanceof FiberRpcError) {
-    return false;
+    return typeof error.code === "number" && [502, 503, 504].includes(error.code);
   }
   return error instanceof TypeError || isAbortError(error);
 }
@@ -59,15 +62,16 @@ function delay(ms: number, signal?: AbortSignal) {
     return Promise.resolve();
   }
   return new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timeout);
-        reject(signal.reason ?? new DOMException("Fiber RPC aborted", "AbortError"));
-      },
-      { once: true },
-    );
+    let timeout: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason ?? new DOMException("Fiber RPC aborted", "AbortError"));
+    };
+    timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 
@@ -131,7 +135,7 @@ export async function rpcCall(endpoint: FiberRpcEndpoint, method: string, params
       });
 
       if (!response.ok) {
-        throw new FiberRpcError(`Fiber RPC HTTP ${response.status}`);
+        throw new FiberRpcError(`Fiber RPC HTTP ${response.status}`, response.status);
       }
 
       const payload = await response.json();

--- a/fiber-link-service/packages/fiber-adapter/src/fiber-client.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/fiber-client.ts
@@ -9,21 +9,145 @@ export class FiberRpcError extends Error {
   }
 }
 
-export async function rpcCall(endpoint: string, method: string, params: unknown) {
-  const response = await fetch(endpoint, {
+export class FiberRpcTimeoutError extends FiberRpcError {
+  constructor(timeoutMs: number) {
+    super(`Fiber RPC timed out after ${timeoutMs}ms`);
+    this.name = "FiberRpcTimeoutError";
+  }
+}
+
+export type FiberRpcCallOptions = {
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+  retryCount?: number;
+  retryDelayMs?: number;
+  signal?: AbortSignal;
+  omitParams?: boolean;
+};
+
+export type FiberRpcEndpoint = string | ({ endpoint: string } & FiberRpcCallOptions);
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_COUNT = 1;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+function resolveEndpointOptions(endpoint: FiberRpcEndpoint, options: FiberRpcCallOptions = {}) {
+  if (typeof endpoint === "string") {
+    return { endpoint, options };
+  }
+
+  const { endpoint: resolvedEndpoint, ...endpointOptions } = endpoint;
+  return { endpoint: resolvedEndpoint, options: { ...endpointOptions, ...options } };
+}
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function isRetryableError(error: unknown) {
+  if (error instanceof FiberRpcError) {
+    return false;
+  }
+  return error instanceof TypeError || isAbortError(error);
+}
+
+function delay(ms: number, signal?: AbortSignal) {
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason ?? new DOMException("Fiber RPC aborted", "AbortError"));
+  }
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        reject(signal.reason ?? new DOMException("Fiber RPC aborted", "AbortError"));
+      },
+      { once: true },
+    );
+  });
+}
+
+async function fetchWithTimeout(endpoint: string, init: RequestInit, options: Required<Pick<FiberRpcCallOptions, "timeoutMs">> & Pick<FiberRpcCallOptions, "fetchFn" | "signal">) {
+  const fetchFn = options.fetchFn ?? fetch;
+  const controller = new AbortController();
+  let timedOut = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const abortFromCaller = () => {
+    controller.abort(options.signal?.reason ?? new DOMException("Fiber RPC aborted", "AbortError"));
+  };
+
+  if (options.signal?.aborted) {
+    abortFromCaller();
+  } else {
+    options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
+
+  if (options.timeoutMs > 0) {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new FiberRpcTimeoutError(options.timeoutMs));
+    }, options.timeoutMs);
+  }
+
+  try {
+    return await fetchFn(endpoint, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (timedOut) {
+      throw new FiberRpcTimeoutError(options.timeoutMs);
+    }
+    throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    options.signal?.removeEventListener("abort", abortFromCaller);
+  }
+}
+
+export async function rpcCall(endpoint: FiberRpcEndpoint, method: string, params: unknown, callOptions: FiberRpcCallOptions = {}) {
+  const { endpoint: resolvedEndpoint, options } = resolveEndpointOptions(endpoint, callOptions);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const retryCount = options.retryCount ?? DEFAULT_RETRY_COUNT;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  const init = {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [params] }),
-  });
+    body: JSON.stringify(
+      options.omitParams ? { jsonrpc: "2.0", id: 1, method } : { jsonrpc: "2.0", id: 1, method, params: [params] },
+    ),
+  } satisfies RequestInit;
 
-  if (!response.ok) {
-    throw new FiberRpcError(`Fiber RPC HTTP ${response.status}`);
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const response = await fetchWithTimeout(resolvedEndpoint, init, {
+        fetchFn: options.fetchFn,
+        signal: options.signal,
+        timeoutMs,
+      });
+
+      if (!response.ok) {
+        throw new FiberRpcError(`Fiber RPC HTTP ${response.status}`);
+      }
+
+      const payload = await response.json();
+      if (payload?.error) {
+        throw new FiberRpcError(payload.error.message ?? "Fiber RPC error", payload.error.code, payload.error.data);
+      }
+
+      return payload?.result;
+    } catch (error) {
+      if (options.signal?.aborted) {
+        throw options.signal.reason ?? error;
+      }
+      if (attempt >= retryCount || !isRetryableError(error)) {
+        throw error;
+      }
+      await delay(retryDelayMs, options.signal);
+    }
   }
-
-  const payload = await response.json();
-  if (payload?.error) {
-    throw new FiberRpcError(payload.error.message ?? "Fiber RPC error", payload.error.code, payload.error.data);
-  }
-
-  return payload?.result;
 }

--- a/fiber-link-service/packages/fiber-adapter/src/provider.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/provider.ts
@@ -9,6 +9,10 @@ export type CreateAdapterProviderArgs = {
   endpoint?: string;
   settlementSubscription?: CreateAdapterArgs["settlementSubscription"];
   fetchFn?: CreateAdapterArgs["fetchFn"];
+  timeoutMs?: CreateAdapterArgs["timeoutMs"];
+  retryCount?: CreateAdapterArgs["retryCount"];
+  retryDelayMs?: CreateAdapterArgs["retryDelayMs"];
+  signal?: CreateAdapterArgs["signal"];
   simulation?: CreateSimulationAdapterArgs;
   rpcFactory?: (args: CreateAdapterArgs) => FiberAdapter;
   env?: NodeJS.ProcessEnv;
@@ -79,5 +83,9 @@ export function createAdapterProvider(args: CreateAdapterProviderArgs = {}): Fib
     endpoint,
     settlementSubscription: args.settlementSubscription,
     fetchFn: args.fetchFn,
+    timeoutMs: args.timeoutMs,
+    retryCount: args.retryCount,
+    retryDelayMs: args.retryDelayMs,
+    signal: args.signal,
   });
 }

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/channel-ops.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/channel-ops.ts
@@ -1,4 +1,4 @@
-import { FiberRpcError, rpcCall } from "../fiber-client";
+import { FiberRpcError, rpcCall, type FiberRpcEndpoint } from "../fiber-client";
 import { hasLocalChainLiquiditySweepSupport } from "./rebalance-ops";
 import { normalizeRpcAmount, normalizeRpcInteger, pickRequiredAmount, pickStringCandidate, pickTxEvidence, toHexQuantity } from "./normalize";
 import { rpcCallWithoutParams, toRpcUdtTypeScript } from "./invoice-ops";
@@ -81,7 +81,7 @@ function isUnsupportedRpcMethodError(error: unknown): boolean {
   return message === "unauthorized" || message.includes("method not found") || message.includes("unknown method");
 }
 
-async function probeDirectRebalanceSupport(endpoint: string): Promise<boolean> {
+async function probeDirectRebalanceSupport(endpoint: FiberRpcEndpoint): Promise<boolean> {
   try {
     await rpcCall(endpoint, "get_rebalance_status", {
       request_id: "__capability_probe__",
@@ -95,7 +95,7 @@ async function probeDirectRebalanceSupport(endpoint: string): Promise<boolean> {
   }
 }
 
-async function probeChannelLifecycleSupport(endpoint: string): Promise<boolean> {
+async function probeChannelLifecycleSupport(endpoint: FiberRpcEndpoint): Promise<boolean> {
   try {
     await rpcCall(endpoint, "list_channels", {});
     return true;
@@ -108,7 +108,7 @@ async function probeChannelLifecycleSupport(endpoint: string): Promise<boolean> 
 }
 
 export async function listChannels(
-  endpoint: string,
+  endpoint: FiberRpcEndpoint,
   { includeClosed = false, peerId }: ListChannelsArgs,
 ): Promise<ListChannelsResult> {
   const payload: Record<string, unknown> = {};
@@ -129,7 +129,7 @@ export async function listChannels(
 }
 
 export async function openChannel(
-  endpoint: string,
+  endpoint: FiberRpcEndpoint,
   { peerId, fundingAmount, fundingUdtTypeScript, tlcFeeProportionalMillionths }: OpenChannelArgs,
 ): Promise<OpenChannelResult> {
   const payload: Record<string, unknown> = {
@@ -152,7 +152,7 @@ export async function openChannel(
 }
 
 export async function acceptChannel(
-  endpoint: string,
+  endpoint: FiberRpcEndpoint,
   { temporaryChannelId, fundingAmount }: AcceptChannelArgs,
 ): Promise<AcceptChannelResult> {
   const result = (await rpcCall(endpoint, "accept_channel", {
@@ -164,14 +164,14 @@ export async function acceptChannel(
 }
 
 export async function getCkbChannelAcceptancePolicy(
-  endpoint: string,
+  endpoint: FiberRpcEndpoint,
 ): Promise<CkbChannelAcceptancePolicy> {
   const result = (await rpcCallWithoutParams(endpoint, "node_info")) as Record<string, unknown> | undefined;
   return parseCkbChannelAcceptancePolicy(result);
 }
 
 export async function shutdownChannel(
-  endpoint: string,
+  endpoint: FiberRpcEndpoint,
   { channelId, closeScript, feeRate, force }: ShutdownChannelArgs,
 ): Promise<ShutdownChannelResult> {
   const payload: Record<string, unknown> = {
@@ -192,7 +192,7 @@ export async function shutdownChannel(
   return txHash ? { txHash } : {};
 }
 
-export async function getLiquidityCapabilities(endpoint: string): Promise<LiquidityCapabilities> {
+export async function getLiquidityCapabilities(endpoint: FiberRpcEndpoint): Promise<LiquidityCapabilities> {
   const [directRebalance, channelLifecycle] = await Promise.all([
     probeDirectRebalanceSupport(endpoint),
     probeChannelLifecycleSupport(endpoint),

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/index.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/index.ts
@@ -12,22 +12,22 @@ import { ensureChainLiquidity, getRebalanceStatus } from "./rebalance-ops";
 import { createSettlementSubscriber } from "./settlement-stream";
 import type { CreateAdapterArgs, FiberAdapter } from "../types";
 
-export function createAdapter({ endpoint, settlementSubscription, fetchFn }: CreateAdapterArgs): FiberAdapter {
-  const resolvedFetch = fetchFn ?? fetch;
-  const subscribeSettlements = createSettlementSubscriber(settlementSubscription, resolvedFetch);
+export function createAdapter({ endpoint, settlementSubscription, fetchFn, timeoutMs, retryCount, retryDelayMs, signal }: CreateAdapterArgs): FiberAdapter {
+  const rpcEndpoint = { endpoint, fetchFn, timeoutMs, retryCount, retryDelayMs, signal };
+  const subscribeSettlements = createSettlementSubscriber(settlementSubscription, fetchFn ?? fetch);
 
   return {
-    createInvoice: (args) => createInvoice(endpoint, args),
-    getInvoiceStatus: (args) => getInvoiceStatus(endpoint, args),
+    createInvoice: (args) => createInvoice(rpcEndpoint, args),
+    getInvoiceStatus: (args) => getInvoiceStatus(rpcEndpoint, args),
     subscribeSettlements,
-    executeWithdrawal: (args) => executeWithdrawal(endpoint, args),
-    getLiquidityCapabilities: () => getLiquidityCapabilities(endpoint),
-    listChannels: (args) => listChannels(endpoint, args),
-    openChannel: (args) => openChannel(endpoint, args),
-    acceptChannel: (args) => acceptChannel(endpoint, args),
-    getCkbChannelAcceptancePolicy: () => getCkbChannelAcceptancePolicy(endpoint),
-    shutdownChannel: (args) => shutdownChannel(endpoint, args),
-    ensureChainLiquidity: (args) => ensureChainLiquidity(endpoint, args),
-    getRebalanceStatus: (args) => getRebalanceStatus(endpoint, args),
+    executeWithdrawal: (args) => executeWithdrawal(rpcEndpoint, args),
+    getLiquidityCapabilities: () => getLiquidityCapabilities(rpcEndpoint),
+    listChannels: (args) => listChannels(rpcEndpoint, args),
+    openChannel: (args) => openChannel(rpcEndpoint, args),
+    acceptChannel: (args) => acceptChannel(rpcEndpoint, args),
+    getCkbChannelAcceptancePolicy: () => getCkbChannelAcceptancePolicy(rpcEndpoint),
+    shutdownChannel: (args) => shutdownChannel(rpcEndpoint, args),
+    ensureChainLiquidity: (args) => ensureChainLiquidity(rpcEndpoint, args),
+    getRebalanceStatus: (args) => getRebalanceStatus(rpcEndpoint, args),
   };
 }

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/invoice-ops.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/invoice-ops.ts
@@ -1,4 +1,4 @@
-import { FiberRpcError, rpcCall } from "../fiber-client";
+import { FiberRpcError, rpcCall, type FiberRpcEndpoint } from "../fiber-client";
 import { toHexQuantity, normalizeOptionalName } from "./normalize";
 import type {
   Asset,
@@ -62,24 +62,10 @@ function isUdtTypeScript(value: unknown): value is RpcUdtTypeScript {
   );
 }
 
-async function rpcCallWithoutParams(endpoint: string, method: string): Promise<unknown> {
-  const response = await fetch(endpoint, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [] }),
-  });
-
-  if (!response.ok) {
-    throw new FiberRpcError(`Fiber RPC HTTP ${response.status}`);
-  }
-
-  const payload = await response.json();
-  if (payload?.error) {
-    throw new FiberRpcError(payload.error.message ?? "Fiber RPC error", payload.error.code, payload.error.data);
-  }
-
-  return payload?.result;
+async function rpcCallWithoutParams(endpoint: FiberRpcEndpoint, method: string): Promise<unknown> {
+  return rpcCall(endpoint, method, undefined, { omitParams: true });
 }
+
 
 function pickUsdiUdtScript(nodeInfo: unknown): RpcUdtTypeScript | null {
   if (!nodeInfo || typeof nodeInfo !== "object") {
@@ -111,7 +97,7 @@ function pickUsdiUdtScript(nodeInfo: unknown): RpcUdtTypeScript | null {
   return script;
 }
 
-export async function resolveUsdiUdtScript(endpoint: string): Promise<RpcUdtTypeScript> {
+export async function resolveUsdiUdtScript(endpoint: FiberRpcEndpoint): Promise<RpcUdtTypeScript> {
   const envJson = process.env.FIBER_USDI_UDT_TYPE_SCRIPT_JSON;
   if (typeof envJson === "string" && envJson.trim()) {
     let parsed: unknown;
@@ -160,7 +146,7 @@ export function toRpcUdtTypeScript(script: UdtTypeScript): RpcUdtTypeScript {
   };
 }
 
-export async function createInvoice(endpoint: string, { amount, asset }: CreateInvoiceArgs) {
+export async function createInvoice(endpoint: FiberRpcEndpoint, { amount, asset }: CreateInvoiceArgs) {
   const payload: Record<string, unknown> = {
     amount: toHexQuantity(amount),
     currency: mapAssetToCurrency(asset),
@@ -176,7 +162,7 @@ export async function createInvoice(endpoint: string, { amount, asset }: CreateI
   return { invoice: result.invoice_address };
 }
 
-export async function getInvoiceStatus(endpoint: string, { invoice }: { invoice: string }) {
+export async function getInvoiceStatus(endpoint: FiberRpcEndpoint, { invoice }: { invoice: string }) {
   const parsed = (await rpcCall(endpoint, "parse_invoice", {
     invoice,
   })) as Record<string, unknown> | undefined;

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.ts
@@ -1,4 +1,4 @@
-import { FiberRpcError, rpcCall } from "../fiber-client";
+import { FiberRpcError, rpcCall, type FiberRpcEndpoint } from "../fiber-client";
 import {
   executeCkbOnchainTransfer,
   getCkbTransactionStatus,
@@ -234,7 +234,7 @@ async function getLocalChainLiquidityStatus(args: GetRebalanceStatusArgs): Promi
 }
 
 export async function ensureChainLiquidity(
-  endpoint: string,
+  endpoint: FiberRpcEndpoint,
   args: EnsureChainLiquidityArgs,
 ) {
   const tracked = await getOrRefreshLocalSweepTracking({ requestId: args.requestId });
@@ -263,7 +263,7 @@ export async function ensureChainLiquidity(
 }
 
 export async function getRebalanceStatus(
-  endpoint: string,
+  endpoint: FiberRpcEndpoint,
   args: GetRebalanceStatusArgs,
 ) {
   const localStatus = await getLocalChainLiquidityStatus(args);

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/withdrawal-ops.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/withdrawal-ops.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { rpcCall } from "../fiber-client";
+import { rpcCall, type FiberRpcEndpoint } from "../fiber-client";
 import { executeCkbOnchainWithdrawal } from "../ckb-onchain-withdrawal";
 import { executeUdtOnchainWithdrawal } from "../udt-onchain-withdrawal";
 import { pickTxEvidence, toHexQuantity } from "./normalize";
@@ -11,7 +11,7 @@ function generateFallbackRequestId({ invoice, amount, asset }: { invoice: string
 }
 
 export async function executeWithdrawal(
-  endpoint: string,
+  endpoint: FiberRpcEndpoint,
   { amount, asset, destination, requestId }: ExecuteWithdrawalArgs,
 ) {
   if (destination.kind === "CKB_ADDRESS") {

--- a/fiber-link-service/packages/fiber-adapter/src/types.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/types.ts
@@ -140,11 +140,18 @@ export type SettlementSubscriptionConfig = {
   authToken?: string;
 };
 
+export type FiberRpcRequestOptions = {
+  timeoutMs?: number;
+  retryCount?: number;
+  retryDelayMs?: number;
+  signal?: AbortSignal;
+};
+
 export type CreateAdapterArgs = {
   endpoint: string;
   settlementSubscription?: SettlementSubscriptionConfig;
   fetchFn?: typeof fetch;
-};
+} & FiberRpcRequestOptions;
 
 export type GetHotWalletInventoryArgs = {
   asset: Asset;


### PR DESCRIPTION
## Summary
- Add Fiber RPC timeout handling with AbortController-backed request cancellation.
- Add bounded retry/backoff for transient network/abort failures while preserving non-retryable JSON-RPC/application errors.
- Thread adapter request options through RPC operations and abort in-flight worker cycle calls during shutdown.

## Test Plan
- bunx vitest --run packages/fiber-adapter apps/worker/src/worker-runtime.test.ts apps/worker/src/config.test.ts

Closes #384
