### PR TITLE
fix(compose): make volume cleanup opt-in

### DIFF
--- a/deploy/compose/compose-readiness.sh
+++ b/deploy/compose/compose-readiness.sh
@@ -13,15 +13,17 @@ DRY_RUN=0
 SKIP_SMOKE=0
 VERBOSE=0
 WAIT_SECONDS=120
+DESTROY_VOLUMES="${FIBER_LINK_DESTROY_VOLUMES:-0}"
 
 usage() {
   cat <<'EOF'
-Usage: compose-readiness.sh [--dry-run] [--skip-smoke] [--verbose]
+Usage: compose-readiness.sh [--dry-run] [--skip-smoke] [--verbose] [--destroy-volumes]
 
 Options:
-  --dry-run     Print commands without executing side effects.
-  --skip-smoke  Start services and wait for readiness without HTTP smoke checks.
-  --verbose     Print command execution details.
+  --dry-run          Print commands without executing side effects.
+  --skip-smoke       Start services and wait for readiness without HTTP smoke checks.
+  --verbose          Print command execution details.
+  --destroy-volumes  Remove compose volumes during cleanup. Can also be enabled with FIBER_LINK_DESTROY_VOLUMES=1.
 EOF
 }
 
@@ -35,6 +37,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     --verbose)
       VERBOSE=1
+      ;;
+    --destroy-volumes)
+      DESTROY_VOLUMES=1
       ;;
     -h|--help)
       usage
@@ -59,8 +64,22 @@ fi
 
 RPC_PORT="${RPC_PORT:-3000}"
 RPC_URL="http://127.0.0.1:${RPC_PORT}"
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-fiber-link-readiness-$(date -u +"%Y%m%d%H%M%S")-$$}"
+COMPOSE_DOWN_ARGS="--remove-orphans"
+if [[ "${DESTROY_VOLUMES}" == "1" ]]; then
+  COMPOSE_DOWN_ARGS="${COMPOSE_DOWN_ARGS} --volumes"
+fi
 
 echo "Evidence directory: ${EVIDENCE_DIR}"
