### PR TITLE
fix(rpc): fix Redis rate-limit race via atomic Lua script

### DIFF
--- a/fiber-link-service/apps/rpc/src/rate-limit.test.ts
+++ b/fiber-link-service/apps/rpc/src/rate-limit.test.ts
@@ -78,6 +78,30 @@ describe("rpc rate limit", () => {
     await client.quit();
   });
 
+  it("RedisRateLimitStore recovers a key that has no TTL set", async () => {
+    // A key can lose its TTL via manual PERSIST, Redis restore, or a prior partial
+    // failure before PEXPIRE ran. Without the pttl<0 branch the key would increment
+    // forever and permanently rate-limit the caller. The Lua script detects PTTL==-1
+    // and resets the expiry on the next request.
+    const client = new Redis();
+    const store = new RedisRateLimitStore(client);
+
+    // Seed a key with no TTL directly via the mock client.
+    const rawKey = `rate:${rateLimitKey("recover", "tip.create")}`;
+    await (client as unknown as Redis).set(rawKey, "5");
+
+    const result = await store.consume({ key: rateLimitKey("recover", "tip.create"), limit: 100, windowMs: 60_000 });
+
+    // After the consume the key must have a TTL so it will eventually expire.
+    const pttl = await (client as unknown as Redis).pttl(rawKey);
+    expect(pttl).toBeGreaterThan(0);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(94); // 100 - 6
+
+    await store.close();
+    await client.quit();
+  });
+
   it("createRateLimitStore uses Redis when a Redis URL is configured", async () => {
     const store = createRateLimitStore(
       {

--- a/fiber-link-service/apps/rpc/src/rate-limit.test.ts
+++ b/fiber-link-service/apps/rpc/src/rate-limit.test.ts
@@ -54,6 +54,30 @@ describe("rpc rate limit", () => {
     await client.quit();
   });
 
+  it("RedisRateLimitStore does not reset the TTL window on concurrent requests", async () => {
+    // If two requests arrive concurrently both get count=1 from separate INCR calls
+    // before either sets the TTL, the second PEXPIRE call would silently reset the
+    // window. The Lua script fixes this by only calling PEXPIRE when count===1 inside
+    // a single atomic operation, so the TTL is stable across concurrent calls.
+    const client = new Redis();
+    const store = new RedisRateLimitStore(client);
+
+    const [first, second] = await Promise.all([
+      store.consume({ key: rateLimitKey("concurrent", "tip.create"), limit: 10, windowMs: 60_000 }),
+      store.consume({ key: rateLimitKey("concurrent", "tip.create"), limit: 10, windowMs: 60_000 }),
+    ]);
+
+    // Both should be counted; no window reset means resetAtEpochMs is consistent.
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+    const delta = Math.abs(first.resetAtEpochMs - second.resetAtEpochMs);
+    // Both reset times should be within the same window, not independently extended.
+    expect(delta).toBeLessThan(1_000);
+
+    await store.close();
+    await client.quit();
+  });
+
   it("createRateLimitStore uses Redis when a Redis URL is configured", async () => {
     const store = createRateLimitStore(
       {

--- a/fiber-link-service/apps/rpc/src/rate-limit.ts
+++ b/fiber-link-service/apps/rpc/src/rate-limit.ts
@@ -89,7 +89,7 @@ export class RedisRateLimitStore implements RateLimitStore {
       number,
     ];
     const count = result[0];
-    const ttlMs = result[1];
+    const ttlMs = result[1] > 0 ? result[1] : input.windowMs;
 
     const resetAtEpochMs = Date.now() + Math.max(0, ttlMs);
     const allowed = count <= input.limit;

--- a/fiber-link-service/apps/rpc/src/rate-limit.ts
+++ b/fiber-link-service/apps/rpc/src/rate-limit.ts
@@ -65,15 +65,17 @@ export class InMemoryRateLimitStore implements RateLimitStore {
   }
 }
 
-// Lua script: atomically increment and set TTL on first write.
-// Returns [count, pttl_ms]. Using PEXPIRE only when count==1 ensures the
-// sliding window is not accidentally reset by concurrent requests.
+// Lua script: atomically increment and conditionally set TTL.
+// PEXPIRE runs when the key is new (count==1) or has no TTL (pttl<0), the
+// latter recovering keys that lost their expiry through manual intervention,
+// a Redis restore, or a prior partial failure.
 const RATE_LIMIT_LUA = `
 local count = redis.call('INCR', KEYS[1])
-if count == 1 then
-  redis.call('PEXPIRE', KEYS[1], ARGV[1])
-end
 local pttl = redis.call('PTTL', KEYS[1])
+if count == 1 or pttl < 0 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+  pttl = tonumber(ARGV[1])
+end
 return {count, pttl}
 `.trim();
 
@@ -87,7 +89,7 @@ export class RedisRateLimitStore implements RateLimitStore {
       number,
     ];
     const count = result[0];
-    const ttlMs = result[1] >= 0 ? result[1] : input.windowMs;
+    const ttlMs = result[1];
 
     const resetAtEpochMs = Date.now() + Math.max(0, ttlMs);
     const allowed = count <= input.limit;

--- a/fiber-link-service/apps/rpc/src/rate-limit.ts
+++ b/fiber-link-service/apps/rpc/src/rate-limit.ts
@@ -12,7 +12,7 @@ export type RateLimitStore = {
   close(): Promise<void>;
 };
 
-type RedisLike = Pick<Redis, "incr" | "pexpire" | "pttl" | "quit">;
+type RedisLike = Pick<Redis, "incr" | "pexpire" | "pttl" | "quit" | "eval">;
 
 type Bucket = {
   count: number;
@@ -65,18 +65,29 @@ export class InMemoryRateLimitStore implements RateLimitStore {
   }
 }
 
+// Lua script: atomically increment and set TTL on first write.
+// Returns [count, pttl_ms]. Using PEXPIRE only when count==1 ensures the
+// sliding window is not accidentally reset by concurrent requests.
+const RATE_LIMIT_LUA = `
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+local pttl = redis.call('PTTL', KEYS[1])
+return {count, pttl}
+`.trim();
+
 export class RedisRateLimitStore implements RateLimitStore {
   constructor(private client: RedisLike, private owned = false) {}
 
   async consume(input: { key: string; limit: number; windowMs: number }): Promise<RateLimitDecision> {
     const redisKey = `rate:${input.key}`;
-    const count = await this.client.incr(redisKey);
-
-    let ttlMs = await this.client.pttl(redisKey);
-    if (count === 1 || ttlMs < 0) {
-      await this.client.pexpire(redisKey, input.windowMs);
-      ttlMs = input.windowMs;
-    }
+    const result = (await this.client.eval(RATE_LIMIT_LUA, 1, redisKey, String(input.windowMs))) as [
+      number,
+      number,
+    ];
+    const count = result[0];
+    const ttlMs = result[1] >= 0 ? result[1] : input.windowMs;
 
     const resetAtEpochMs = Date.now() + Math.max(0, ttlMs);
     const allowed = count <= input.limit;


### PR DESCRIPTION
## Summary

- `RedisRateLimitStore` used three separate Redis commands — `INCR`, `PTTL`, `PEXPIRE` — to count and window-limit requests. Under concurrent load two requests could both receive `count=1` from `INCR` before either set the TTL; the second `PEXPIRE` would then reset the sliding window, letting more requests through than the configured limit.
- Replaces the three-command sequence with a single Lua script that atomically increments the counter and sets `PEXPIRE` only on first write. The window is never reset by concurrent requests.
- Adds `eval` to the `RedisLike` type and a new test that exercises the concurrent case.

## Changed files

- `apps/rpc/src/rate-limit.ts` — Lua script + updated `consume` implementation
- `apps/rpc/src/rate-limit.test.ts` — concurrent-request race regression test

## Test plan

- [ ] `bun run test` passes in `apps/rpc`
- [ ] ioredis-mock supports `eval` — verified locally
- [ ] Rate-limit headers (`x-ratelimit-remaining`) are consistent under load

https://claude.ai/code/session_01S8LscYGu1PQJKTMF7RrBpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8LscYGu1PQJKTMF7RrBpN)_