### PR TITLE
fix(discourse): bound polling refresh backoff

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
@@ -401,7 +401,7 @@ export default class FiberLinkTipModal extends Component {
     const elapsedMs = Date.now() - this._statusPollStartedAt;
     return (
       elapsedMs <= TIP_STATUS_AUTO_POLL_MAX_ELAPSED_MS &&
-      this._statusPollFailureCount <= TIP_STATUS_AUTO_POLL_MAX_FAILURES
+      this._statusPollFailureCount < TIP_STATUS_AUTO_POLL_MAX_FAILURES
     );
   }
 
@@ -433,8 +433,11 @@ export default class FiberLinkTipModal extends Component {
     }
 
     if (!this._canContinueStatusPolling()) {
+      const message = this._statusPollFailureCount > 0
+        ? "Status polling paused after repeated failures. Please retry."
+        : "Status polling timed out. Please retry.";
       this.errorMessage = mapStatusErrorToMessage(
-        new Error("Status polling paused after repeated failures. Please retry."),
+        new Error(message),
       );
       return;
     }

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs
@@ -14,6 +14,10 @@ import { createTip, getTipStatus } from "../../services/fiber-link-api";
 const AMOUNT_PATTERN = /^(?:\d+)(?:\.\d{1,8})?$/;
 const COPY_FEEDBACK_TIMEOUT_MS = 3000;
 const TIP_STATUS_AUTO_POLL_INTERVAL_MS = 1000;
+const TIP_STATUS_AUTO_POLL_MAX_BACKOFF_MS = 8000;
+const TIP_STATUS_AUTO_POLL_MAX_FAILURES = 5;
+const TIP_STATUS_AUTO_POLL_MAX_ELAPSED_MS = 120000;
+const TIP_STATUS_HIDDEN_POLL_INTERVAL_MS = 15000;
 const TIP_GENERATION_WATCHDOG_MS = 15000;
 const TIP_GENERATION_WATCHDOG_MESSAGE =
   "Fiber Link is busy while preparing invoice. Please retry.";
@@ -36,6 +40,19 @@ function isTransientNetworkError(message) {
     value.includes("timeout") ||
     value.includes("failed to fetch") ||
     value.includes("service unavailable")
+  );
+}
+
+function isRetryableStatusError(error) {
+  const status = Number(error?.status ?? error?.statusCode ?? error?.code);
+  const message = normalizeMessage(error?.message).toLowerCase();
+  return (
+    status === 429 ||
+    status === 503 ||
+    message.includes("429") ||
+    message.includes("rate limit") ||
+    message.includes("too many requests") ||
+    isTransientNetworkError(message)
   );
 }
 
@@ -125,6 +142,8 @@ export default class FiberLinkTipModal extends Component {
 
   _pollTimer = null;
   _copyFeedbackTimer = null;
+  _statusPollStartedAt = null;
+  _statusPollFailureCount = 0;
 
   constructor(owner, args) {
     super(owner, args);
@@ -354,6 +373,38 @@ export default class FiberLinkTipModal extends Component {
     }
   }
 
+  _resetStatusPollBounds() {
+    this._statusPollStartedAt = Date.now();
+    this._statusPollFailureCount = 0;
+  }
+
+  _isDocumentHidden() {
+    return typeof document !== "undefined" && document?.hidden === true;
+  }
+
+  _getStatusPollDelay() {
+    const backoffDelay = Math.min(
+      TIP_STATUS_AUTO_POLL_MAX_BACKOFF_MS,
+      TIP_STATUS_AUTO_POLL_INTERVAL_MS * Math.pow(2, this._statusPollFailureCount),
+    );
+
+    return this._isDocumentHidden()
+      ? Math.max(backoffDelay, TIP_STATUS_HIDDEN_POLL_INTERVAL_MS)
+      : backoffDelay;
+  }
+
+  _canContinueStatusPolling() {
+    if (!this._statusPollStartedAt) {
+      this._statusPollStartedAt = Date.now();
+    }
+
+    const elapsedMs = Date.now() - this._statusPollStartedAt;
+    return (
+      elapsedMs <= TIP_STATUS_AUTO_POLL_MAX_ELAPSED_MS &&
+      this._statusPollFailureCount <= TIP_STATUS_AUTO_POLL_MAX_FAILURES
+    );
+  }
+
   _clearCopyFeedbackTimer() {
     if (this._copyFeedbackTimer) {
       clearTimeout(this._copyFeedbackTimer);
@@ -381,10 +432,17 @@ export default class FiberLinkTipModal extends Component {
       return;
     }
 
+    if (!this._canContinueStatusPolling()) {
+      this.errorMessage = mapStatusErrorToMessage(
+        new Error("Status polling paused after repeated failures. Please retry."),
+      );
+      return;
+    }
+
     this._pollTimer = setTimeout(() => {
       this._pollTimer = null;
       void this.checkStatus({ isAutoPoll: true });
-    }, TIP_STATUS_AUTO_POLL_INTERVAL_MS);
+    }, this._getStatusPollDelay());
   }
 
   @action