+echo "Compose project: ${COMPOSE_PROJECT_NAME}"
+
+if [[ "${DESTROY_VOLUMES}" == "1" ]]; then
+  cat >&2 <<EOF
+WARNING: destructive compose volume cleanup is enabled.
+Target compose project: ${COMPOSE_PROJECT_NAME}
+Env file: ${ENV_FILE}
+EOF
+fi
 
 declare -A CHECK_STATUS=(
   [precheck]="not_run"
@@ -198,7 +217,7 @@ fi
 run_step "compose-logs" "${EVIDENCE_DIR}/compose-logs.log" "docker compose -f \"$COMPOSE_FILE\" logs --no-color --timestamps rpc worker fnn postgres redis"
 
 if [[ "${CHECK_STATUS[spinup]}" == "pass" ]]; then
-  if run_step "compose-down" "${EVIDENCE_DIR}/compose-down.log" "cd \"$ROOT_DIR\" && docker compose -f \"$COMPOSE_FILE\" down --remove-orphans --volumes"; then
+  if run_step "compose-down" "${EVIDENCE_DIR}/compose-down.log" "cd \"$ROOT_DIR\" && docker compose -f \"$COMPOSE_FILE\" down ${COMPOSE_DOWN_ARGS}"; then
     CHECK_STATUS[shutdown]="pass"
   else
     CHECK_STATUS[shutdown]="fail"
@@ -223,6 +242,8 @@ cat > "$summary_file" <<EOF
   "timestamp": "${TIMESTAMP}",
   "dryRun": ${DRY_RUN},
   "skipSmoke": ${SKIP_SMOKE},
+  "destroyVolumes": "${DESTROY_VOLUMES}",
+  "composeProjectName": "${COMPOSE_PROJECT_NAME}",
   "waitSeconds": ${WAIT_SECONDS},
   "checks": {
     "precheck": "${CHECK_STATUS[precheck]}",

--- a/deploy/compose/compose-readiness.sh
+++ b/deploy/compose/compose-readiness.sh
@@ -242,7 +242,7 @@ cat > "$summary_file" <<EOF
   "timestamp": "${TIMESTAMP}",
   "dryRun": ${DRY_RUN},
   "skipSmoke": ${SKIP_SMOKE},
-  "destroyVolumes": "${DESTROY_VOLUMES}",
+  "destroyVolumes": ${DESTROY_VOLUMES},
   "composeProjectName": "${COMPOSE_PROJECT_NAME}",
   "waitSeconds": ${WAIT_SECONDS},
   "checks": {

--- a/scripts/compose-volume-cleanup-opt-in.test.sh
+++ b/scripts/compose-volume-cleanup-opt-in.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+READINESS_SCRIPT="${ROOT_DIR}/deploy/compose/compose-readiness.sh"
+SMOKE_SCRIPT="${ROOT_DIR}/scripts/testnet-smoke.sh"
+
+assert_contains() {
+  local needle="$1"
+  local file="$2"
+  if ! grep -Fq -- "${needle}" "${file}"; then
+    echo "expected ${file} to contain: ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local file="$2"
+  if grep -Fq -- "${needle}" "${file}"; then
+    echo "expected ${file} not to contain: ${needle}" >&2
+    exit 1
+  fi
+}
+
+assert_contains '--destroy-volumes' "${READINESS_SCRIPT}"
+assert_contains 'FIBER_LINK_DESTROY_VOLUMES=1' "${READINESS_SCRIPT}"
+assert_contains 'fiber-link-readiness-' "${READINESS_SCRIPT}"
+assert_contains 'WARNING: destructive compose volume cleanup is enabled.' "${READINESS_SCRIPT}"
+assert_contains 'Target compose project: ${COMPOSE_PROJECT_NAME}' "${READINESS_SCRIPT}"
+assert_contains 'Env file: ${ENV_FILE}' "${READINESS_SCRIPT}"
+assert_contains 'COMPOSE_DOWN_ARGS="--remove-orphans"' "${READINESS_SCRIPT}"
+assert_contains 'COMPOSE_DOWN_ARGS="${COMPOSE_DOWN_ARGS} --volumes"' "${READINESS_SCRIPT}"
+assert_not_contains 'down --remove-orphans --volumes' "${READINESS_SCRIPT}"
+
+assert_contains '--destroy-volumes' "${SMOKE_SCRIPT}"
+assert_contains 'FIBER_LINK_DESTROY_VOLUMES=1' "${SMOKE_SCRIPT}"
+assert_contains 'fiber-link-smoke-' "${SMOKE_SCRIPT}"
+assert_contains 'WARNING: destructive compose volume cleanup is enabled.' "${SMOKE_SCRIPT}"
+assert_contains 'Target compose project: ${COMPOSE_PROJECT_NAME}' "${SMOKE_SCRIPT}"
+assert_contains 'Env file: ${ENV_FILE}' "${SMOKE_SCRIPT}"
+assert_contains 'local args=(down --remove-orphans)' "${SMOKE_SCRIPT}"
+assert_contains 'args+=(--volumes)' "${SMOKE_SCRIPT}"
+assert_not_contains 'compose down -v --remove-orphans' "${SMOKE_SCRIPT}"
+assert_not_contains 'docker compose down -v --remove-orphans' "${SMOKE_SCRIPT}"
+
+"${READINESS_SCRIPT}" --help | grep -Fq -- '--destroy-volumes'
+"${SMOKE_SCRIPT}" --help | grep -Fq -- '--destroy-volumes'

--- a/scripts/testnet-smoke.sh
+++ b/scripts/testnet-smoke.sh
@@ -82,7 +82,7 @@ cleanup_stack() {
 
   mkdir -p "${ARTIFACT_DIR}"
   compose logs --no-color > "${ARTIFACT_DIR}/compose.log" || true
-  compose down --remove-orphans > "${ARTIFACT_DIR}/compose-down.log" 2>&1
+  compose $(compose_down_reset_args) > "${ARTIFACT_DIR}/compose-down.log" 2>&1
 }
 
 exit_with() {
@@ -152,7 +152,7 @@ if [[ ! -f "${ENV_FILE}" ]]; then
 fi
 
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(get_env_value COMPOSE_PROJECT_NAME)}"
-export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-fiber-link-smoke-$(date +%Y%m%d%H%M%S)-$$}"
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-fiber-link-smoke-$(date -u +%Y%m%d%H%M%S)-$$}"
 
 if [[ "${DESTROY_VOLUMES}" == "1" ]]; then
   cat >&2 <<EOF
@@ -197,8 +197,7 @@ fi
 
 vlog "reset compose stack to deterministic baseline"
 # Preserve persistent compose volumes by default; opt in with --destroy-volumes or FIBER_LINK_DESTROY_VOLUMES=1.
-read -r -a reset_args <<< "$(compose_down_reset_args)"
-compose "${reset_args[@]}" || true
+compose $(compose_down_reset_args) || true
 
 vlog "starting compose stack"
 compose up -d --build > "${ARTIFACT_DIR}/compose-up.log" 2>&1

--- a/scripts/testnet-smoke.sh
+++ b/scripts/testnet-smoke.sh
@@ -13,6 +13,7 @@ DRY_RUN=0
 SKIP_SMOKE=0
 VERBOSE=0
 STARTED_COMPOSE=0
+DESTROY_VOLUMES="${FIBER_LINK_DESTROY_VOLUMES:-0}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_DIR="${ROOT_DIR}/deploy/compose"
@@ -21,13 +22,14 @@ ARTIFACT_DIR="${ROOT_DIR}/.tmp/testnet-smoke/$(date +%Y%m%d-%H%M%S)"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/testnet-smoke.sh [--dry-run] [--skip-smoke] [--verbose]
+Usage: scripts/testnet-smoke.sh [--dry-run] [--skip-smoke] [--verbose] [--destroy-volumes]
 
 Options:
-  --dry-run     Print planned actions and validate prerequisites without starting containers.
-  --skip-smoke  Skip tip.create invoice smoke (health check still runs).
-  --verbose     Print additional progress logs.
-  -h, --help    Show this help message.
+  --dry-run          Print planned actions and validate prerequisites without starting containers.
+  --skip-smoke       Skip tip.create invoice smoke (health check still runs).
+  --verbose          Print additional progress logs.
+  --destroy-volumes  Remove compose volumes before the smoke run. Can also be enabled with FIBER_LINK_DESTROY_VOLUMES=1.
+  -h, --help         Show this help message.
 
 Exit codes:
   0   PASS
@@ -52,6 +54,14 @@ vlog() {
 
 compose() {
   (cd "${COMPOSE_DIR}" && docker compose "$@")
+}
+
+compose_down_reset_args() {
+  local args=(down --remove-orphans)
+  if [[ "${DESTROY_VOLUMES}" == "1" ]]; then
+    args+=(--volumes)
+  fi
+  printf '%s\n' "${args[*]}"
 }
 
 get_env_value() {
@@ -110,6 +120,9 @@ while [[ $# -gt 0 ]]; do
     --verbose)
       VERBOSE=1
       ;;
+    --destroy-volumes)
+      DESTROY_VOLUMES=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -138,6 +151,17 @@ if [[ ! -f "${ENV_FILE}" ]]; then
   exit_with "${EXIT_PRECHECK}" "missing ${ENV_FILE} (copy deploy/compose/.env.example first)"
 fi
 
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(get_env_value COMPOSE_PROJECT_NAME)}"
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-fiber-link-smoke-$(date +%Y%m%d%H%M%S)-$$}"
+
+if [[ "${DESTROY_VOLUMES}" == "1" ]]; then
+  cat >&2 <<EOF
+WARNING: destructive compose volume cleanup is enabled.
+Target compose project: ${COMPOSE_PROJECT_NAME}
+Env file: ${ENV_FILE}
+EOF
+fi
+
 required_keys=(
   POSTGRES_PASSWORD
   FIBER_SECRET_KEY_PASSWORD
@@ -158,7 +182,8 @@ HMAC_SECRET="$(get_env_value FIBER_LINK_HMAC_SECRET)"
 
 if [[ "${DRY_RUN}" -eq 1 ]]; then
   log "dry-run mode enabled"
-  log "would run: docker compose down -v --remove-orphans"
+  log "compose project: ${COMPOSE_PROJECT_NAME}"
+  log "would run: docker compose $(compose_down_reset_args)"
   log "would run: docker compose up -d --build"
   log "would wait for postgres/redis health and rpc/worker/fnn running"
   log "would run signed health.ping against http://127.0.0.1:${RPC_PORT}/rpc"
@@ -171,7 +196,9 @@ if [[ "${DRY_RUN}" -eq 1 ]]; then
 fi
 
 vlog "reset compose stack to deterministic baseline"
-compose down -v --remove-orphans || true
+# Preserve persistent compose volumes by default; opt in with --destroy-volumes or FIBER_LINK_DESTROY_VOLUMES=1.
+read -r -a reset_args <<< "$(compose_down_reset_args)"
+compose "${reset_args[@]}" || true
 
 vlog "starting compose stack"
 compose up -d --build > "${ARTIFACT_DIR}/compose-up.log" 2>&1


### PR DESCRIPTION
Summary
- Add --destroy-volumes / FIBER_LINK_DESTROY_VOLUMES=1 opt-in gates for compose readiness and testnet smoke volume cleanup.
- Default smoke/readiness runs to isolated compose project names while preserving volumes unless destructive cleanup is explicitly enabled.
- Emit destructive cleanup warnings with target project and env file, and add shell coverage for safe defaults and explicit destructive mode.

Test Plan
- bash -n deploy/compose/compose-readiness.sh scripts/testnet-smoke.sh scripts/compose-volume-cleanup-opt-in.test.sh
- scripts/compose-volume-cleanup-opt-in.test.sh
- ./deploy/compose/compose-readiness.sh --dry-run --skip-smoke (verified commands omit --volumes)
- ./deploy/compose/compose-readiness.sh --dry-run --skip-smoke --destroy-volumes (verified commands include --volumes and warning is printed)

Closes #391