### PR TITLE
fix(compose): validate backup integrity and FNN state

### DIFF
--- a/deploy/compose/compose-backup.test.sh
+++ b/deploy/compose/compose-backup.test.sh
@@ -25,7 +25,7 @@ assert_contains() {
 assert_file_contains() {
   local file="$1"
   local needle="$2"
-  grep -Fq "${needle}" "${file}" || fail "expected ${file} to contain '${needle}'"
+  grep -Fq -- "${needle}" "${file}" || fail "expected ${file} to contain '${needle}'"
 }
 
 make_fake_docker() {
@@ -85,12 +85,19 @@ run_backup_dry_run() {
   [[ -f "${backup_dir}/db/postgres.sql" ]] || fail "missing postgres.sql in dry-run backup"
   [[ -f "${backup_dir}/runtime/worker-settlement-cursor.json" ]] || fail "missing worker cursor placeholder in dry-run backup"
   [[ -f "${backup_dir}/metadata/manifest.json" ]] || fail "missing backup manifest in dry-run backup"
+  [[ -f "${backup_dir}/metadata/checksums.sha256" ]] || fail "missing backup checksums in dry-run backup"
   [[ -f "${backup_dir}/metadata/retention-policy.md" ]] || fail "missing backup retention policy in dry-run backup"
   [[ -f "${backup_dir}/status/step-results.tsv" ]] || fail "missing step-results.tsv in dry-run backup"
+  [[ -f "${backup_dir}/fnn/README.txt" ]] || fail "missing fnn state opt-in marker in dry-run backup"
+  [[ -f "${backup_dir}/fnn2/README.txt" ]] || fail "missing fnn2 state opt-in marker in dry-run backup"
 
   assert_file_contains "${backup_dir}/commands/command-index.log" "pg_dump"
   assert_file_contains "${backup_dir}/metadata/retention-policy.md" "45 days"
   assert_file_contains "${backup_dir}/status/step-results.tsv" "DRY_RUN"
+  assert_file_contains "${backup_dir}/status/step-results.tsv" $'fnn-state\tSKIPPED'
+  assert_file_contains "${backup_dir}/metadata/manifest.json" '"schemaVersion": 1'
+  assert_file_contains "${backup_dir}/metadata/manifest.json" '"includeFnnState": false'
+  (cd "${backup_dir}" && sha256sum -c metadata/checksums.sha256 >/dev/null) || fail "checksum validation failed for dry-run backup"
 
   printf '%s\n' "${backup_dir}" > "${TMP_DIR}/backup-dir.txt"
 }
@@ -118,6 +125,46 @@ run_restore_dry_run() {
   [[ -f "${backup_dir}/restore/step-results.tsv" ]] || fail "missing restore step results"
   assert_file_contains "${backup_dir}/restore/command-index.log" "docker compose"
   assert_file_contains "${backup_dir}/restore/step-results.tsv" "DRY_RUN"
+
+  set +e
+  output="$(
+    PATH="${fake_bin}:${PATH}" \
+      "${RESTORE_SCRIPT}" \
+      --backup "${backup_dir}" \
+      --yes 2>&1
+  )"
+  local rc=$?
+  set -e
+  [[ "${rc}" -eq 10 ]] || fail "expected live restore from dry-run bundle to fail precheck, got ${rc}: ${output}"
+  assert_contains "${output}" "refusing live restore from a dry-run backup bundle"
+}
+
+run_backup_dry_run_with_fnn_state() {
+  local fake_bin="${TMP_DIR}/fake-bin-fnn-state"
+  local output_root="${TMP_DIR}/backup-output-fnn-state"
+  local output
+  local backup_dir
+
+  export FAKE_DOCKER_LOG="${TMP_DIR}/fake-docker-fnn-state.log"
+  make_fake_docker "${fake_bin}"
+
+  output="$(
+    PATH="${fake_bin}:${PATH}" \
+      "${BACKUP_SCRIPT}" \
+      --dry-run \
+      --include-fnn-state \
+      --output-root "${output_root}"
+  )"
+
+  assert_contains "${output}" "RESULT=PASS CODE=0"
+  backup_dir="$(printf '%s\n' "${output}" | sed -n 's/.*BACKUP_DIR=\([^ ]*\).*/\1/p')"
+  [[ -n "${backup_dir}" ]] || fail "failed to parse BACKUP_DIR from fnn-state output"
+  [[ -f "${backup_dir}/fnn/data.tar.gz" ]] || fail "missing fnn state tarball placeholder"
+  [[ -f "${backup_dir}/fnn2/data.tar.gz" ]] || fail "missing fnn2 state tarball placeholder"
+  assert_file_contains "${backup_dir}/metadata/manifest.json" '"includeFnnState": true'
+  assert_file_contains "${backup_dir}/commands/command-index.log" "--volumes-from fiber-link-fnn"
+  assert_file_contains "${backup_dir}/commands/command-index.log" "--volumes-from fiber-link-fnn2"
+  (cd "${backup_dir}" && sha256sum -c metadata/checksums.sha256 >/dev/null) || fail "checksum validation failed for fnn-state backup"
 }
 
 run_backup_dry_run_with_env_override() {
@@ -168,6 +215,7 @@ run_help_checks
 assert_repo_wiring
 run_backup_dry_run
 run_restore_dry_run
+run_backup_dry_run_with_fnn_state
 run_backup_dry_run_with_env_override
 
 printf 'compose-backup checks passed\n'

--- a/deploy/compose/compose-backup.test.sh
+++ b/deploy/compose/compose-backup.test.sh
@@ -41,6 +41,22 @@ if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "run" ]]; then
+  backup_mount=""
+  for arg in "$@"; do
+    case "${arg}" in
+      *:/backup)
+        backup_mount="${arg%%:/backup}"
+        ;;
+    esac
+  done
+  if [[ -n "${backup_mount}" ]]; then
+    printf 'tarball-bytes-from-fake-docker\n' > "${backup_mount}/data.tar.gz"
+    printf 'fake docker command log on stdout\n'
+  fi
+  exit 0
+fi
+
 exit 0
 EOF
   chmod +x "${fake_bin}/docker"