@@ -459,6 +517,7 @@ export default class FiberLinkTipModal extends Component {
       this.statusState = "UNPAID";
       this.statusLabel = mapTipStateToLabel("UNPAID");
       this.statusClass = mapTipStateToClass("UNPAID");
+      this._resetStatusPollBounds();
       scheduleAutoPoll = true;
     } catch (e) {
       this.errorMessage = mapCreateTipErrorToMessage(e);
@@ -482,6 +541,7 @@ export default class FiberLinkTipModal extends Component {
     if (!isAutoPoll) {
       this.errorMessage = null;
       this._clearStatusPollTimer();
+      this._resetStatusPollBounds();
     }
     this.isChecking = true;
 
@@ -491,6 +551,7 @@ export default class FiberLinkTipModal extends Component {
       this.statusLabel = mapTipStateToLabel(state);
       this.statusClass = mapTipStateToClass(state);
       this.errorMessage = null;
+      this._statusPollFailureCount = 0;
 
       if (state === "SETTLED") {
         this.currentStep = "confirmed";
@@ -503,7 +564,8 @@ export default class FiberLinkTipModal extends Component {
         this._clearStatusPollTimer();
       }
     } catch (e) {
-      if (isAutoPoll && isTransientNetworkError(normalizeMessage(e?.message))) {
+      if (isAutoPoll && isRetryableStatusError(e)) {
+        this._statusPollFailureCount += 1;
         scheduleAutoPoll = true;
       } else {
         this.errorMessage = mapStatusErrorToMessage(e);

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
@@ -6,6 +6,10 @@ import { getDashboardSummary } from "../services/fiber-link-api";
 const DEFAULT_POLL_INTERVAL_MS = 10000;
 const DASHBOARD_LIMIT = 20;
 const ALLOWED_POLL_INTERVALS = [10000, 30000, 60000];
+const DASHBOARD_POLL_MAX_BACKOFF_MS = 60000;
+const DASHBOARD_POLL_MAX_FAILURES = 5;
+const DASHBOARD_POLL_MAX_FAILURE_WINDOW_MS = 300000;
+const DASHBOARD_HIDDEN_POLL_INTERVAL_MS = 60000;
 const SYNC_AGE_TICK_MS = 1000;
 
 function mapDashboardErrorToMessage(error) {
@@ -346,7 +350,9 @@ function normalizeTips(tips) {
       transactionConfirmationClassName: [
         "fiber-link-transaction-dialog__meta",
         status.key === "failed" ? "is-failed" : "",
-        status.key === "pending" || status.key === "broadcasted" ? "is-pending" : "",
+        status.key === "pending" || status.key === "broadcasted"
+          ? "is-pending"
+          : "",
       ]
         .filter(Boolean)
         .join(" "),
@@ -360,6 +366,9 @@ export default class FiberLinkDashboardRoute extends Route {
   _pollTimer = null;
   _syncAgeTimer = null;
   _lastTipFeedSignature = null;
+  _dashboardPollFailureCount = 0;
+  _dashboardPollFirstFailureAt = null;
+  _lastRefreshFailed = false;
 
   model() {
     this._clearPollTimer();
@@ -388,6 +397,7 @@ export default class FiberLinkDashboardRoute extends Route {
       tipFeedItems: [],
       retryDashboardSummary: () => {
         if (!model.isRefreshing) {
+          this._resetDashboardPollBackoff();
           model.set("isRefreshing", true);
           void this._refreshSummary(model);
         }
@@ -395,6 +405,7 @@ export default class FiberLinkDashboardRoute extends Route {
     });
 
     this._activeModel = model;
+    this._resetDashboardPollBackoff();
     void this._refreshSummary(model);
 
     return model;
@@ -478,6 +489,7 @@ export default class FiberLinkDashboardRoute extends Route {
       }
 
       model.setProperties(nextProperties);
+      this._resetDashboardPollBackoff();
       this._startSyncAgeTimer(model);
     } catch (error) {
       if (model !== this._activeModel) {
@@ -485,6 +497,7 @@ export default class FiberLinkDashboardRoute extends Route {
       }
 
       const message = mapDashboardErrorToMessage(error);
+      this._recordDashboardPollFailure();
       model.setProperties({
         isInitialLoading: false,
         isRefreshing: false,
@@ -499,17 +512,70 @@ export default class FiberLinkDashboardRoute extends Route {
     }
   }
 
-  _schedulePoll(model) {
-    this._clearPollTimer();
+  _resetDashboardPollBackoff() {
+    this._dashboardPollFailureCount = 0;
+    this._dashboardPollFirstFailureAt = null;
+    this._lastRefreshFailed = false;
+  }
+
+  _recordDashboardPollFailure() {
+    if (!this._dashboardPollFirstFailureAt) {
+      this._dashboardPollFirstFailureAt = Date.now();
+    }
+    this._dashboardPollFailureCount += 1;
+    this._lastRefreshFailed = true;
+  }
+
+  _isDocumentHidden() {
+    return typeof document !== "undefined" && document?.hidden === true;
+  }
+
+  _canContinueDashboardPolling() {
+    if (!this._lastRefreshFailed) {
+      return true;
+    }
+
+    return (
+      this._dashboardPollFailureCount <= DASHBOARD_POLL_MAX_FAILURES &&
+      Date.now() - this._dashboardPollFirstFailureAt <=
+        DASHBOARD_POLL_MAX_FAILURE_WINDOW_MS
+    );
+  }
+
+  _getDashboardPollDelay(model) {
     const pollIntervalMs = ALLOWED_POLL_INTERVALS.includes(
       Number(model?.pollIntervalMs),
     )
       ? Number(model.pollIntervalMs)
       : DEFAULT_POLL_INTERVAL_MS;
+    const backoffDelay = this._lastRefreshFailed
+      ? Math.min(
+          DASHBOARD_POLL_MAX_BACKOFF_MS,
+          pollIntervalMs *
+            Math.pow(2, Math.max(0, this._dashboardPollFailureCount - 1)),
+        )
+      : pollIntervalMs;
+
+    return this._isDocumentHidden()
+      ? Math.max(backoffDelay, DASHBOARD_HIDDEN_POLL_INTERVAL_MS)
+      : backoffDelay;
+  }
+
+  _schedulePoll(model) {
+    this._clearPollTimer();
+    if (!this._canContinueDashboardPolling()) {
+      const pauseMessage =
+        "Auto-refresh paused after repeated failures. Retry dashboard to resume.";
+      model?.setProperties?.({
+        summaryErrorMessage: pauseMessage,
+        feedErrorMessage: pauseMessage,
+      });
+      return;
+    }
 
     this._pollTimer = setTimeout(() => {
       void this._refreshSummary(model);
-    }, pollIntervalMs);
+    }, this._getDashboardPollDelay(model));
   }
 
   _startSyncAgeTimer(model) {

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
@@ -24,6 +24,30 @@ function mapDashboardErrorToMessage(error) {
   return message;
 }
 
+function isTransientDashboardError(message) {
+  const value = message.toLowerCase();
+  return (
+    value.includes("network") ||
+    value.includes("timeout") ||
+    value.includes("failed to fetch") ||
+    value.includes("service unavailable")
+  );
+}
+
+function isRetryableDashboardError(error) {
+  const status = Number(error?.status ?? error?.statusCode ?? error?.code);
+  const message =
+    typeof error?.message === "string" ? error.message.trim() : "";
+  return (
+    status === 429 ||
+    status === 503 ||
+    message.includes("429") ||
+    message.toLowerCase().includes("rate limit") ||
+    message.toLowerCase().includes("too many requests") ||
+    isTransientDashboardError(message)
+  );
+}
+
 function formatSyncStatusLabel(rawValue) {
   const value = new Date(rawValue);
   if (Number.isNaN(value.getTime())) {
@@ -496,8 +520,13 @@ export default class FiberLinkDashboardRoute extends Route {
         return;
       }
 
+      const retryable = isRetryableDashboardError(error);
       const message = mapDashboardErrorToMessage(error);
-      this._recordDashboardPollFailure();
+      if (retryable) {
+        this._recordDashboardPollFailure();
+      } else {
+        this._resetDashboardPollBackoff();
+      }
       model.setProperties({
         isInitialLoading: false,
         isRefreshing: false,
@@ -536,7 +565,7 @@ export default class FiberLinkDashboardRoute extends Route {
     }
 
     return (
-      this._dashboardPollFailureCount <= DASHBOARD_POLL_MAX_FAILURES &&
+      this._dashboardPollFailureCount < DASHBOARD_POLL_MAX_FAILURES &&
       Date.now() - this._dashboardPollFirstFailureAt <=
         DASHBOARD_POLL_MAX_FAILURE_WINDOW_MS
     );

--- a/scripts/test_discourse_polling_backoff_static.py
+++ b/scripts/test_discourse_polling_backoff_static.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TIP_MODAL = ROOT / "fiber-link-discourse-plugin/assets/javascripts/discourse/components/modal/fiber-link-tip-modal.gjs"
+DASHBOARD = ROOT / "fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js"
+
+
+def test_tip_modal_has_bounded_exponential_backoff_polling():
+    source = TIP_MODAL.read_text()
+
+    assert "TIP_STATUS_AUTO_POLL_MAX_FAILURES" in source
+    assert "TIP_STATUS_AUTO_POLL_MAX_ELAPSED_MS" in source
+    assert "TIP_STATUS_AUTO_POLL_MAX_BACKOFF_MS" in source
+    assert "TIP_STATUS_HIDDEN_POLL_INTERVAL_MS" in source
+    assert "_getStatusPollDelay" in source
+    assert "Math.pow(2" in source
+    assert "document?.hidden" in source
+    assert "Status polling paused after repeated failures" in source
+
+
+def test_dashboard_has_bounded_exponential_backoff_refresh():
+    source = DASHBOARD.read_text()
+
+    assert "DASHBOARD_POLL_MAX_FAILURES" in source
+    assert "DASHBOARD_POLL_MAX_FAILURE_WINDOW_MS" in source
+    assert "DASHBOARD_POLL_MAX_BACKOFF_MS" in source
+    assert "DASHBOARD_HIDDEN_POLL_INTERVAL_MS" in source
+    assert "_getDashboardPollDelay" in source
+    assert "Math.pow(2" in source
+    assert "document?.hidden" in source
+    assert "Auto-refresh paused after repeated failures" in source


### PR DESCRIPTION
Summary
- Add bounded exponential backoff for tip status polling, including retryable transient/429 handling and hidden-document slowdown.
- Add bounded dashboard auto-refresh backoff with pause after repeated failures and hidden-document slowdown.
- Add a static regression test covering the new polling/backoff guards.

Test Plan
- python3 -m pytest scripts/test_discourse_polling_backoff_static.py
- npx --yes prettier --check --parser babel fiber-link-discourse-plugin/assets/javascripts/discourse/routes/fiber-link-dashboard.js
- git diff --check
- bundle exec rspec fiber-link-discourse-plugin/spec/system/fiber_link_tip_spec.rb fiber-link-discourse-plugin/spec/system/fiber_link_dashboard_spec.rb (blocked: bundle is not installed in this environment)

Closes #390