### PR TITLE
Robustness: harden Fiber Link RPC controller

### DIFF
--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -221,19 +221,18 @@ module ::FiberLink
       end
       return true unless missing_setting
 
-      render_error(request_id, :bad_request, -32602, missing_setting.to_s.humanize)
+      render_error(request_id, :bad_request, -32603, missing_setting.to_s.humanize)
       false
     end
 
     def enforce_method_rate_limit(method, request_id)
       return true unless defined?(::RateLimiter)
+      return true if current_user&.admin?
 
       max_requests, window_seconds = rate_limit_for_method(method)
       ::RateLimiter.new(current_user, "fiber_link_rpc_#{method.tr(".", "_")}", max_requests, window_seconds).performed!
       true
-    rescue StandardError => error
-      raise unless defined?(::RateLimiter::LimitExceeded) && error.is_a?(::RateLimiter::LimitExceeded)
-
+    rescue ::RateLimiter::LimitExceeded
       render_error(request_id, :too_many_requests, -32005, "Rate limit exceeded")
       false
     end

--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -12,6 +12,9 @@ module ::FiberLink
 
     ALLOWED_WITHDRAWAL_STATES = ["ALL", "LIQUIDITY_PENDING", "PENDING", "PROCESSING", "RETRY_PENDING", "COMPLETED", "FAILED"].freeze
     ALLOWED_SETTLEMENT_STATES = ["ALL", "UNPAID", "SETTLED", "FAILED"].freeze
+    READ_METHOD_RATE_LIMIT = [60, 60].freeze
+    MUTATING_METHOD_RATE_LIMIT = [10, 60].freeze
+    MUTATING_METHODS = ["tip.create", "withdrawal.request"].freeze
 
     def proxy
       request_json = parse_request_json
@@ -19,10 +22,19 @@ module ::FiberLink
 
       request_id = request_json["id"]
       method = request_json["method"]
-      params = request_json["params"] || {}
+      params = request_json.key?("params") ? request_json["params"] : {}
+
+      unless params.is_a?(Hash)
+        render_error(request_id, :bad_request, -32602, "Invalid params")
+        return
+      end
 
       sanitized_params = sanitize_params(method, params, request_id)
       return unless sanitized_params
+
+      return unless validate_service_settings(request_id)
+
+      return unless enforce_method_rate_limit(method, request_id)
 
       response = service_client.post(method:, params: sanitized_params, request_id:)
       render body: enrich_response_body(method, response.body), status: response.status, content_type: "application/json"
@@ -50,7 +62,11 @@ module ::FiberLink
     end
 
     def parse_request_json
-      JSON.parse(request.raw_post)
+      payload = JSON.parse(request.raw_post)
+      return payload if payload.is_a?(Hash)
+
+      render_error(nil, :bad_request, -32600, "Invalid request")
+      nil
     rescue JSON::ParserError
       render json: {
                jsonrpc: "2.0",
@@ -197,6 +213,33 @@ module ::FiberLink
           payload[:paymentRequest] = legacy_to_address
         end
       end
+    end
+
+    def validate_service_settings(request_id)
+      missing_setting = %i[fiber_link_service_url fiber_link_app_id fiber_link_app_secret].find do |setting|
+        SiteSetting.public_send(setting).blank?
+      end
+      return true unless missing_setting
+
+      render_error(request_id, :bad_request, -32602, missing_setting.to_s.humanize)
+      false
+    end
+
+    def enforce_method_rate_limit(method, request_id)
+      return true unless defined?(::RateLimiter)
+
+      max_requests, window_seconds = rate_limit_for_method(method)
+      ::RateLimiter.new(current_user, "fiber_link_rpc_#{method.tr(".", "_")}", max_requests, window_seconds).performed!
+      true
+    rescue StandardError => error
+      raise unless defined?(::RateLimiter::LimitExceeded) && error.is_a?(::RateLimiter::LimitExceeded)
+
+      render_error(request_id, :too_many_requests, -32005, "Rate limit exceeded")
+      false
+    end
+
+    def rate_limit_for_method(method)
+      MUTATING_METHODS.include?(method) ? MUTATING_METHOD_RATE_LIMIT : READ_METHOD_RATE_LIMIT
     end
 
     def enrich_response_body(method, raw_body)

--- a/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
+++ b/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
       expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
     end
 
-    it "returns JSON-RPC invalid params when service settings are missing" do
+    it "returns JSON-RPC internal error when service settings are missing" do
       sign_in(user)
       SiteSetting.fiber_link_service_url = ""
 
@@ -360,7 +360,7 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
       body = JSON.parse(response.body)
       expect(body.fetch("jsonrpc")).to eq("2.0")
       expect(body.fetch("id")).to eq("missing-settings")
-      expect(body.dig("error", "code")).to eq(-32602)
+      expect(body.dig("error", "code")).to eq(-32603)
 
       expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
     end
@@ -395,6 +395,32 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
       expect(body.dig("error", "message")).to eq("Rate limit exceeded")
 
       expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
+    end
+
+    it "lets admins bypass RPC method rate limits" do
+      admin = Fabricate(:admin)
+      sign_in(admin)
+
+      stub_request(:post, "https://fiber-link.example/rpc").to_return(
+        status: 200,
+        body: { jsonrpc: "2.0", id: "admin-bypass", result: { invoice: "inv-admin" } }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      expect(::RateLimiter).not_to receive(:new)
+
+      post "/fiber-link/rpc",
+           params: {
+             jsonrpc: "2.0",
+             id: "admin-bypass",
+             method: "tip.create",
+             params: { amount: "1", asset: "CKB", postId: topic.first_post.id },
+           },
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.dig("result", "invoice")).to eq("inv-admin")
     end
 
     it "returns a JSON-RPC error envelope for invalid postId" do

--- a/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
+++ b/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
@@ -292,6 +292,42 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
       }
     end
 