@@ -199,6 +215,32 @@ EOF_ENV
     || fail "expected ${backup_dir}/commands/command-index.log to contain '--env-file \"${custom_env_file}\"'"
 }
 
+run_backup_live_fnn_state_uses_separate_log() {
+  local fake_bin="${TMP_DIR}/fake-bin-live-fnn-state"
+  local output_root="${TMP_DIR}/backup-output-live-fnn-state"
+  local output
+  local backup_dir
+
+  export FAKE_DOCKER_LOG="${TMP_DIR}/fake-docker-live-fnn-state.log"
+  make_fake_docker "${fake_bin}"
+
+  output="$(
+    PATH="${fake_bin}:${PATH}" \
+      "${BACKUP_SCRIPT}" \
+      --include-fnn-state \
+      --output-root "${output_root}"
+  )"
+
+  assert_contains "${output}" "RESULT=PASS CODE=0"
+  backup_dir="$(printf '%s\n' "${output}" | sed -n 's/.*BACKUP_DIR=\([^ ]*\).*/\1/p')"
+  [[ -n "${backup_dir}" ]] || fail "failed to parse BACKUP_DIR from live fnn-state output"
+  assert_file_contains "${backup_dir}/fnn/data.tar.gz" "tarball-bytes-from-fake-docker"
+  assert_file_contains "${backup_dir}/fnn/data.tar.gz.log" "fake docker command log on stdout"
+  assert_file_contains "${backup_dir}/fnn2/data.tar.gz" "tarball-bytes-from-fake-docker"
+  assert_file_contains "${backup_dir}/fnn2/data.tar.gz.log" "fake docker command log on stdout"
+  (cd "${backup_dir}" && sha256sum -c metadata/checksums.sha256 >/dev/null) || fail "checksum validation failed for live fnn-state backup"
+}
+
 assert_repo_wiring() {
   [[ -f "${BACKUP_RUNBOOK_FILE}" ]] || fail "missing backup runbook"
   [[ -x "${BACKUP_SCRIPT}" ]] || fail "backup script is not executable"
@@ -217,5 +259,6 @@ run_backup_dry_run
 run_restore_dry_run
 run_backup_dry_run_with_fnn_state
 run_backup_dry_run_with_env_override
+run_backup_live_fnn_state_uses_separate_log
 
 printf 'compose-backup checks passed\n'

--- a/docs/runbooks/compose-backup-recovery.md
+++ b/docs/runbooks/compose-backup-recovery.md
@@ -12,8 +12,9 @@ The backup bundle captures:
 - a logical PostgreSQL dump with `--clean --if-exists --create`
 - the worker settlement cursor file
 - compose config and service status snapshots
-- container metadata for the main stateful services
-- retention metadata and a replayable command log
+- container metadata for the main stateful services, including FNN/FNN2
+- optional FNN/FNN2 `/data` volume tarballs when `--include-fnn-state` is used
+- retention metadata, a replayable command log, a manifest, and SHA-256 checksums
 
 This is not point-in-time recovery and it does not replace database replication, offsite storage, or full node-data backup.
 
@@ -29,6 +30,7 @@ Optional flags:
 
 - `--output-root <path>`: override output root (default `deploy/compose/backups`)
 - `--retention-days <n>`: override retention policy days (default `BACKUP_RETENTION_DAYS` from `deploy/compose/.env`, otherwise `30`)
+- `--include-fnn-state`: include `fiber-link-fnn` and `fiber-link-fnn2` `/data` volume tarballs (`fnn/data.tar.gz`, `fnn2/data.tar.gz`) in addition to metadata
 - `--dry-run`: create a placeholder bundle and command plan without docker side effects
 - `--verbose`: print progress logs
 
@@ -44,6 +46,8 @@ Generated bundle layout:
 deploy/compose/backups/<UTC_TIMESTAMP>/
   commands/
   db/
+  fnn/
+  fnn2/
   metadata/
   runtime/
   snapshots/
@@ -73,6 +77,8 @@ Success output:
 RESULT=PASS CODE=0 BACKUP_SOURCE=... RESTORE_MODE=...
 ```
 
+Restore validates `metadata/manifest.json`, `status/step-results.tsv`, and `metadata/checksums.sha256` before any restore command is planned. Live restore refuses bundles produced with `--dry-run`. If the manifest says FNN state was included, restore also requires `fnn/data.tar.gz` and `fnn2/data.tar.gz` and replays those tarballs before the application services are started.
+
 ## Restore Rehearsal
 
 For each release window:
@@ -86,7 +92,15 @@ docker compose -f deploy/compose/docker-compose.yml ps
 curl -fsS http://127.0.0.1:${RPC_PORT:-3000}/healthz/ready
 ```
 
-4. Verify the backup contained the expected policy and withdrawal state:
+4. Verify the backup integrity and expected policy/state before promoting it:
+
+```bash
+cd deploy/compose/backups/<UTC_TIMESTAMP>
+sha256sum -c metadata/checksums.sha256
+jq '.schemaVersion, .overallStatus, .includeFnnState' metadata/manifest.json
+```
+
+5. Verify the restored database contains the expected withdrawal state:
 
 ```bash
 docker exec -i fiber-link-postgres psql \
@@ -95,11 +109,12 @@ docker exec -i fiber-link-postgres psql \
   -c "select count(*) from withdrawals;"
 ```
 
-5. Attach the `BACKUP_DIR` or `BACKUP_ARCHIVE` path to the release ticket along with the restore rehearsal timestamp.
+6. Attach the `BACKUP_DIR` or `BACKUP_ARCHIVE` path to the release ticket along with the restore rehearsal timestamp.
 
 ## Operational Notes
 
 - The restore flow stops `rpc` and `worker` before replaying the PostgreSQL dump, then starts them again after restore.
+- If `--include-fnn-state` was used during capture, restore stops `fnn` and `fnn2`, extracts the saved `/data` tarballs into their volumes, then starts those services before `rpc`/`worker`.
 - If the worker cursor backup contains `UNSET`, cursor restore is skipped.
 - Keep generated backup bundles outside git history; `deploy/compose/backups/` is ignored by this repository.
 - Promote the generated `.tar.gz` archive to long-term storage before local cleanup.
@@ -107,5 +122,5 @@ docker exec -i fiber-link-postgres psql \
 ## Current Limits
 
 - No offsite copy, PITR, or WAL shipping is configured here.
-- FNN node volumes are not included in this backup bundle.
+- FNN node volume capture is opt-in with `--include-fnn-state`; use it for release-gate backups that must preserve node state, and ensure the archive is stored securely because it may contain sensitive node data.
 - Monitoring and alerting for backup success/failure are still separate follow-up work.

--- a/scripts/capture-compose-backup.sh
+++ b/scripts/capture-compose-backup.sh
@@ -6,10 +6,12 @@ EXIT_USAGE=2
 EXIT_PRECHECK=10
 EXIT_CAPTURE_FAILURE=11
 EXIT_ARCHIVE_FAILURE=12
+EXIT_INTEGRITY_FAILURE=13
 
 DRY_RUN=0
 VERBOSE=0
 RETENTION_DAYS=""
+INCLUDE_FNN_STATE=0
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_FILE="${ROOT_DIR}/deploy/compose/docker-compose.yml"
@@ -25,6 +27,7 @@ OVERALL_FAILURE=0
 POSTGRES_USER_DEFAULT="fiber"
 POSTGRES_DB_DEFAULT="fiber_link"
 WORKER_CURSOR_FILE_DEFAULT="/var/lib/fiber-link/settlement-cursor.json"
+BACKUP_HELPER_IMAGE_DEFAULT="public.ecr.aws/docker/library/alpine:3.20"
 
 usage() {
   printf '%s\n' \
@@ -33,6 +36,7 @@ usage() {
     "Options:" \
     "  --output-root <path>    Output root directory (default: deploy/compose/backups)." \
     "  --retention-days <n>    Retention policy in days (default: BACKUP_RETENTION_DAYS from .env or 30)." \
+    "  --include-fnn-state     Include FNN and FNN2 /data volume tarballs in the backup bundle." \
     "  --dry-run               Generate the bundle structure and command plan without docker side effects." \
     "  --verbose               Print progress logs." \
     "  -h, --help              Show this help message." \
@@ -42,7 +46,8 @@ usage() {
     "  2   invalid usage" \
     "  10  precheck failure" \
     "  11  one or more capture steps failed" \
-    "  12  archive generation failure"
+    "  12  archive generation failure" \
+    "  13  manifest/checksum generation failure"
 }
 
 log() {
@@ -101,6 +106,15 @@ bool_status() {
   fi
 }
 
+write_checksums() {
+  (
+    cd "${BACKUP_DIR}"
+    find commands db fnn fnn2 metadata runtime snapshots status -type f ! -path 'metadata/checksums.sha256' -print \
+      | LC_ALL=C sort \
+      | xargs sha256sum
+  ) > "${BACKUP_DIR}/metadata/checksums.sha256"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --output-root)
@@ -112,6 +126,9 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || { usage >&2; exit "${EXIT_USAGE}"; }
       RETENTION_DAYS="$2"
       shift
+      ;;
+    --include-fnn-state)
+      INCLUDE_FNN_STATE=1
       ;;
     --dry-run)
       DRY_RUN=1
@@ -149,13 +166,14 @@ fi
 POSTGRES_USER="${POSTGRES_USER:-${POSTGRES_USER_DEFAULT}}"
 POSTGRES_DB="${POSTGRES_DB:-${POSTGRES_DB_DEFAULT}}"
 WORKER_CURSOR_FILE="${WORKER_SETTLEMENT_CURSOR_FILE:-${WORKER_CURSOR_FILE_DEFAULT}}"
+BACKUP_HELPER_IMAGE="${BACKUP_HELPER_IMAGE:-${BACKUP_HELPER_IMAGE_DEFAULT}}"
 
 BACKUP_DIR="${OUTPUT_ROOT}/${TIMESTAMP}"
 ARCHIVE_FILE="${BACKUP_DIR}.tar.gz"
 COMMAND_LOG="${BACKUP_DIR}/commands/command-index.log"
 STEP_RESULTS_FILE="${BACKUP_DIR}/status/step-results.tsv"
 
-for binary in bash docker git tar awk jq; do
+for binary in bash docker git tar awk jq find xargs sha256sum; do
   if ! command -v "${binary}" >/dev/null 2>&1; then
     log "missing required binary: ${binary}"
     exit "${EXIT_PRECHECK}"
@@ -175,6 +193,8 @@ fi
 mkdir -p \
   "${BACKUP_DIR}/commands" \
   "${BACKUP_DIR}/db" \
+  "${BACKUP_DIR}/fnn" \
+  "${BACKUP_DIR}/fnn2" \
   "${BACKUP_DIR}/runtime" \
   "${BACKUP_DIR}/snapshots" \
   "${BACKUP_DIR}/metadata" \
@@ -210,6 +230,16 @@ run_capture_step "worker-inspect" \
   "docker inspect fiber-link-worker" \
   "{}"
 
+run_capture_step "fnn-inspect" \
+  "${BACKUP_DIR}/runtime/fnn-container-inspect.json" \
+  "docker inspect fiber-link-fnn" \
+  "{}"
+
+run_capture_step "fnn2-inspect" \
+  "${BACKUP_DIR}/runtime/fnn2-container-inspect.json" \
+  "docker inspect fiber-link-fnn2" \
+  "{}"
+
 run_capture_step "postgres-dump" \
   "${BACKUP_DIR}/db/postgres.sql" \
   "docker exec fiber-link-postgres pg_dump --clean --if-exists --create --format=plain --no-owner --no-privileges -U \"${POSTGRES_USER}\" -d \"${POSTGRES_DB}\"" \
@@ -219,6 +249,23 @@ run_capture_step "worker-cursor" \
   "${BACKUP_DIR}/runtime/worker-settlement-cursor.json" \
   "docker exec fiber-link-worker sh -lc 'if [ -f \"${WORKER_CURSOR_FILE}\" ]; then cat \"${WORKER_CURSOR_FILE}\"; else printf \"UNSET\\n\"; fi'" \
   "UNSET"
+
+if [[ "${INCLUDE_FNN_STATE}" -eq 1 ]]; then
+  run_capture_step "fnn-state" \
+    "${BACKUP_DIR}/fnn/data.tar.gz" \
+    "docker run --rm --volumes-from fiber-link-fnn -v \"${BACKUP_DIR}/fnn:/backup\" \"${BACKUP_HELPER_IMAGE}\" sh -lc 'cd /data && tar -czf /backup/data.tar.gz .'" \
+    "DRY_RUN fnn /data volume tarball placeholder"
+
+  run_capture_step "fnn2-state" \
+    "${BACKUP_DIR}/fnn2/data.tar.gz" \
+    "docker run --rm --volumes-from fiber-link-fnn2 -v \"${BACKUP_DIR}/fnn2:/backup\" \"${BACKUP_HELPER_IMAGE}\" sh -lc 'cd /data && tar -czf /backup/data.tar.gz .'" \
+    "DRY_RUN fnn2 /data volume tarball placeholder"
+else
+  printf '%s\n' "FNN state capture disabled. Re-run with --include-fnn-state to include /data volume tarballs." > "${BACKUP_DIR}/fnn/README.txt"
+  printf '%s\n' "FNN2 state capture disabled. Re-run with --include-fnn-state to include /data volume tarballs." > "${BACKUP_DIR}/fnn2/README.txt"
+  write_step_result "fnn-state" "SKIPPED" "${BACKUP_DIR}/fnn/README.txt" "--include-fnn-state not set"
+  write_step_result "fnn2-state" "SKIPPED" "${BACKUP_DIR}/fnn2/README.txt" "--include-fnn-state not set"
+fi
 
 overall_status="$(bool_status "${OVERALL_FAILURE}")"
 
@@ -237,27 +284,43 @@ jq -n \
   --arg postgresUser "${POSTGRES_USER}" \
   --arg postgresDb "${POSTGRES_DB}" \
   --arg workerCursorFile "${WORKER_CURSOR_FILE}" \
+  --arg backupHelperImage "${BACKUP_HELPER_IMAGE}" \
   --argjson retentionDays "${RETENTION_DAYS}" \
   --argjson dryRun "$([[ "${DRY_RUN}" -eq 1 ]] && printf 'true' || printf 'false')" \
+  --argjson includeFnnState "$([[ "${INCLUDE_FNN_STATE}" -eq 1 ]] && printf 'true' || printf 'false')" \
   '{
+    schemaVersion: 1,
     generatedAtUtc: $generatedAtUtc,
     retentionDays: $retentionDays,
     dryRun: $dryRun,
+    includeFnnState: $includeFnnState,
     overallStatus: $overallStatus,
     postgresUser: $postgresUser,
     postgresDb: $postgresDb,
     workerCursorFile: $workerCursorFile,
+    backupHelperImage: $backupHelperImage,
     files: {
       commandLog: "commands/command-index.log",
       stepResults: "status/step-results.tsv",
+      checksums: "metadata/checksums.sha256",
       postgresDump: "db/postgres.sql",
       workerCursor: "runtime/worker-settlement-cursor.json",
       composeConfig: "snapshots/compose-config.txt",
       composePs: "snapshots/compose-ps.txt",
       postgresInspect: "runtime/postgres-container-inspect.json",
-      workerInspect: "runtime/worker-container-inspect.json"
+      workerInspect: "runtime/worker-container-inspect.json",
+      fnnInspect: "runtime/fnn-container-inspect.json",
+      fnn2Inspect: "runtime/fnn2-container-inspect.json",
+      fnnState: "fnn/data.tar.gz",
+      fnn2State: "fnn2/data.tar.gz"
     }
   }' > "${BACKUP_DIR}/metadata/manifest.json"
+
+if ! write_checksums; then
+  printf 'RESULT=FAIL CODE=%s MESSAGE=%s BACKUP_DIR=%s BACKUP_ARCHIVE=%s\n' \
+    "${EXIT_INTEGRITY_FAILURE}" "checksum generation failed" "${BACKUP_DIR}" "${ARCHIVE_FILE}"
+  exit "${EXIT_INTEGRITY_FAILURE}"
+fi
 
 set +e
 tar -czf "${ARCHIVE_FILE}" -C "$(dirname "${BACKUP_DIR}")" "$(basename "${BACKUP_DIR}")"

--- a/scripts/capture-compose-backup.sh
+++ b/scripts/capture-compose-backup.sh
@@ -98,6 +98,41 @@ run_capture_step() {
   return 0
 }
 
+run_file_capture_step() {
+  local name="$1"
+  local output_file="$2"
+  local log_file="$3"
+  local command="$4"
+  local dry_run_content="$5"
+
+  mkdir -p "$(dirname "${output_file}")" "$(dirname "${log_file}")"
+  printf '[%s] %s\n' "${name}" "${command}" >> "${COMMAND_LOG}"
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf '%s\n' "${dry_run_content}" > "${output_file}"
+    printf 'DRY_RUN: command output captured separately from %s\n' "${output_file}" > "${log_file}"
+    write_step_result "${name}" "DRY_RUN" "${output_file}" "${command}"
+    return 0
+  fi
+
+  set +e
+  bash -c "${command}" > "${log_file}" 2>&1
+  local rc=$?
+  set -e
+
+  if [[ "${rc}" -eq 0 && -s "${output_file}" ]]; then
+    write_step_result "${name}" "PASS" "${output_file}" "${command}"
+    return 0
+  fi
+
+  if [[ "${rc}" -eq 0 ]]; then
+    printf 'capture command succeeded but did not create non-empty output file: %s\n' "${output_file}" >> "${log_file}"
+  fi
+  write_step_result "${name}" "FAIL:${rc}" "${output_file}" "${command}"
+  OVERALL_FAILURE=1
+  return 0
+}
+
 bool_status() {
   if [[ "$1" -eq 0 ]]; then
     printf 'PASS'
@@ -173,7 +208,7 @@ ARCHIVE_FILE="${BACKUP_DIR}.tar.gz"
 COMMAND_LOG="${BACKUP_DIR}/commands/command-index.log"
 STEP_RESULTS_FILE="${BACKUP_DIR}/status/step-results.tsv"
 
-for binary in bash docker git tar awk jq find xargs sha256sum; do
+for binary in awk bash docker find git jq sha256sum sort tar xargs; do
   if ! command -v "${binary}" >/dev/null 2>&1; then
     log "missing required binary: ${binary}"
     exit "${EXIT_PRECHECK}"
@@ -251,13 +286,15 @@ run_capture_step "worker-cursor" \
   "UNSET"
 
 if [[ "${INCLUDE_FNN_STATE}" -eq 1 ]]; then
-  run_capture_step "fnn-state" \
+  run_file_capture_step "fnn-state" \
     "${BACKUP_DIR}/fnn/data.tar.gz" \
+    "${BACKUP_DIR}/fnn/data.tar.gz.log" \
     "docker run --rm --volumes-from fiber-link-fnn -v \"${BACKUP_DIR}/fnn:/backup\" \"${BACKUP_HELPER_IMAGE}\" sh -lc 'cd /data && tar -czf /backup/data.tar.gz .'" \
     "DRY_RUN fnn /data volume tarball placeholder"
 
-  run_capture_step "fnn2-state" \
+  run_file_capture_step "fnn2-state" \
     "${BACKUP_DIR}/fnn2/data.tar.gz" \
+    "${BACKUP_DIR}/fnn2/data.tar.gz.log" \
     "docker run --rm --volumes-from fiber-link-fnn2 -v \"${BACKUP_DIR}/fnn2:/backup\" \"${BACKUP_HELPER_IMAGE}\" sh -lc 'cd /data && tar -czf /backup/data.tar.gz .'" \
     "DRY_RUN fnn2 /data volume tarball placeholder"
 else

--- a/scripts/restore-compose-backup.sh
+++ b/scripts/restore-compose-backup.sh
@@ -24,6 +24,7 @@ OVERALL_FAILURE=0
 POSTGRES_USER_DEFAULT="fiber"
 POSTGRES_DB_DEFAULT="fiber_link"
 WORKER_CURSOR_FILE_DEFAULT="/var/lib/fiber-link/settlement-cursor.json"
+BACKUP_HELPER_IMAGE_DEFAULT="public.ecr.aws/docker/library/alpine:3.20"
 
 usage() {
   printf '%s\n' \
@@ -97,6 +98,55 @@ run_restore_step() {
   return 0
 }
 
+validate_backup_integrity() {
+  local manifest="${BACKUP_DIR}/metadata/manifest.json"
+  local checksums="${BACKUP_DIR}/metadata/checksums.sha256"
+  local step_results="${BACKUP_DIR}/status/step-results.tsv"
+  local include_fnn_state
+
+  for required in \
+    "${BACKUP_DIR}/db/postgres.sql" \
+    "${BACKUP_DIR}/runtime/worker-settlement-cursor.json" \
+    "${manifest}" \
+    "${checksums}" \
+    "${step_results}"; do
+    if [[ ! -f "${required}" ]]; then
+      log "backup bundle missing required file: ${required}"
+      exit "${EXIT_PRECHECK}"
+    fi
+  done
+
+  if ! jq -e '.schemaVersion == 1 and (.overallStatus == "PASS" or .overallStatus == "DRY_RUN") and (.files.postgresDump | type == "string") and (.files.workerCursor | type == "string") and (.files.checksums == "metadata/checksums.sha256")' "${manifest}" >/dev/null; then
+    log "backup manifest schema/status validation failed: ${manifest}"
+    exit "${EXIT_PRECHECK}"
+  fi
+
+  if [[ "${DRY_RUN}" -eq 0 && "$(jq -r '.dryRun // false' "${manifest}")" == "true" ]]; then
+    log "refusing live restore from a dry-run backup bundle"
+    exit "${EXIT_PRECHECK}"
+  fi
+
+  if ! awk -F '\t' 'NR > 1 && $2 ~ /^FAIL/ { bad=1 } END { exit bad }' "${step_results}"; then
+    log "backup status includes failed capture steps: ${step_results}"
+    exit "${EXIT_PRECHECK}"
+  fi
+
+  include_fnn_state="$(jq -r '.includeFnnState // false' "${manifest}")"
+  if [[ "${include_fnn_state}" == "true" ]]; then
+    for required in "${BACKUP_DIR}/fnn/data.tar.gz" "${BACKUP_DIR}/fnn2/data.tar.gz"; do
+      if [[ ! -f "${required}" ]]; then
+        log "backup manifest requires FNN state but file is missing: ${required}"
+        exit "${EXIT_PRECHECK}"
+      fi
+    done
+  fi
+
+  if ! (cd "${BACKUP_DIR}" && sha256sum -c "metadata/checksums.sha256" >/dev/null); then
+    log "backup checksum validation failed: ${checksums}"
+    exit "${EXIT_PRECHECK}"
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --backup)
@@ -141,8 +191,9 @@ fi
 POSTGRES_USER="${POSTGRES_USER:-${POSTGRES_USER_DEFAULT}}"
 POSTGRES_DB="${POSTGRES_DB:-${POSTGRES_DB_DEFAULT}}"
 WORKER_CURSOR_FILE="${WORKER_SETTLEMENT_CURSOR_FILE:-${WORKER_CURSOR_FILE_DEFAULT}}"
+BACKUP_HELPER_IMAGE="${BACKUP_HELPER_IMAGE:-${BACKUP_HELPER_IMAGE_DEFAULT}}"
 
-for binary in bash docker tar awk jq mktemp; do
+for binary in bash docker tar awk jq mktemp find head sha256sum; do
   if ! command -v "${binary}" >/dev/null 2>&1; then
     log "missing required binary: ${binary}"
     exit "${EXIT_PRECHECK}"
@@ -175,15 +226,7 @@ else
   exit "${EXIT_PRECHECK}"
 fi
 
-for required in \
-  "${BACKUP_DIR}/db/postgres.sql" \
-  "${BACKUP_DIR}/runtime/worker-settlement-cursor.json" \
-  "${BACKUP_DIR}/metadata/manifest.json"; do
-  if [[ ! -f "${required}" ]]; then
-    log "backup bundle missing required file: ${required}"
-    exit "${EXIT_PRECHECK}"
-  fi
-done
+validate_backup_integrity
 
 RESTORE_DIR="${BACKUP_DIR}/restore"
 COMMAND_LOG="${RESTORE_DIR}/command-index.log"
@@ -213,6 +256,17 @@ if [[ "$(cat "${BACKUP_DIR}/runtime/worker-settlement-cursor.json")" == "UNSET" 
 else
   run_restore_step "worker-cursor-restore" \
     "docker cp \"${BACKUP_DIR}/runtime/worker-settlement-cursor.json\" \"fiber-link-worker:${WORKER_CURSOR_FILE}\""
+fi
+
+if [[ "$(jq -r '.includeFnnState // false' "${BACKUP_DIR}/metadata/manifest.json")" == "true" ]]; then
+  run_restore_step "compose-stop-fnn" \
+    "cd \"${ROOT_DIR}\" && docker compose -f \"${COMPOSE_FILE}\" stop fnn fnn2 || true"
+  run_restore_step "fnn-state-restore" \
+    "docker run --rm --volumes-from fiber-link-fnn -v \"${BACKUP_DIR}/fnn:/backup:ro\" \"${BACKUP_HELPER_IMAGE}\" sh -lc 'cd /data && tar -xzf /backup/data.tar.gz'"
+  run_restore_step "fnn2-state-restore" \
+    "docker run --rm --volumes-from fiber-link-fnn2 -v \"${BACKUP_DIR}/fnn2:/backup:ro\" \"${BACKUP_HELPER_IMAGE}\" sh -lc 'cd /data && tar -xzf /backup/data.tar.gz'"
+  run_restore_step "compose-up-fnn" \
+    "cd \"${ROOT_DIR}\" && docker compose -f \"${COMPOSE_FILE}\" up -d fnn fnn2"
 fi
 
 run_restore_step "compose-up-apps" \


### PR DESCRIPTION
Summary
- add manifest schema/checksum generation to compose backup bundles and validate them before restore
- capture FNN/FNN2 inspect metadata and add opt-in FNN/FNN2 /data volume backup/restore with --include-fnn-state
- update backup recovery runbook and shell tests for integrity, dry-run rejection, and FNN state coverage

Test Plan
- bash -n scripts/capture-compose-backup.sh scripts/restore-compose-backup.sh deploy/compose/compose-backup.test.sh
- deploy/compose/compose-backup.test.sh
- git diff --check

Closes #393