### PR TITLE
feat(rpc): add fault-tolerant Redis nonce store with in-memory fallback

### DIFF
--- a/fiber-link-service/apps/rpc/src/nonce-store.test.ts
+++ b/fiber-link-service/apps/rpc/src/nonce-store.test.ts
@@ -66,6 +66,25 @@ describe("nonce store", () => {
       await store.close();
     });
 
+    it("still reaches the in-memory fallback when onFallback observer throws", async () => {
+      const failingRedis = {
+        set: async () => { throw new Error("Redis unavailable"); },
+        quit: async () => {},
+      } as unknown as Redis;
+
+      const primary = new RedisNonceStore(failingRedis);
+      const store = new FaultTolerantRedisNonceStore(primary, {
+        onFallback: () => { throw new Error("metrics pipeline exploded"); },
+      });
+
+      const first = await store.isReplay("app1", "nonce-obs-throw", 1_000);
+      const second = await store.isReplay("app1", "nonce-obs-throw", 1_000);
+
+      expect(first).toBe(false);
+      expect(second).toBe(true);
+      await store.close();
+    });
+
     it("treats different nonces independently when falling back", async () => {
       const failingRedis = {
         set: async () => { throw new Error("Redis unavailable"); },

--- a/fiber-link-service/apps/rpc/src/nonce-store.test.ts
+++ b/fiber-link-service/apps/rpc/src/nonce-store.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import Redis from "ioredis-mock";
-import { InMemoryNonceStore, RedisNonceStore } from "./nonce-store";
+import { InMemoryNonceStore, RedisNonceStore, FaultTolerantRedisNonceStore } from "./nonce-store";
 
 describe("nonce store", () => {
   it("InMemoryNonceStore marks a repeated nonce as replay", async () => {
@@ -27,5 +27,60 @@ describe("nonce store", () => {
     await storeA.close();
     await storeB.close();
     await client.quit();
+  });
+
+  describe("FaultTolerantRedisNonceStore", () => {
+    it("delegates to primary Redis store when available", async () => {
+      const client = new Redis();
+      const primary = new RedisNonceStore(client);
+      const store = new FaultTolerantRedisNonceStore(primary);
+
+      const first = await store.isReplay("app1", "nonce-ft-1", 1_000);
+      const second = await store.isReplay("app1", "nonce-ft-1", 1_000);
+
+      expect(first).toBe(false);
+      expect(second).toBe(true);
+      await store.close();
+      await client.quit();
+    });
+
+    it("falls back to in-memory store when Redis throws and calls onFallback", async () => {
+      const errors: unknown[] = [];
+      const failingRedis = {
+        set: async () => { throw new Error("Redis connection refused"); },
+        quit: async () => {},
+      } as unknown as Redis;
+
+      const primary = new RedisNonceStore(failingRedis);
+      const store = new FaultTolerantRedisNonceStore(primary, {
+        onFallback: (err) => errors.push(err),
+      });
+
+      const first = await store.isReplay("app1", "nonce-fallback", 1_000);
+      const second = await store.isReplay("app1", "nonce-fallback", 1_000);
+
+      expect(first).toBe(false);
+      expect(second).toBe(true);
+      expect(errors).toHaveLength(2);
+      expect((errors[0] as Error).message).toMatch(/connection refused/);
+      await store.close();
+    });
+
+    it("treats different nonces independently when falling back", async () => {
+      const failingRedis = {
+        set: async () => { throw new Error("Redis unavailable"); },
+        quit: async () => {},
+      } as unknown as Redis;
+
+      const primary = new RedisNonceStore(failingRedis);
+      const store = new FaultTolerantRedisNonceStore(primary);
+
+      const a = await store.isReplay("app1", "nonce-a", 1_000);
+      const b = await store.isReplay("app1", "nonce-b", 1_000);
+
+      expect(a).toBe(false);
+      expect(b).toBe(false);
+      await store.close();
+    });
   });
 });

--- a/fiber-link-service/apps/rpc/src/nonce-store.ts
+++ b/fiber-link-service/apps/rpc/src/nonce-store.ts
@@ -40,11 +40,65 @@ export class RedisNonceStore implements NonceStore {
   }
 }
 
-export function createNonceStore() {
+export type FaultTolerantNonceStoreOptions = {
+  /** Called when Redis is unavailable and the fallback is used. */
+  onFallback?: (error: unknown) => void;
+};
+
+/**
+ * Wraps a primary Redis nonce store with an in-memory fallback.
+ *
+ * When Redis is temporarily unavailable (network hiccup, restart) requests
+ * are not rejected outright — the in-memory store handles the nonce check for
+ * that request and the error is surfaced via `onFallback` so operators can
+ * alert on it. Replay protection remains intact within the single process;
+ * cross-instance replay protection is degraded only for the duration of the
+ * outage.
+ *
+ * For stricter deployments where replay protection must never be degraded,
+ * use `RedisNonceStore` directly — errors will propagate and callers can
+ * decide how to handle them.
+ */
+export class FaultTolerantRedisNonceStore implements NonceStore {
+  private readonly fallback = new InMemoryNonceStore();
+
+  constructor(
+    private readonly primary: RedisNonceStore,
+    private readonly options: FaultTolerantNonceStoreOptions = {},
+  ) {}
+
+  async isReplay(appId: string, nonce: string, ttlMs: number): Promise<boolean> {
+    try {
+      return await this.primary.isReplay(appId, nonce, ttlMs);
+    } catch (error) {
+      this.options.onFallback?.(error);
+      return this.fallback.isReplay(appId, nonce, ttlMs);
+    }
+  }
+
+  async close(): Promise<void> {
+    await Promise.all([this.primary.close(), this.fallback.close()]);
+  }
+}
+
+export type CreateNonceStoreOptions = {
+  /**
+   * When `true`, Redis errors fall back to an in-memory store rather than
+   * propagating. Defaults to `false` (fail-closed / strict replay protection).
+   */
+  faultTolerant?: boolean;
+  onFallback?: (error: unknown) => void;
+};
+
+export function createNonceStore(options: CreateNonceStoreOptions = {}): NonceStore {
   const redisUrl = process.env.FIBER_LINK_NONCE_REDIS_URL ?? process.env.REDIS_URL;
   if (redisUrl) {
     const client = new Redis(redisUrl);
-    return new RedisNonceStore(client, true);
+    const primary = new RedisNonceStore(client, true);
+    if (options.faultTolerant) {
+      return new FaultTolerantRedisNonceStore(primary, { onFallback: options.onFallback });
+    }
+    return primary;
   }
   return new InMemoryNonceStore();
 }

--- a/fiber-link-service/apps/rpc/src/nonce-store.ts
+++ b/fiber-link-service/apps/rpc/src/nonce-store.ts
@@ -71,7 +71,11 @@ export class FaultTolerantRedisNonceStore implements NonceStore {
     try {
       return await this.primary.isReplay(appId, nonce, ttlMs);
     } catch (error) {
-      this.options.onFallback?.(error);
+      try {
+        this.options.onFallback?.(error);
+      } catch {
+        // Observer errors must not prevent fallback replay protection.
+      }
       return this.fallback.isReplay(appId, nonce, ttlMs);
     }
   }


### PR DESCRIPTION
## Summary

- When Redis is temporarily unavailable (network blip, restart), `RedisNonceStore.isReplay` throws. This propagates to the RPC handler as `INTERNAL_ERROR`, blocking all authenticated requests for the duration of the outage.
- Adds `FaultTolerantRedisNonceStore` that catches Redis errors, calls an optional `onFallback` observer for alerting, and transparently falls back to the in-process `InMemoryNonceStore` for that request.
- The existing `RedisNonceStore` is unchanged and remains the default (`createNonceStore()`). The fault-tolerant wrapper is opt-in (`createNonceStore({ faultTolerant: true })`) for operators who prioritise availability over strict cross-instance replay protection during outages.
- Adds `onFallback` callback so operators can wire alerts (e.g. increment a metric, log a warning) when the fallback fires.

## Security note

During a Redis outage, with `faultTolerant: true`, replay protection degrades to single-process in-memory scope. Nonces seen on one process instance won't be visible to others. This is an explicit availability–security trade-off; the strict default is unchanged.

## Changed files

- `apps/rpc/src/nonce-store.ts` — `FaultTolerantRedisNonceStore` class + updated `createNonceStore`
- `apps/rpc/src/nonce-store.test.ts` — tests for fallback and onFallback callback

## Test plan

- [ ] `bun run test` passes in `apps/rpc`
- [ ] Verify `onFallback` fires when Redis is stopped during integration testing
- [ ] Confirm `RedisNonceStore` (default) still propagates errors when `faultTolerant` is not set

https://claude.ai/code/session_01S8LscYGu1PQJKTMF7RrBpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8LscYGu1PQJKTMF7RrBpN)_