+    it "rejects non-object JSON-RPC payloads without forwarding" do
+      sign_in(user)
+
+      stub_request(:post, "https://fiber-link.example/rpc").to_return(status: 200, body: "{}")
+
+      [[], "x"].each do |payload|
+        post "/fiber-link/rpc", params: payload, as: :json
+
+        expect(response).to have_http_status(:bad_request)
+        body = JSON.parse(response.body)
+        expect(body.fetch("jsonrpc")).to eq("2.0")
+        expect(body.fetch("id")).to be_nil
+        expect(body.dig("error", "code")).to eq(-32600)
+      end
+
+      expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
+    end
+
+    it "rejects non-object JSON-RPC params without forwarding" do
+      sign_in(user)
+
+      stub_request(:post, "https://fiber-link.example/rpc").to_return(status: 200, body: "{}")
+
+      post "/fiber-link/rpc",
+           params: { jsonrpc: "2.0", id: "array-params", method: "dashboard.summary", params: [] },
+           as: :json
+
+      expect(response).to have_http_status(:bad_request)
+      body = JSON.parse(response.body)
+      expect(body.fetch("jsonrpc")).to eq("2.0")
+      expect(body.fetch("id")).to eq("array-params")
+      expect(body.dig("error", "code")).to eq(-32602)
+
+      expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
+    end
+
     it "rejects unknown methods without forwarding" do
       sign_in(user)
 
@@ -306,6 +342,57 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
       expect(body.fetch("jsonrpc")).to eq("2.0")
       expect(body.fetch("id")).to eq("x")
       expect(body.dig("error", "code")).to eq(-32601)
+
+      expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
+    end
+
+    it "returns JSON-RPC invalid params when service settings are missing" do
+      sign_in(user)
+      SiteSetting.fiber_link_service_url = ""
+
+      stub_request(:post, "https://fiber-link.example/rpc").to_return(status: 200, body: "{}")
+
+      post "/fiber-link/rpc",
+           params: { jsonrpc: "2.0", id: "missing-settings", method: "tip.status", params: { invoice: "inv-1" } },
+           as: :json
+
+      expect(response).to have_http_status(:bad_request)
+      body = JSON.parse(response.body)
+      expect(body.fetch("jsonrpc")).to eq("2.0")
+      expect(body.fetch("id")).to eq("missing-settings")
+      expect(body.dig("error", "code")).to eq(-32602)
+
+      expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
+    end
+
+    it "rate limits high-rate mutating RPC methods without forwarding" do
+      sign_in(user)
+
+      stub_request(:post, "https://fiber-link.example/rpc").to_return(status: 200, body: "{}")
+      limiter = instance_double(::RateLimiter)
+      rate_limiter_called = false
+      allow(::RateLimiter).to receive(:new).and_wrap_original do |original, *args|
+        actor, key, max_requests, window_seconds = args
+        if actor.is_a?(User) && key == "fiber_link_rpc_tip_create" && max_requests == 10 && window_seconds == 60
+          rate_limiter_called = true
+          limiter
+        else
+          original.call(*args)
+        end
+      end
+      expect(limiter).to receive(:performed!).and_raise(RateLimiter::LimitExceeded.new(1))
+
+      post "/fiber-link/rpc",
+           params: { jsonrpc: "2.0", id: "limited", method: "tip.create", params: { postId: topic.first_post.id } },
+           as: :json
+
+      expect(rate_limiter_called).to eq(true)
+      expect(response).to have_http_status(:too_many_requests)
+      body = JSON.parse(response.body)
+      expect(body.fetch("jsonrpc")).to eq("2.0")
+      expect(body.fetch("id")).to eq("limited")
+      expect(body.dig("error", "code")).to eq(-32005)
+      expect(body.dig("error", "message")).to eq("Rate limit exceeded")
 
       expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
     end


### PR DESCRIPTION
## Summary
- Validate JSON-RPC requests before forwarding to the Fiber Link service.
- Reject non-object payloads/params with stable JSON-RPC errors.
- Add method-specific Discourse rate limiting for mutating Fiber Link RPC methods.

## Test Plan
- docker exec discourse_dev bash -lc 'cd /src && sudo -u discourse LOAD_PLUGINS=1 bundle exec rspec plugins/fiber-link/spec/requests/fiber_link/rpc_controller_spec.rb'
- git diff --check

Closes #389
