### PR TITLE
fix(compose): validate env and gate fnn2 readiness

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -1,6 +1,8 @@
 # Required runtime values (set these before first bootstrap).
-# POSTGRES_PASSWORD and FIBER_LINK_HMAC_SECRET must not stay default-like in shared envs.
-# FNN_ASSET_SHA256 must match the selected FNN release asset digest exactly.
+# POSTGRES_PASSWORD, FIBER_SECRET_KEY_PASSWORD, and FIBER_LINK_HMAC_SECRET
+# must not stay default-like in shared envs; deploy/compose/validate-env.sh
+# rejects placeholders before containers start.
+# FNN_ASSET_SHA256 must be a 64-character sha256 digest matching the selected FNN release asset exactly.
 POSTGRES_DB=fiber_link
 POSTGRES_USER=fiber
 POSTGRES_PASSWORD=change-me-before-prod

--- a/deploy/compose/compose-readiness.sh
+++ b/deploy/compose/compose-readiness.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="${ROOT_DIR}/deploy/compose/docker-compose.yml"
 ENV_FILE="${ROOT_DIR}/deploy/compose/.env"
 TEST_SCRIPT="${ROOT_DIR}/deploy/compose/compose-reference.test.sh"
+VALIDATE_ENV_SCRIPT="${ROOT_DIR}/deploy/compose/validate-env.sh"
 EVIDENCE_ROOT="${ROOT_DIR}/deploy/compose/evidence"
 TIMESTAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
 EVIDENCE_DIR="${EVIDENCE_ROOT}/${TIMESTAMP}"
@@ -56,6 +57,17 @@ done
 
 mkdir -p "$EVIDENCE_DIR"
 
+echo "Evidence directory: ${EVIDENCE_DIR}"
+
+validate_env_cmd="\"$VALIDATE_ENV_SCRIPT\" \"$ENV_FILE\""
+echo "[compose-readiness] env-validation: ${validate_env_cmd}" >> "${EVIDENCE_DIR}/commands.log"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[DRY-RUN] ${validate_env_cmd}" | tee -a "${EVIDENCE_DIR}/env-validation.log"
+elif ! "$VALIDATE_ENV_SCRIPT" "$ENV_FILE" >>"${EVIDENCE_DIR}/env-validation.log" 2>&1; then
+  echo "compose env validation failed; aborting before reading env or starting containers" >&2
+  exit 1
+fi
+
 if [[ -f "$ENV_FILE" ]]; then
   set -a
   source "$ENV_FILE"
@@ -64,11 +76,16 @@ fi
 
 RPC_PORT="${RPC_PORT:-3000}"
 RPC_URL="http://127.0.0.1:${RPC_PORT}"
+FIBER_CHANNEL_ACCEPT_RPC_URL="${FIBER_CHANNEL_ACCEPT_RPC_URL:-http://fnn2:8227}"
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-fiber-link-readiness-$(date -u +"%Y%m%d%H%M%S")-$$}"
 COMPOSE_DOWN_ARGS="--remove-orphans"
 if [[ "${DESTROY_VOLUMES}" == "1" ]]; then
   COMPOSE_DOWN_ARGS="${COMPOSE_DOWN_ARGS} --volumes"
 fi
+
+shell_quote() {
+  printf '%q' "$1"
+}
 
 echo "Evidence directory: ${EVIDENCE_DIR}"
 echo "Compose project: ${COMPOSE_PROJECT_NAME}"
@@ -85,6 +102,8 @@ declare -A CHECK_STATUS=(
   [precheck]="not_run"
   [spinup]="not_run"
   [fnn]="not_run"
+  [fnn2]="not_run"
+  [fnn2_rpc]="not_run"
   [rpc]="not_run"
   [worker]="not_run"
   [smoke]="not_run"
@@ -143,6 +162,14 @@ wait_for_health() {
   return 1
 }
 
+probe_fnn2_channel_accept_rpc() {
+  local probe_payload='{"jsonrpc":"2.0","id":"compose-readiness-fnn2","method":"node_info","params":[]}'
+  local cmd quoted_accept_url
+  quoted_accept_url="$(shell_quote "${FIBER_CHANNEL_ACCEPT_RPC_URL}")"
+  cmd="docker compose -f \"$COMPOSE_FILE\" exec -T -e FIBER_CHANNEL_ACCEPT_RPC_URL=${quoted_accept_url} rpc sh -lc 'curl -fsS \"\$FIBER_CHANNEL_ACCEPT_RPC_URL\" -H '\''content-type: application/json'\'' --data '\''${probe_payload}'\''' > \"${EVIDENCE_DIR}/fnn2-node-info.json\" && grep -q '\"result\"' \"${EVIDENCE_DIR}/fnn2-node-info.json\""
+  run_step "fnn2-channel-accept-rpc" "${EVIDENCE_DIR}/fnn2-channel-accept-rpc.log" "$cmd"
+}
+
 precheck_cmd="[ -f \"$TEST_SCRIPT\" ] && \"$TEST_SCRIPT\""
 if run_step "precheck" "${EVIDENCE_DIR}/precheck.log" "$precheck_cmd"; then
   CHECK_STATUS[precheck]="pass"
@@ -165,10 +192,24 @@ if [[ "${CHECK_STATUS[spinup]}" == "pass" ]]; then
     CHECK_STATUS[fnn]="fail"
   fi
 
+  if wait_for_health fnn2 "$WAIT_SECONDS"; then
+    CHECK_STATUS[fnn2]="pass"
+  else
+    CHECK_STATUS[fnn2]="fail"
+  fi
+
   if wait_for_health rpc "$WAIT_SECONDS"; then
     CHECK_STATUS[rpc]="pass"
   else
     CHECK_STATUS[rpc]="fail"
+  fi
+
+  if [[ "${CHECK_STATUS[fnn2]}" == "pass" && "${CHECK_STATUS[rpc]}" == "pass" ]]; then
+    if probe_fnn2_channel_accept_rpc; then
+      CHECK_STATUS[fnn2_rpc]="pass"
+    else
+      CHECK_STATUS[fnn2_rpc]="fail"
+    fi
   fi
 
   if wait_for_health worker "$WAIT_SECONDS"; then
@@ -178,7 +219,7 @@ if [[ "${CHECK_STATUS[spinup]}" == "pass" ]]; then
   fi
 fi
 
-if [[ "${CHECK_STATUS[fnn]}" == "pass" && "${CHECK_STATUS[rpc]}" == "pass" && "${CHECK_STATUS[worker]}" == "pass" ]]; then
+if [[ "${CHECK_STATUS[fnn]}" == "pass" && "${CHECK_STATUS[fnn2]}" == "pass" && "${CHECK_STATUS[fnn2_rpc]}" == "pass" && "${CHECK_STATUS[rpc]}" == "pass" && "${CHECK_STATUS[worker]}" == "pass" ]]; then
   run_step "compose-ps-ready" "${EVIDENCE_DIR}/compose-ready-ps.log" "docker compose -f \"$COMPOSE_FILE\" ps"
 fi
 
@@ -214,7 +255,7 @@ else
   CHECK_STATUS[smoke]="skipped"
 fi
 
-run_step "compose-logs" "${EVIDENCE_DIR}/compose-logs.log" "docker compose -f \"$COMPOSE_FILE\" logs --no-color --timestamps rpc worker fnn postgres redis"
+run_step "compose-logs" "${EVIDENCE_DIR}/compose-logs.log" "docker compose -f \"$COMPOSE_FILE\" logs --no-color --timestamps rpc worker fnn fnn2 postgres redis"
 
 if [[ "${CHECK_STATUS[spinup]}" == "pass" ]]; then
   if run_step "compose-down" "${EVIDENCE_DIR}/compose-down.log" "cd \"$ROOT_DIR\" && docker compose -f \"$COMPOSE_FILE\" down ${COMPOSE_DOWN_ARGS}"; then
@@ -228,6 +269,8 @@ summary_file="${EVIDENCE_DIR}/summary.json"
 if [[ "${CHECK_STATUS[precheck]}" == "pass" && \
   "${CHECK_STATUS[spinup]}" == "pass" && \
   "${CHECK_STATUS[fnn]}" == "pass" && \
+  "${CHECK_STATUS[fnn2]}" == "pass" && \
+  "${CHECK_STATUS[fnn2_rpc]}" == "pass" && \
   "${CHECK_STATUS[rpc]}" == "pass" && \
   "${CHECK_STATUS[worker]}" == "pass" && \
   ( "${CHECK_STATUS[smoke]}" == "pass" || "${CHECK_STATUS[smoke]}" == "skipped" ) ]]; then
@@ -249,6 +292,8 @@ cat > "$summary_file" <<EOF
     "precheck": "${CHECK_STATUS[precheck]}",
     "spinup": "${CHECK_STATUS[spinup]}",
     "fnn": "${CHECK_STATUS[fnn]}",
+    "fnn2": "${CHECK_STATUS[fnn2]}",
+    "fnn2Rpc": "${CHECK_STATUS[fnn2_rpc]}",
     "rpc": "${CHECK_STATUS[rpc]}",
     "worker": "${CHECK_STATUS[worker]}",
     "smoke": "${CHECK_STATUS[smoke]}",

--- a/deploy/compose/compose-readiness.sh
+++ b/deploy/compose/compose-readiness.sh
@@ -98,6 +98,10 @@ Env file: ${ENV_FILE}
 EOF
 fi
 
+shell_quote() {
+  printf '%q' "$1"
+}
+
 declare -A CHECK_STATUS=(
   [precheck]="not_run"
   [spinup]="not_run"

--- a/deploy/compose/compose-reference.test.sh
+++ b/deploy/compose/compose-reference.test.sh
@@ -11,6 +11,8 @@ EVIDENCE_TEMPLATE_DIR="${ROOT_DIR}/docs/runbooks/evidence-template/deployment"
 EVIDENCE_SCRIPT="${ROOT_DIR}/scripts/capture-deployment-evidence.sh"
 BACKUP_TEST_SCRIPT="${ROOT_DIR}/deploy/compose/compose-backup.test.sh"
 OPS_TEST_SCRIPT="${ROOT_DIR}/deploy/compose/compose-ops.test.sh"
+VALIDATE_ENV_SCRIPT="${ROOT_DIR}/deploy/compose/validate-env.sh"
+VALIDATE_ENV_TEST_SCRIPT="${ROOT_DIR}/deploy/compose/validate-env.test.sh"
 ENV_FILE="${ROOT_DIR}/deploy/compose/.env.example"
 SERVICE_DOCKERFILE="${ROOT_DIR}/deploy/compose/service.Dockerfile"
 RPC_HEALTHCHECK_SCRIPT="${ROOT_DIR}/fiber-link-service/apps/rpc/src/scripts/healthcheck-ready.ts"
@@ -28,6 +30,8 @@ for required in \
   "${EVIDENCE_SCRIPT}" \
   "${BACKUP_TEST_SCRIPT}" \
   "${OPS_TEST_SCRIPT}" \
+  "${VALIDATE_ENV_SCRIPT}" \
+  "${VALIDATE_ENV_TEST_SCRIPT}" \
   "${ENV_FILE}" \
   "${SERVICE_DOCKERFILE}" \
   "${RPC_HEALTHCHECK_SCRIPT}" \
@@ -67,6 +71,16 @@ if [[ ! -x "${OPS_TEST_SCRIPT}" ]]; then
   exit 1
 fi
 
+if [[ ! -x "${VALIDATE_ENV_SCRIPT}" ]]; then
+  echo "compose env validator is not executable: ${VALIDATE_ENV_SCRIPT}" >&2
+  exit 1
+fi
+
+if [[ ! -x "${VALIDATE_ENV_TEST_SCRIPT}" ]]; then
+  echo "compose env validator test script is not executable: ${VALIDATE_ENV_TEST_SCRIPT}" >&2
+  exit 1
+fi
+
 for compose_file in "${ENV_FILE}" "${COMPOSE_FILE}"; do
   if grep -nE "^(<<<<<<<|=======|>>>>>>> )" "${compose_file}" >/dev/null; then
     echo "merge-conflict marker found in ${compose_file}" >&2
@@ -86,8 +100,9 @@ fi
 
 "${BACKUP_TEST_SCRIPT}"
 "${OPS_TEST_SCRIPT}"
+"${VALIDATE_ENV_TEST_SCRIPT}"
 
-for service in rpc worker postgres redis fnn; do
+for service in rpc worker postgres redis fnn fnn2; do
   if ! grep -Eq "^[[:space:]]{2}${service}:" "${COMPOSE_FILE}"; then
     echo "docker compose missing service: ${service}" >&2
     exit 1
@@ -183,6 +198,41 @@ fi
 
 if ! grep -q "FIBER_LINK_RATE_LIMIT_REDIS_URL: \${FIBER_LINK_RATE_LIMIT_REDIS_URL:-redis://redis:6379/1}" "${COMPOSE_FILE}"; then
   echo "docker-compose missing shared Redis rate-limit configuration" >&2
+  exit 1
+fi
+
+if ! grep -q "FNN_ASSET_SHA256" "${VALIDATE_ENV_SCRIPT}" || ! grep -q "64-character" "${VALIDATE_ENV_SCRIPT}"; then
+  echo "compose env validator missing sha256 validation" >&2
+  exit 1
+fi
+
+if ! grep -q "FIBER_CHANNEL_ACCEPT_RPC_URL" "${VALIDATE_ENV_SCRIPT}"; then
+  echo "compose env validator missing channel-accept URL validation" >&2
+  exit 1
+fi
+
+if ! grep -q "validate-env.sh" "$0"; then
+  echo "compose reference checks missing env validator coverage" >&2
+  exit 1
+fi
+
+if ! grep -q "validate-env.sh" "${ROOT_DIR}/scripts/testnet-smoke.sh"; then
+  echo "testnet smoke missing compose env validator precheck" >&2
+  exit 1
+fi
+
+if ! grep -q "validate-env.sh" "${ROOT_DIR}/deploy/compose/compose-readiness.sh"; then
+  echo "compose readiness missing compose env validator precheck" >&2
+  exit 1
+fi
+
+if ! grep -A15 '^  worker:' "${COMPOSE_FILE}" | grep -q '^      fnn2:$'; then
+  echo "docker-compose worker missing fnn2 dependency gate" >&2
+  exit 1
+fi
+
+if ! grep -A10 '^  worker:' "${COMPOSE_FILE}" | grep -q "condition: service_healthy"; then
+  echo "docker-compose worker fnn2 dependency must use service_healthy" >&2
   exit 1
 fi
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     volumes:
       - fnn-data:/data
     healthcheck:
-      test: ["CMD-SHELL", "FNN_HOST_IP=$$(hostname -i | awk '{print $$1}'); curl -sS --max-time 3 \"http://$${FNN_HOST_IP}:8227\" >/dev/null"]
+      test: ["CMD-SHELL", "FNN_HOST_IP=$$(hostname -i | awk '{print $$1}'); curl -fsS --max-time 3 \"http://$${FNN_HOST_IP}:8227\" -H 'content-type: application/json' --data '{\"jsonrpc\":\"2.0\",\"id\":\"health\",\"method\":\"node_info\",\"params\":[]}' | grep -q '\"result\"'"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -74,7 +74,7 @@ services:
     volumes:
       - fnn2-data:/data
     healthcheck:
-      test: ["CMD-SHELL", "FNN_HOST_IP=$$(hostname -i | awk '{print $$1}'); curl -sS --max-time 3 \"http://$${FNN_HOST_IP}:8227\" >/dev/null"]
+      test: ["CMD-SHELL", "FNN_HOST_IP=$$(hostname -i | awk '{print $$1}'); curl -fsS --max-time 3 \"http://$${FNN_HOST_IP}:8227\" -H 'content-type: application/json' --data '{\"jsonrpc\":\"2.0\",\"id\":\"health\",\"method\":\"node_info\",\"params\":[]}' | grep -q '\"result\"'"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -140,6 +140,8 @@ services:
       postgres:
         condition: service_healthy
       rpc:
+        condition: service_healthy
+      fnn2:
         condition: service_healthy
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-fiber}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-fiber_link}

--- a/deploy/compose/validate-env.sh
+++ b/deploy/compose/validate-env.sh
@@ -39,18 +39,50 @@ fi
 get_env_value() {
   local key="$1"
   local line value
-  line="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "${ENV_FILE}" | tail -n1 || true)"
+  line="$({
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+      line="$(strip_unquoted_comment "${line%$'\r'}")"
+      [[ "${line}" =~ ^[[:space:]]*(export[[:space:]]+)?${key}= ]] || continue
+      printf '%s\n' "${line}"
+    done <"${ENV_FILE}"
+  } | tail -n1 || true)"
   if [[ -z "${line}" ]]; then
     printf ''
     return 0
   fi
   value="${line#*=}"
-  value="${value%%#*}"
   value="${value%$'\r'}"
+  value="$(trim_env_whitespace "${value}")"
   value="${value#\"}"
   value="${value%\"}"
   value="${value#\'}"
   value="${value%\'}"
+  printf '%s' "${value}"
+}
+
+strip_unquoted_comment() {
+  local input="$1" output="" char quote="" i
+  for ((i = 0; i < ${#input}; i++)); do
+    char="${input:i:1}"
+    if [[ -z "${quote}" && "${char}" == "#" ]]; then
+      break
+    fi
+    if [[ "${char}" == "'" || "${char}" == '"' ]]; then
+      if [[ -z "${quote}" ]]; then
+        quote="${char}"
+      elif [[ "${quote}" == "${char}" ]]; then
+        quote=""
+      fi
+    fi
+    output+="${char}"
+  done
+  printf '%s' "${output}"
+}
+
+trim_env_whitespace() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
   printf '%s' "${value}"
 }
 

--- a/deploy/compose/validate-env.sh
+++ b/deploy/compose/validate-env.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${COMPOSE_ENV_FILE:-${ROOT_DIR}/deploy/compose/.env}"
+
+usage() {
+  cat <<'EOF'
+Usage: validate-env.sh [ENV_FILE]
+
+Validates deploy/compose runtime environment before starting containers.
+Set COMPOSE_ENV_FILE or pass ENV_FILE to validate a non-default env file.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -gt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ $# -eq 1 ]]; then
+  ENV_FILE="$1"
+fi
+
+fail() {
+  printf 'compose env validation failed: %s\n' "$*" >&2
+  exit 1
+}
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  fail "missing ${ENV_FILE} (copy deploy/compose/.env.example and replace placeholders first)"
+fi
+
+get_env_value() {
+  local key="$1"
+  local line value
+  line="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "${ENV_FILE}" | tail -n1 || true)"
+  if [[ -z "${line}" ]]; then
+    printf ''
+    return 0
+  fi
+  value="${line#*=}"
+  value="${value%%#*}"
+  value="${value%$'\r'}"
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
+  printf '%s' "${value}"
+}
+
+is_placeholder() {
+  local value="${1,,}"
+  [[ -z "${value}" ]] \
+    || [[ "${value}" == *change-me* ]] \
+    || [[ "${value}" == *changeme* ]] \
+    || [[ "${value}" == *replace-with* ]] \
+    || [[ "${value}" == *placeholder* ]] \
+    || [[ "${value}" == *example* ]] \
+    || [[ "${value}" == "todo" ]] \
+    || [[ "${value}" == "secret" ]] \
+    || [[ "${value}" == "password" ]]
+}
+
+require_secret() {
+  local key="$1" min_len="${2:-12}" value
+  value="$(get_env_value "${key}")"
+  [[ -n "${value}" ]] || fail "${key} must be set"
+  ! is_placeholder "${value}" || fail "${key} still uses a placeholder/default-like value"
+  (( ${#value} >= min_len )) || fail "${key} must be at least ${min_len} characters"
+}
+
+require_sha256() {
+  local key="$1" value
+  value="$(get_env_value "${key}")"
+  [[ -n "${value}" ]] || fail "${key} must be set"
+  ! is_placeholder "${value}" || fail "${key} still uses a placeholder value"
+  [[ "${value}" =~ ^[A-Fa-f0-9]{64}$ ]] || fail "${key} must be a 64-character hexadecimal sha256 digest"
+  [[ ! "${value}" =~ ^0{64}$ ]] || fail "${key} must not be the all-zero digest"
+}
+
+validate_url() {
+  local key="$1" required="${2:-required}" value
+  value="$(get_env_value "${key}")"
+  if [[ -z "${value}" ]]; then
+    [[ "${required}" == "optional" ]] && return 0
+    fail "${key} must be set"
+  fi
+  ! is_placeholder "${value}" || fail "${key} still uses a placeholder value"
+  case "${key}" in
+    FIBER_LINK_RATE_LIMIT_REDIS_URL)
+      [[ "${value}" =~ ^rediss?://[^[:space:]]+$ ]] \
+        || fail "${key} must be a redis:// or rediss:// URL"
+      ;;
+    FIBER_SETTLEMENT_SUBSCRIPTION_URL)
+      [[ "${value}" =~ ^(https?|wss?)://[^[:space:]/:]+(:[0-9]{1,5})?(/[^[:space:]]*)?$ ]] \
+        || fail "${key} must be an http(s) or ws(s) URL"
+      ;;
+    *)
+      [[ "${value}" =~ ^https?://[^[:space:]/:]+(:[0-9]{1,5})?(/[^[:space:]]*)?$ ]] \
+        || fail "${key} must be an http(s) URL"
+      ;;
+  esac
+}
+
+validate_port() {
+  local key="$1" default="$2" value
+  value="$(get_env_value "${key}")"
+  value="${value:-${default}}"
+  [[ "${value}" =~ ^[0-9]+$ ]] || fail "${key} must be numeric"
+  (( value >= 1 && value <= 65535 )) || fail "${key} must be between 1 and 65535"
+}
+
+validate_int() {
+  local key="$1" default="$2" min="$3" max="${4:-}" value
+  value="$(get_env_value "${key}")"
+  value="${value:-${default}}"
+  [[ "${value}" =~ ^[0-9]+$ ]] || fail "${key} must be numeric"
+  (( value >= min )) || fail "${key} must be >= ${min}"
+  if [[ -n "${max}" ]]; then
+    (( value <= max )) || fail "${key} must be <= ${max}"
+  fi
+}
+
+require_secret POSTGRES_PASSWORD 12
+require_secret FIBER_SECRET_KEY_PASSWORD 12
+require_secret FIBER_LINK_HMAC_SECRET 32
+require_sha256 FNN_ASSET_SHA256
+
+validate_url FIBER_RPC_URL
+validate_url FIBER_CHANNEL_ACCEPT_RPC_URL
+validate_url FIBER_SETTLEMENT_SUBSCRIPTION_URL optional
+validate_url FIBER_LINK_RATE_LIMIT_REDIS_URL
+
+for key_default in \
+  POSTGRES_PORT:5432 REDIS_PORT:6379 RPC_PORT:3000 \
+  FNN_RPC_PORT:8227 FNN_P2P_PORT:8228 FNN2_RPC_PORT:9227 FNN2_P2P_PORT:9228; do
+  validate_port "${key_default%%:*}" "${key_default##*:}"
+done
+
+for int_default_min in \
+  RPC_HEALTHCHECK_TIMEOUT_MS:3000:1 \
+  BACKUP_RETENTION_DAYS:30:1 \
+  RPC_RATE_LIMIT_WINDOW_MS:60000:1 \
+  RPC_RATE_LIMIT_MAX_REQUESTS:300:1 \
+  FIBER_WITHDRAWAL_POLICY_MAX_PER_REQUEST:5000:1 \
+  FIBER_WITHDRAWAL_POLICY_PER_USER_DAILY_MAX:20000:1 \
+  FIBER_WITHDRAWAL_POLICY_PER_APP_DAILY_MAX:200000:1 \
+  FIBER_WITHDRAWAL_POLICY_COOLDOWN_SECONDS:0:0 \
+  WORKER_WITHDRAWAL_INTERVAL_MS:30000:1 \
+  WORKER_SETTLEMENT_INTERVAL_MS:30000:1 \
+  WORKER_SETTLEMENT_BATCH_SIZE:200:1 \
+  WORKER_MAX_RETRIES:3:0 \
+  WORKER_RETRY_DELAY_MS:60000:0 \
+  WORKER_SETTLEMENT_MAX_RETRIES:3:0 \
+  WORKER_SETTLEMENT_RETRY_DELAY_MS:60000:0 \
+  WORKER_SETTLEMENT_PENDING_TIMEOUT_MS:1800000:1 \
+  WORKER_SHUTDOWN_TIMEOUT_MS:15000:1 \
+  WORKER_READINESS_TIMEOUT_MS:5000:1 \
+  WORKER_OPS_MAX_UNPAID_BACKLOG:25:0 \
+  WORKER_OPS_MAX_OLDEST_UNPAID_AGE_MS:900000:0 \
+  WORKER_OPS_MAX_RETRY_PENDING:3:0 \
+  WORKER_OPS_MAX_RECENT_FAILED_SETTLEMENTS:0:0 \
+  WORKER_OPS_RECENT_FAILURE_LOOKBACK_HOURS:24:1 \
+  WORKER_OPS_MAX_WITHDRAWAL_PARITY_ISSUES:0:0 \
+  WORKER_OPS_WITHDRAWAL_LOOKBACK_HOURS:24:1 \
+  WORKER_OPS_WITHDRAWAL_SAMPLE_LIMIT:500:1 \
+  FIBER_CHANNEL_ROTATION_BOOTSTRAP_RESERVE:61:0 \
+  FIBER_CHANNEL_ROTATION_MIN_RECOVERABLE_AMOUNT:61:0 \
+  FIBER_CHANNEL_ROTATION_MAX_CONCURRENT:1:1; do
+  IFS=: read -r key default min <<<"${int_default_min}"
+  validate_int "${key}" "${default}" "${min}"
+done
+
+printf 'compose env validation passed: %s\n' "${ENV_FILE}"

--- a/deploy/compose/validate-env.test.sh
+++ b/deploy/compose/validate-env.test.sh
@@ -36,6 +36,14 @@ set_env FNN_ASSET_SHA256 '0123456789abcdef0123456789abcdef0123456789abcdef012345
 
 "${VALIDATOR}" "${VALID_ENV}" >/dev/null
 
+COMMENT_ENV="${TMP_DIR}/comment.env"
+cp "${VALID_ENV}" "${COMMENT_ENV}"
+{
+  printf '# POSTGRES_PASSWORD=change-me-commented-out\n'
+  printf 'export FIBER_LINK_HMAC_SECRET="0123456789abcdef#0123456789abcdef" # preserves quoted hash\n'
+} >>"${COMMENT_ENV}"
+"${VALIDATOR}" "${COMMENT_ENV}" >/dev/null
+
 expect_fail() {
   local label="$1" key="$2" value="$3"
   local env_file="${TMP_DIR}/${label}.env"

--- a/deploy/compose/validate-env.test.sh
+++ b/deploy/compose/validate-env.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATOR="${ROOT_DIR}/deploy/compose/validate-env.sh"
+ENV_EXAMPLE="${ROOT_DIR}/deploy/compose/.env.example"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+VALID_ENV="${TMP_DIR}/valid.env"
+cp "${ENV_EXAMPLE}" "${VALID_ENV}"
+
+set_env() {
+  local key="$1" value="$2" file="${3:-${VALID_ENV}}"
+  python3 - "$file" "$key" "$value" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+lines = path.read_text().splitlines()
+for idx, line in enumerate(lines):
+    if line.startswith(f"{key}="):
+        lines[idx] = f"{key}={value}"
+        break
+else:
+    lines.append(f"{key}={value}")
+path.write_text("\n".join(lines) + "\n")
+PY
+}
+
+set_env POSTGRES_PASSWORD 'strong-postgres-password'
+set_env FIBER_SECRET_KEY_PASSWORD 'strong-fnn-password'
+set_env FIBER_LINK_HMAC_SECRET '0123456789abcdef0123456789abcdef'
+set_env FNN_ASSET_SHA256 '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+"${VALIDATOR}" "${VALID_ENV}" >/dev/null
+
+expect_fail() {
+  local label="$1" key="$2" value="$3"
+  local env_file="${TMP_DIR}/${label}.env"
+  cp "${VALID_ENV}" "${env_file}"
+  set_env "${key}" "${value}" "${env_file}"
+  if "${VALIDATOR}" "${env_file}" >"${TMP_DIR}/${label}.out" 2>&1; then
+    echo "expected validation failure for ${label}" >&2
+    exit 1
+  fi
+}
+
+expect_fail placeholder-secret POSTGRES_PASSWORD 'change-me-before-prod'
+expect_fail short-hmac FIBER_LINK_HMAC_SECRET 'too-short'
+expect_fail placeholder-sha FNN_ASSET_SHA256 'replace-with-release-sha256'
+expect_fail malformed-sha FNN_ASSET_SHA256 'not-a-sha'
+expect_fail malformed-url FIBER_CHANNEL_ACCEPT_RPC_URL 'fnn2:8227'
+expect_fail bad-port FNN2_RPC_PORT '70000'
+expect_fail bad-number WORKER_SETTLEMENT_BATCH_SIZE '0'
+
+echo "compose env validation checks passed"

--- a/scripts/testnet-smoke.sh
+++ b/scripts/testnet-smoke.sh
@@ -18,6 +18,7 @@ DESTROY_VOLUMES="${FIBER_LINK_DESTROY_VOLUMES:-0}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_DIR="${ROOT_DIR}/deploy/compose"
 ENV_FILE="${COMPOSE_DIR}/.env"
+VALIDATE_ENV_SCRIPT="${COMPOSE_DIR}/validate-env.sh"
 ARTIFACT_DIR="${ROOT_DIR}/.tmp/testnet-smoke/$(date +%Y%m%d-%H%M%S)"
 
 usage() {
@@ -162,6 +163,14 @@ Env file: ${ENV_FILE}
 EOF
 fi
 
+if [[ ! -x "${VALIDATE_ENV_SCRIPT}" ]]; then
+  exit_with "${EXIT_PRECHECK}" "missing executable compose env validator: ${VALIDATE_ENV_SCRIPT}"
+fi
+
+if ! "${VALIDATE_ENV_SCRIPT}" "${ENV_FILE}" > "${ARTIFACT_DIR}/env-validation.log" 2>&1; then
+  exit_with "${EXIT_PRECHECK}" "compose env validation failed (see ${ARTIFACT_DIR}/env-validation.log)"
+fi
+
 required_keys=(
   POSTGRES_PASSWORD
   FIBER_SECRET_KEY_PASSWORD
@@ -185,7 +194,7 @@ if [[ "${DRY_RUN}" -eq 1 ]]; then
   log "compose project: ${COMPOSE_PROJECT_NAME}"
   log "would run: docker compose $(compose_down_reset_args)"
   log "would run: docker compose up -d --build"
-  log "would wait for postgres/redis health and rpc/worker/fnn running"
+  log "would wait for postgres/redis/fnn/fnn2 health and rpc/worker readiness gates"
   log "would run signed health.ping against http://127.0.0.1:${RPC_PORT}/rpc"
   if [[ "${SKIP_SMOKE}" -eq 0 ]]; then
     log "would run signed tip.create smoke request"
@@ -214,7 +223,7 @@ is_running() {
 }
 
 deadline=$(( $(date +%s) + 600 ))
-until is_healthy fiber-link-postgres && is_healthy fiber-link-redis && is_running fiber-link-rpc && is_running fiber-link-worker && is_running fiber-link-fnn; do
+until is_healthy fiber-link-postgres && is_healthy fiber-link-redis && is_healthy fiber-link-fnn && is_healthy fiber-link-fnn2 && is_running fiber-link-rpc && is_running fiber-link-worker; do
   if [[ "$(date +%s)" -ge "${deadline}" ]]; then
     compose ps > "${ARTIFACT_DIR}/compose-ps-timeout.log" 2>&1 || true
     exit_with "${EXIT_STARTUP_TIMEOUT}" "timeout waiting for compose services"


### PR DESCRIPTION
## Summary
- Add compose env validation for placeholders, sha256 digests, URLs, ports, and numeric thresholds.
- Gate worker startup on healthy fnn2 and strengthen FNN JSON-RPC healthchecks.
- Extend compose/testnet readiness scripts and shell/static checks for fnn2 channel-accept RPC readiness.

## Test Plan
- bash -n deploy/compose/validate-env.sh deploy/compose/validate-env.test.sh deploy/compose/compose-readiness.sh scripts/testnet-smoke.sh deploy/compose/compose-reference.test.sh
- ./deploy/compose/validate-env.test.sh
- ./deploy/compose/compose-reference.test.sh

Closes #392
