### PR TITLE
Refresh creator Fiber Link dashboard analytics UX

### DIFF
--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-analytics.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-analytics.gjs
@@ -13,10 +13,51 @@ const RANGES = [
   { value: "all", label: "All time" },
 ];
 
+const RANKING_LIMIT = 5;
+
+function rangeLabelFor(value) {
+  return RANGES.find((range) => range.value === value)?.label ?? "30 days";
+}
+
 function formatAmount(amount) {
   const n = parseFloat(amount ?? "0");
   if (!isFinite(n)) return "0";
   return n.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
+
+function formatShortDate(value) {
+  if (!value) return "No tips yet";
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnlyMatch) {
+    const [, year, month, day] = dateOnlyMatch;
+    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatDateTime(value) {
+  if (!value) return "Pending";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function withdrawalStateLabel(state) {
+  return String(state ?? "pending").replace(/_/g, " ").toLowerCase();
+}
+
+function withdrawalStateClass(state) {
+  return `is-${String(state ?? "pending").toLowerCase().replace(/_/g, "-")}`;
 }
 
 export default class FiberLinkAnalytics extends Component {
@@ -24,6 +65,7 @@ export default class FiberLinkAnalytics extends Component {
   @tracked data = null;
   @tracked isLoading = false;
   @tracked errorMessage = null;
+  @tracked queuedRange = null;
 
   get ranges() {
     return RANGES;
@@ -32,15 +74,194 @@ export default class FiberLinkAnalytics extends Component {
   get hasData() {
     return (
       this.data &&
-      (this.data.timeSeries?.length > 0 ||
-        this.data.topPosts?.length > 0 ||
-        this.data.topTippers?.length > 0)
+      (this.timeSeries.length > 0 ||
+        this.topPosts.length > 0 ||
+        this.topTippers.length > 0 ||
+        this.withdrawals.length > 0)
     );
   }
 
+  get isShowingStaleData() {
+    return Boolean(this.errorMessage && this.hasData);
+  }
+
+  get isRefreshingVisibleData() {
+    return Boolean(this.isLoading && this.hasData);
+  }
+
+  get panelClass() {
+    return `fiber-link-analytics${this.isShowingStaleData ? " is-stale" : ""}`;
+  }
+
+  get loadingClass() {
+    return `fiber-link-analytics__loading${this.isRefreshingVisibleData ? " is-inline" : ""}`;
+  }
+
+  get loadingMessage() {
+    return this.isRefreshingVisibleData ? "Refreshing creator signal..." : "Loading creator signal...";
+  }
+
+  get timeSeries() {
+    return this.data?.timeSeries ?? [];
+  }
+
+  get topPosts() {
+    return this.data?.topPosts ?? [];
+  }
+
+  get visibleTopPosts() {
+    return this.topPosts.slice(0, RANKING_LIMIT);
+  }
+
+  get hiddenTopPostCount() {
+    return Math.max(this.topPosts.length - this.visibleTopPosts.length, 0);
+  }
+
+  get topTippers() {
+    return this.data?.topTippers ?? [];
+  }
+
+  get visibleTopTippers() {
+    return this.topTippers.slice(0, RANKING_LIMIT);
+  }
+
+  get hiddenTopTipperCount() {
+    return Math.max(this.topTippers.length - this.visibleTopTippers.length, 0);
+  }
+
+  get withdrawals() {
+    return this.data?.withdrawalHistory ?? [];
+  }
+
+  get recentWithdrawals() {
+    return this.withdrawals.slice(0, 5);
+  }
+
+  get rangeLabel() {
+    return rangeLabelFor(this.range);
+  }
+
+  get visibleRange() {
+    return this.data?.range ?? this.range;
+  }
+
+  get visibleRangeLabel() {
+    return rangeLabelFor(this.visibleRange);
+  }
+
+  get isRangePending() {
+    return Boolean(this.hasData && this.data?.range && this.data.range !== this.range);
+  }
+
+  get rangeStateLabel() {
+    if (!this.isRangePending) return `Showing ${this.visibleRangeLabel}`;
+    return `Showing ${this.visibleRangeLabel}; ${this.rangeLabel} requested`;
+  }
+
+  get totalAmount() {
+    return this.timeSeries.reduce((sum, row) => sum + parseFloat(row.amount ?? "0"), 0);
+  }
+
+  get activeTipDays() {
+    return this.timeSeries.filter((row) => parseFloat(row.amount ?? "0") > 0).length;
+  }
+
+  get quietTipDays() {
+    return Math.max(this.timeSeries.length - this.activeTipDays, 0);
+  }
+
+  get peakDay() {
+    if (!this.timeSeries.length) return null;
+    return this.timeSeries.reduce((best, row) => {
+      const rowAmount = parseFloat(row.amount ?? "0");
+      const bestAmount = parseFloat(best.amount ?? "0");
+      return rowAmount > bestAmount ? row : best;
+    }, this.timeSeries[0]);
+  }
+
+  get peakDayDateLabel() {
+    return formatShortDate(this.peakDay?.date);
+  }
+
+  get peakDayAmountLabel() {
+    return `${formatAmount(this.peakDay?.amount)} CKB`;
+  }
+
+  get rhythmNote() {
+    if (!this.timeSeries.length) return "No settled tip days in this window yet.";
+    if (this.activeTipDays === 0) return `${this.timeSeries.length} quiet days, no settled tip volume yet.`;
+    if (this.quietTipDays === 0) return `${this.activeTipDays} active tip days, no quiet days in this chart.`;
+    return `${this.activeTipDays} active tip days, ${this.quietTipDays} quiet days. Peak: ${this.peakDayDateLabel}.`;
+  }
+
+  get strongestPost() {
+    return this.topPosts[0] ?? null;
+  }
+
+  get strongestPostLabel() {
+    return this.strongestPost ? `Post #${this.strongestPost.postId}` : "No post winner yet";
+  }
+
+  get strongestPostMeta() {
+    if (!this.strongestPost) return "Settled tips will reveal the first post to revisit.";
+    return `${this.strongestPost.tipCount} tips / ${formatAmount(this.strongestPost.totalAmount)} CKB`;
+  }
+
+  get topSupporter() {
+    return this.topTippers[0] ?? null;
+  }
+
+  get topSupporterLabel() {
+    return this.topSupporter?.userId ?? "No supporter leader yet";
+  }
+
+  get topSupporterMeta() {
+    if (!this.topSupporter) return "Repeat supporter signals appear after tips settle.";
+    return `${this.topSupporter.tipCount} tips / ${formatAmount(this.topSupporter.totalAmount)} CKB`;
+  }
+
+  get latestWithdrawal() {
+    return this.recentWithdrawals[0] ?? null;
+  }
+
+  get latestWithdrawalMeta() {
+    if (!this.latestWithdrawal) return "No payout requests in this window.";
+    return `${formatAmount(this.latestWithdrawal.amount)} ${this.latestWithdrawal.asset} / ${withdrawalStateLabel(this.latestWithdrawal.state)}`;
+  }
+
+  get creatorBriefLead() {
+    if (this.strongestPost && this.topSupporter) {
+      return `${this.strongestPostLabel} is carrying this window, and ${this.topSupporterLabel} is the supporter to notice.`;
+    }
+    if (this.strongestPost) {
+      return `${this.strongestPostLabel} is the strongest earning post in this window.`;
+    }
+    if (this.topSupporter) {
+      return `${this.topSupporterLabel} is the supporter creating the clearest repeat signal.`;
+    }
+    if (this.withdrawals.length) {
+      return "This window is mostly payout activity, not fresh settled tips.";
+    }
+    return "This window is waiting for its first strong creator signal.";
+  }
+
+  get creatorBriefBody() {
+    if (this.totalAmount > 0) {
+      return `${formatAmount(this.totalAmount)} CKB settled in the visible ${this.visibleRangeLabel} window across ${this.activeTipDays} active tip days. Use these cues to decide what to revisit, who to notice, and when to review payouts.`;
+    }
+    if (this.withdrawals.length) {
+      return `There are payout requests in the visible ${this.visibleRangeLabel} window, but no settled tip rhythm yet. Review payout status first, then wait for new settled tips before reading content signals.`;
+    }
+    return "When settled tips arrive, this brief will call out the post, supporter, and payout pressure worth inspecting first.";
+  }
+
+  get generatedAtLabel() {
+    return formatDateTime(this.data?.generatedAt);
+  }
+
   get maxTimeSeriesAmount() {
-    if (!this.data?.timeSeries?.length) return 1;
-    return Math.max(...this.data.timeSeries.map((d) => parseFloat(d.amount ?? "0")), 1);
+    if (!this.timeSeries.length) return 1;
+    return Math.max(...this.timeSeries.map((d) => parseFloat(d.amount ?? "0")), 1);
   }
 
   barWidth(amount) {
@@ -48,122 +269,320 @@ export default class FiberLinkAnalytics extends Component {
     return `${Math.min(100, Math.max(0, pct)).toFixed(1)}%`;
   }
 
+  barRowClass(row) {
+    const amount = parseFloat(row?.amount ?? "0");
+    let className = "fiber-link-analytics__bar-row";
+    if (amount <= 0) className += " is-zero";
+    if (amount > 0 && row?.date === this.peakDay?.date) className += " is-peak";
+    return className;
+  }
+
   constructor(owner, args) {
     super(owner, args);
-    this.loadAnalytics();
+    void this.loadAnalytics().catch(() => {});
   }
 
   @action
   async onRangeChange(event) {
-    this.range = event.target.value;
+    const nextRange = event.target.value;
+    if (nextRange === this.range && this.data?.range === nextRange && !this.errorMessage) {
+      return;
+    }
+    this.range = nextRange;
     await this.loadAnalytics();
   }
 
   @action
   async loadAnalytics() {
-    if (this.isLoading) return;
+    if (this.isLoading) {
+      this.queuedRange = this.range;
+      return;
+    }
     this.isLoading = true;
     this.errorMessage = null;
+    const requestedRange = this.range;
     try {
-      this.data = await getDashboardAnalytics({ range: this.range });
+      this.data = await getDashboardAnalytics({ range: requestedRange });
     } catch (e) {
       this.errorMessage = e?.message || "Failed to load analytics.";
     } finally {
       this.isLoading = false;
+      const queuedRange = this.queuedRange;
+      this.queuedRange = null;
+      if (queuedRange && queuedRange === this.range && queuedRange !== this.data?.range) {
+        await this.loadAnalytics();
+      }
     }
   }
 
   <template>
-    <section class="fiber-link-analytics" data-fiber-link-analytics>
-      <div class="fiber-link-analytics__header">
-        <h3 class="fiber-link-analytics__title">Analytics</h3>
-        <select
-          class="fiber-link-analytics__range"
-          aria-label="Date range"
-          {{on "change" this.onRangeChange}}
-        >
-          {{#each this.ranges as |r|}}
-            <option value={{r.value}} selected={{eq r.value this.range}}>{{r.label}}</option>
-          {{/each}}
-        </select>
+    <section id="fiber-link-analytics-panel" class={{this.panelClass}} data-fiber-link-analytics>
+      <div class="fiber-link-analytics__masthead">
+        <div class="fiber-link-analytics__headline">
+          <span class="fiber-link-analytics__eyebrow">Creator analytics</span>
+          <h3 class="fiber-link-analytics__title">
+            Know which moments are earning attention.
+          </h3>
+          <p>
+            Track settled CKB volume, the posts converting into tips, repeat
+            supporters, and withdrawal pressure without leaving Discourse.
+          </p>
+        </div>
+
+        <div class="fiber-link-analytics__controls">
+          <div class="fiber-link-analytics__scope-control" aria-label="Analytics asset scope">
+            <span>Asset scope</span>
+            <strong>CKB settlement</strong>
+          </div>
+
+          <label class="fiber-link-analytics__range-control">
+            <span>Window</span>
+            <select
+              class="fiber-link-analytics__range"
+              aria-label="Date range"
+              name="fiber-link-analytics-range"
+              {{on "change" this.onRangeChange}}
+            >
+              {{#each this.ranges as |r|}}
+                <option value={{r.value}} selected={{eq r.value this.range}}>{{r.label}}</option>
+              {{/each}}
+            </select>
+            <em>Session only; new visits start at 30 days.</em>
+          </label>
+        </div>
+      </div>
+
+      <div class="fiber-link-analytics__proof-strip" role="list" aria-label="Analytics data basis">
+        <span role="listitem">CKB settlement view</span>
+        <span role="listitem">Settled tips only</span>
+        <span role="listitem">Visible loaded window</span>
+        <span role="listitem">Range not saved</span>
+        <span role="listitem">Top 5 shown from ranked results</span>
+        <span role="listitem">No modeled deltas</span>
       </div>
 
       {{#if this.errorMessage}}
-        <p class="fiber-link-tip-alert is-error">{{this.errorMessage}}</p>
+        <div class="fiber-link-analytics__error" role="status">
+          <span>Analytics unavailable</span>
+          <p>
+            {{this.errorMessage}}
+              {{#if this.hasData}}
+              Showing {{this.visibleRangeLabel}} data until {{this.rangeLabel}} refresh succeeds.
+            {{else}}
+              Withdrawal and activity tools remain available.
+            {{/if}}
+          </p>
+          <button type="button" {{on "click" this.loadAnalytics}}>
+            Retry analytics
+          </button>
+        </div>
       {{/if}}
 
       {{#if this.isLoading}}
-        <p class="fiber-link-analytics__loading">Loading analytics…</p>
-      {{else if this.hasData}}
-
-        {{#if this.data.timeSeries.length}}
-          <div class="fiber-link-analytics__chart" aria-label="Daily tips chart">
-            {{#each this.data.timeSeries as |row|}}
-              <div class="fiber-link-analytics__bar-row" title="{{row.date}}: {{row.amount}} CKB">
-                <span class="fiber-link-analytics__bar-label">{{row.date}}</span>
-                <span class="fiber-link-analytics__bar-track">
-                  <span
-                    class="fiber-link-analytics__bar-fill"
-                    style="width: {{this.barWidth row.amount}}"
-                    aria-hidden="true"
-                  ></span>
-                </span>
-                <span class="fiber-link-analytics__bar-value">{{formatAmount row.amount}}</span>
-              </div>
-            {{/each}}
-          </div>
-        {{/if}}
-
-        <div class="fiber-link-analytics__tables">
-          {{#if this.data.topPosts.length}}
-            <div class="fiber-link-analytics__table-section">
-              <h4>Top posts</h4>
-              <table class="fiber-link-analytics__table">
-                <thead>
-                  <tr><th>#</th><th>Post</th><th>Tips</th><th>Total CKB</th></tr>
-                </thead>
-                <tbody>
-                  {{#each this.data.topPosts as |post i|}}
-                    <tr>
-                      <td>{{inc i}}</td>
-                      <td>
-                        <a href="/p/{{post.postId}}" target="_blank" rel="noopener noreferrer">
-                          Post #{{post.postId}}
-                        </a>
-                      </td>
-                      <td>{{post.tipCount}}</td>
-                      <td>{{formatAmount post.totalAmount}}</td>
-                    </tr>
-                  {{/each}}
-                </tbody>
-              </table>
-            </div>
-          {{/if}}
-
-          {{#if this.data.topTippers.length}}
-            <div class="fiber-link-analytics__table-section">
-              <h4>Top supporters</h4>
-              <table class="fiber-link-analytics__table">
-                <thead>
-                  <tr><th>#</th><th>User ID</th><th>Tips</th><th>Total CKB</th></tr>
-                </thead>
-                <tbody>
-                  {{#each this.data.topTippers as |tipper i|}}
-                    <tr>
-                      <td>{{inc i}}</td>
-                      <td>{{tipper.userId}}</td>
-                      <td>{{tipper.tipCount}}</td>
-                      <td>{{formatAmount tipper.totalAmount}}</td>
-                    </tr>
-                  {{/each}}
-                </tbody>
-              </table>
-            </div>
+        <div class={{this.loadingClass}} role="status">
+          <span aria-hidden="true"></span>
+          {{this.loadingMessage}}
+          {{#if this.isRangePending}}
+            <em>Keeping {{this.visibleRangeLabel}} visible while {{this.rangeLabel}} loads.</em>
           {{/if}}
         </div>
+      {{/if}}
 
+      {{#if this.hasData}}
+        <div class="fiber-link-analytics__kpis" aria-label="Creator analytics summary">
+          <article>
+            <span>Settled volume</span>
+            <strong>{{formatAmount this.totalAmount}}</strong>
+            <em>CKB in {{this.visibleRangeLabel}}</em>
+          </article>
+          <article>
+            <span>Tip days</span>
+            <strong>{{this.activeTipDays}}</strong>
+            <em>days with settled tips</em>
+          </article>
+          <article>
+            <span>Best day</span>
+            <strong>{{this.peakDayDateLabel}}</strong>
+            <em>{{this.peakDayAmountLabel}}</em>
+          </article>
+          <article>
+            <span>Withdrawals</span>
+            <strong>{{this.withdrawals.length}}</strong>
+            <em>requests in window</em>
+          </article>
+        </div>
+
+        <section class="fiber-link-analytics__brief" aria-label="Creator analytics brief">
+          <span>Creator brief</span>
+          <strong>{{this.creatorBriefLead}}</strong>
+          <p>{{this.creatorBriefBody}}</p>
+        </section>
+
+        <div class="fiber-link-analytics__next-head">
+          <span>Suggested next moves</span>
+          <p>
+            Light guidance from settled activity only. Use it to choose what to
+            inspect next, not as content strategy automation.
+          </p>
+        </div>
+
+        <div class="fiber-link-analytics__actions" aria-label="Suggested creator actions">
+          <article aria-label="Revisit winning post">
+            <span>Revisit winner</span>
+            <strong>{{this.strongestPostLabel}}</strong>
+            <em>{{this.strongestPostMeta}}</em>
+            {{#if this.strongestPost}}
+              <a href="/p/{{this.strongestPost.postId}}" target="_blank" rel="noopener noreferrer">
+                Open post
+              </a>
+            {{/if}}
+          </article>
+          <article aria-label="Notice top supporter">
+            <span>Notice supporter</span>
+            <strong>{{this.topSupporterLabel}}</strong>
+            <em>{{this.topSupporterMeta}}</em>
+          </article>
+          <article aria-label="Review payout focus">
+            <span>Payout focus</span>
+            <strong>Withdrawal desk</strong>
+            <em>{{this.latestWithdrawalMeta}}</em>
+            <a href="#fiber-link-withdrawal-panel">Review payout form</a>
+          </article>
+        </div>
+
+        <div class="fiber-link-analytics__body">
+          <div class="fiber-link-analytics__chart-card">
+            <div class="fiber-link-analytics__section-head">
+              <span>Revenue rhythm</span>
+              <strong>daily settled tips</strong>
+            </div>
+            <div class="fiber-link-analytics__freshness" aria-label="Analytics freshness">
+              <span>Last updated</span>
+              <strong>{{this.generatedAtLabel}}</strong>
+              <em class="fiber-link-analytics__freshness-range">{{this.rangeStateLabel}}</em>
+              {{#if this.isShowingStaleData}}
+                <em class="fiber-link-analytics__freshness-warning">Refresh failed</em>
+              {{/if}}
+            </div>
+            <p class="fiber-link-analytics__rhythm-note">{{this.rhythmNote}}</p>
+
+            {{#if this.timeSeries.length}}
+              <div class="fiber-link-analytics__chart" aria-label="Daily tips chart">
+                {{#each this.timeSeries as |row|}}
+                  <div class={{this.barRowClass row}} title="{{row.date}}: {{row.amount}} CKB">
+                    <span class="fiber-link-analytics__bar-label">{{formatShortDate row.date}}</span>
+                    <span class="fiber-link-analytics__bar-track">
+                      <span
+                        class="fiber-link-analytics__bar-fill"
+                        style="width: {{this.barWidth row.amount}}"
+                        aria-hidden="true"
+                      ></span>
+                    </span>
+                    <span class="fiber-link-analytics__bar-value">{{formatAmount row.amount}}</span>
+                  </div>
+                {{/each}}
+              </div>
+            {{else}}
+              <p class="fiber-link-analytics__empty is-compact">No settled tip days in this window.</p>
+            {{/if}}
+          </div>
+
+          <div class="fiber-link-analytics__side">
+            <section class="fiber-link-analytics__rank-card">
+              <div class="fiber-link-analytics__section-head">
+                <span>Top earning posts</span>
+                <strong>ranked by settled CKB</strong>
+              </div>
+
+              {{#if this.visibleTopPosts.length}}
+                <ol class="fiber-link-analytics__rank-list">
+                  {{#each this.visibleTopPosts as |post i|}}
+                    <li>
+                      <span class="fiber-link-analytics__rank-index">{{inc i}}</span>
+                      <a
+                        class="fiber-link-analytics__rank-main"
+                        href="/p/{{post.postId}}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Post #{{post.postId}}
+                        <em>Open post</em>
+                      </a>
+                      <span class="fiber-link-analytics__rank-evidence">{{post.tipCount}} tips</span>
+                      <strong class="fiber-link-analytics__rank-value">{{formatAmount post.totalAmount}} CKB</strong>
+                    </li>
+                  {{/each}}
+                </ol>
+                {{#if this.hiddenTopPostCount}}
+                  <p class="fiber-link-analytics__rank-more">
+                    +{{this.hiddenTopPostCount}} more returned by analytics. Keep the creator view to the top 5; use export/admin surfaces for full inspection.
+                  </p>
+                {{/if}}
+              {{else}}
+                <p class="fiber-link-analytics__empty is-compact">No tipped posts yet.</p>
+              {{/if}}
+            </section>
+
+            <section class="fiber-link-analytics__rank-card">
+              <div class="fiber-link-analytics__section-head">
+                <span>Repeat supporters</span>
+                <strong>ranked by settled CKB</strong>
+              </div>
+
+              {{#if this.visibleTopTippers.length}}
+                <ol class="fiber-link-analytics__rank-list">
+                  {{#each this.visibleTopTippers as |tipper i|}}
+                    <li>
+                      <span class="fiber-link-analytics__rank-index">{{inc i}}</span>
+                      <span class="fiber-link-analytics__mono">{{tipper.userId}}</span>
+                      <span class="fiber-link-analytics__rank-evidence">{{tipper.tipCount}} tips</span>
+                      <strong class="fiber-link-analytics__rank-value">{{formatAmount tipper.totalAmount}} CKB</strong>
+                    </li>
+                  {{/each}}
+                </ol>
+                {{#if this.hiddenTopTipperCount}}
+                  <p class="fiber-link-analytics__rank-more">
+                    +{{this.hiddenTopTipperCount}} more returned by analytics. Keep the creator view to the top 5; use export/admin surfaces for full inspection.
+                  </p>
+                {{/if}}
+              {{else}}
+                <p class="fiber-link-analytics__empty is-compact">No supporter rankings yet.</p>
+              {{/if}}
+            </section>
+          </div>
+        </div>
+
+        {{#if this.latestWithdrawal}}
+          <section class="fiber-link-analytics__withdrawals">
+            <div class="fiber-link-analytics__section-head">
+              <span>Withdrawal pressure</span>
+              <strong>latest payout signal</strong>
+            </div>
+
+            <article class="fiber-link-analytics__withdrawal-signal">
+              <span class="fiber-link-analytics__status {{withdrawalStateClass this.latestWithdrawal.state}}">
+                {{withdrawalStateLabel this.latestWithdrawal.state}}
+              </span>
+              <strong>{{formatAmount this.latestWithdrawal.amount}} {{this.latestWithdrawal.asset}}</strong>
+              <p>
+                Created {{formatDateTime this.latestWithdrawal.createdAt}}. Keep the full
+                payout history near the withdrawal desk; analytics only surfaces the
+                newest pressure point.
+              </p>
+              <span class="fiber-link-analytics__mono">{{this.latestWithdrawal.id}}</span>
+            </article>
+          </section>
+        {{/if}}
+      {{else if this.errorMessage}}
+      {{else if this.isLoading}}
       {{else}}
-        <p class="fiber-link-analytics__empty">No analytics data yet for this period.</p>
+        <div class="fiber-link-analytics__empty">
+          <strong>No creator analytics yet.</strong>
+          <span>
+            When tips settle, this space will show earning rhythm, highest-signal
+            posts, repeat supporters, and withdrawal pressure.
+          </span>
+        </div>
       {{/if}}
     </section>
   </template>

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-analytics.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-analytics.gjs
@@ -14,6 +14,16 @@ const RANGES = [
 ];
 
 const RANKING_LIMIT = 5;
+const SHORT_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+});
+const DATE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
 
 function rangeLabelFor(value) {
   return RANGES.find((range) => range.value === value)?.label ?? "30 days";
@@ -30,26 +40,18 @@ function formatShortDate(value) {
   const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
   if (dateOnlyMatch) {
     const [, year, month, day] = dateOnlyMatch;
-    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
+    return SHORT_DATE_FORMATTER.format(new Date(Number(year), Number(month) - 1, Number(day)));
   }
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return SHORT_DATE_FORMATTER.format(date);
 }
 
 function formatDateTime(value) {
   if (!value) return "Pending";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return DATE_TIME_FORMATTER.format(date);
 }
 
 function withdrawalStateLabel(state) {
@@ -98,7 +100,7 @@ export default class FiberLinkAnalytics extends Component {
   }
 
   get loadingMessage() {
-    return this.isRefreshingVisibleData ? "Refreshing creator signal..." : "Loading creator signal...";
+    return this.isRefreshingVisibleData ? "Refreshing creator signal…" : "Loading creator signal…";
   }
 
   get timeSeries() {
@@ -171,7 +173,7 @@ export default class FiberLinkAnalytics extends Component {
   }
 
   get peakDay() {
-    if (!this.timeSeries.length) return null;
+    if (!this.timeSeries.length || this.activeTipDays === 0) return null;
     return this.timeSeries.reduce((best, row) => {
       const rowAmount = parseFloat(row.amount ?? "0");
       const bestAmount = parseFloat(best.amount ?? "0");

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-auto-refresh-select.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-auto-refresh-select.gjs
@@ -36,6 +36,7 @@ export default class FiberLinkAutoRefreshSelect extends Component {
       <span>Auto-refresh</span>
       <select
         aria-label="Auto-refresh interval"
+        name="fiber-link-auto-refresh-interval"
         {{on "change" this.updatePollInterval}}
       >
         <option value="10000" selected={{this.isTenSeconds}}>10s</option>

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
@@ -439,6 +439,8 @@ export default class FiberLinkWithdrawalPanel extends Component {
             <input
               class="fiber-link-tip-input fiber-link-dashboard__withdrawal-input is-amount"
               data-fiber-link-withdrawal-input="amount"
+              id="fiber-link-withdrawal-amount"
+              name="fiber-link-withdrawal-amount"
               inputmode="decimal"
               min={{this.minimumWithdrawalAmount}}
               type="text"
@@ -473,6 +475,8 @@ export default class FiberLinkWithdrawalPanel extends Component {
             class="fiber-link-tip-input fiber-link-dashboard__withdrawal-input is-address"
             aria-label="Destination Address"
             data-fiber-link-withdrawal-input="address"
+              id="fiber-link-withdrawal-address"
+              name="fiber-link-withdrawal-address"
             placeholder="ckb1q..."
             spellcheck="false"
             type="text"

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
@@ -209,7 +209,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   get submitLabel() {
-    return this.isSubmitting ? "Requesting..." : "Request withdrawal →";
+    return this.isSubmitting ? "Requesting…" : "Request withdrawal →";
   }
 
   get minimumWithdrawalAmount() {
@@ -441,6 +441,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
               data-fiber-link-withdrawal-input="amount"
               id="fiber-link-withdrawal-amount"
               name="fiber-link-withdrawal-amount"
+              autocomplete="off"
               inputmode="decimal"
               min={{this.minimumWithdrawalAmount}}
               type="text"
@@ -475,9 +476,10 @@ export default class FiberLinkWithdrawalPanel extends Component {
             class="fiber-link-tip-input fiber-link-dashboard__withdrawal-input is-address"
             aria-label="Destination Address"
             data-fiber-link-withdrawal-input="address"
-              id="fiber-link-withdrawal-address"
-              name="fiber-link-withdrawal-address"
-            placeholder="ckb1q..."
+            id="fiber-link-withdrawal-address"
+            name="fiber-link-withdrawal-address"
+            autocomplete="off"
+            placeholder="ckb1q…"
             spellcheck="false"
             type="text"
             value={{this.destinationAddress}}

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
@@ -145,21 +145,15 @@
       <strong aria-hidden="true">01</strong>
       Summary
     </a>
-    <a href="#fiber-link-analytics-panel" data-flow-primary aria-label="Jump to creator signals">
+    <a href="#fiber-link-withdrawal-panel" data-flow-primary aria-label="Jump to payout desk">
       <strong aria-hidden="true">02</strong>
-      Creator signals
-    </a>
-    <a href="#fiber-link-withdrawal-panel" aria-label="Jump to payout desk">
-      <strong aria-hidden="true">03</strong>
       Payout desk
     </a>
     <a href="#fiber-link-activity-log" aria-label="Jump to activity log">
-      <strong aria-hidden="true">04</strong>
+      <strong aria-hidden="true">03</strong>
       Activity log
     </a>
   </nav>
-
-  <FiberLinkAnalytics />
 
   <div class="fiber-link-dashboard__content-grid">
     <div id="fiber-link-withdrawal-panel" class="fiber-link-dashboard__withdrawal-anchor">

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
@@ -45,6 +45,7 @@
   {{/if}}
 
   <section
+    id="fiber-link-summary"
     class="fiber-link-dashboard__metrics"
     aria-label="Fiber Link summary"
   >
@@ -139,14 +140,37 @@
     </section>
   {{/if}}
 
-  <div class="fiber-link-dashboard__content-grid">
-    <FiberLinkWithdrawalPanel
-      @asset={{this.model.balanceAsset}}
-      @availableBalance={{this.model.availableBalance}}
-      @lockedBalance={{this.model.lockedBalance}}
-    />
+  <nav class="fiber-link-dashboard__flow" aria-label="Creator dashboard flow">
+    <a href="#fiber-link-summary" aria-label="Jump to summary">
+      <strong aria-hidden="true">01</strong>
+      Summary
+    </a>
+    <a href="#fiber-link-analytics-panel" data-flow-primary aria-label="Jump to creator signals">
+      <strong aria-hidden="true">02</strong>
+      Creator signals
+    </a>
+    <a href="#fiber-link-withdrawal-panel" aria-label="Jump to payout desk">
+      <strong aria-hidden="true">03</strong>
+      Payout desk
+    </a>
+    <a href="#fiber-link-activity-log" aria-label="Jump to activity log">
+      <strong aria-hidden="true">04</strong>
+      Activity log
+    </a>
+  </nav>
 
-    <section class="fiber-link-dashboard__activity">
+  <FiberLinkAnalytics />
+
+  <div class="fiber-link-dashboard__content-grid">
+    <div id="fiber-link-withdrawal-panel" class="fiber-link-dashboard__withdrawal-anchor">
+      <FiberLinkWithdrawalPanel
+        @asset={{this.model.balanceAsset}}
+        @availableBalance={{this.model.availableBalance}}
+        @lockedBalance={{this.model.lockedBalance}}
+      />
+    </div>
+
+    <section id="fiber-link-activity-log" class="fiber-link-dashboard__activity">
       <FiberLinkTipFeed
         @tips={{this.model.tipFeedItems}}
         @isLoading={{this.model.isInitialLoading}}

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -3582,7 +3582,7 @@ body:has(.fiber-link-dashboard) .profiler-results {
 
 .fiber-link-dashboard__flow {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0;
   margin: -34px 0 44px;
   border-top: 1px solid var(--fl-dashboard-line);

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -2111,28 +2111,24 @@ body:has(.fiber-link-dashboard) .profiler-results {
   border-radius: 0;
   background: transparent !important;
   color: var(--fl-dashboard-black);
-  outline: 0 !important;
   -webkit-focus-ring-color: transparent;
   box-shadow: none !important;
 }
 
 .fiber-link-dashboard__withdrawal-input:focus,
 .fiber-link-dashboard__withdrawal-input:focus-visible {
-  outline: 0 !important;
   border-color: transparent !important;
   box-shadow: none !important;
 }
 
 .fiber-link-dashboard :is(input, select, textarea):focus,
 .fiber-link-dashboard :is(input, select, textarea):focus-visible {
-  outline: 0 !important;
   box-shadow: none !important;
   -webkit-focus-ring-color: transparent;
 }
 
 .fiber-link-dashboard__amount-input-wrap:focus-within,
 .fiber-link-dashboard .fiber-link-tip-field:focus-within {
-  outline: 0 !important;
   box-shadow: none !important;
 }
 
@@ -2307,7 +2303,6 @@ body:has(.fiber-link-dashboard) .profiler-results {
 
 .fiber-link-dashboard .fiber-link-tip-feed-search input:focus,
 .fiber-link-dashboard .fiber-link-tip-feed-search input:focus-visible {
-  outline: 0 !important;
   border-color: var(--fl-dashboard-black);
   box-shadow: none !important;
 }
@@ -4903,25 +4898,38 @@ body:has(.fiber-link-dashboard) .profiler-results {
   }
 }
 
-/* Creator dashboard visual reconciliation: keep the richer analytics structure, but
-   bring the page back toward Discourse's calmer plugin surface. */
+/* Creator dashboard visual reconciliation: keep the richer analytics structure,
+   but inherit the active Discourse theme instead of painting a separate app skin. */
 .fiber-link-dashboard {
-  --fiber-link-dashboard-bg: #fbfaf6;
-  --fiber-link-panel-bg: rgba(255, 253, 247, 0.86);
-  --fiber-link-panel-border: rgba(31, 31, 28, 0.1);
-  --fiber-link-accent-soft: rgba(213, 232, 92, 0.34);
+  --fl-dashboard-black: var(--primary, #222);
+  --fl-dashboard-ink: var(--primary-high, var(--primary, #222));
+  --fl-dashboard-muted: var(--primary-medium, #666);
+  --fl-dashboard-faint: var(--primary-medium, #777);
+  --fl-dashboard-line: var(--primary-low, rgba(0, 0, 0, 0.12));
+  --fl-dashboard-chalk: var(--primary-low, rgba(0, 0, 0, 0.12));
+  --fl-dashboard-powder: transparent;
+  --fl-dashboard-cream: transparent;
+  --fl-dashboard-chart: var(--tertiary, var(--primary, #222));
+  --fl-dashboard-copper: var(--primary-high, var(--primary, #222));
+  --fl-dashboard-blue: var(--tertiary, var(--primary, #222));
+  --fl-dashboard-green: var(--success, var(--primary, #222));
+  --fl-dashboard-red: var(--danger, var(--primary, #222));
+  --fl-dashboard-bg: transparent;
+  --fl-dashboard-sans: inherit;
+  background: transparent !important;
+  color: var(--fl-dashboard-black);
+  font-family: inherit;
 }
 
-.fiber-link-dashboard__hero {
-  background:
-    linear-gradient(135deg, rgba(255, 253, 240, 0.88), rgba(250, 246, 238, 0.72)),
-    radial-gradient(circle at 18% 12%, rgba(214, 232, 95, 0.24), transparent 34%);
-  border: 1px solid rgba(27, 28, 24, 0.08);
-  box-shadow: none;
+.fiber-link-dashboard,
+.fiber-link-dashboard * {
+  letter-spacing: 0;
 }
 
-.fiber-link-dashboard__hero-copy h1 {
-  letter-spacing: -0.065em;
+.fiber-link-dashboard::before,
+.fiber-link-analytics::before,
+.fiber-link-analytics::after {
+  display: none;
 }
 
 .fiber-link-dashboard__metrics,
@@ -4932,61 +4940,143 @@ body:has(.fiber-link-dashboard) .profiler-results {
   z-index: 1;
 }
 
+.fiber-link-dashboard__hero,
+.fiber-link-dashboard__asset-balance-card,
+.fiber-link-dashboard__flow,
+.fiber-link-analytics,
+.fiber-link-analytics__range-control,
+.fiber-link-analytics__scope-control,
+.fiber-link-analytics__proof-strip span,
+.fiber-link-analytics__loading,
+.fiber-link-analytics__empty,
+.fiber-link-analytics__brief,
+.fiber-link-analytics__actions article,
+.fiber-link-analytics__chart-card,
+.fiber-link-analytics__rank-card,
+.fiber-link-analytics__withdrawals,
+.fiber-link-analytics__freshness,
+.fiber-link-analytics__rank-evidence,
+.fiber-link-analytics__status {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.fiber-link-dashboard__hero,
+.fiber-link-analytics {
+  border-color: var(--fl-dashboard-line) !important;
+}
+
 .fiber-link-dashboard__asset-balances {
   margin-block: 18px 28px;
   padding-block: 4px 0;
 }
 
-.fiber-link-dashboard__asset-balance-card {
-  background: rgba(255, 255, 255, 0.68);
-  border: 1px solid rgba(27, 28, 24, 0.08);
+.fiber-link-dashboard__asset-balance-card,
+.fiber-link-analytics__range-control,
+.fiber-link-analytics__scope-control,
+.fiber-link-analytics__proof-strip span,
+.fiber-link-analytics__loading,
+.fiber-link-analytics__empty,
+.fiber-link-analytics__actions article,
+.fiber-link-analytics__chart-card,
+.fiber-link-analytics__rank-card,
+.fiber-link-analytics__withdrawals,
+.fiber-link-analytics__freshness,
+.fiber-link-analytics__rank-evidence,
+.fiber-link-analytics__status {
+  border-color: var(--fl-dashboard-line) !important;
 }
 
 .fiber-link-dashboard__flow {
-  margin-block: 0 26px;
-  border: 1px solid rgba(27, 28, 24, 0.1);
-  background: rgba(255, 255, 255, 0.72);
+  margin-block: 0 32px;
+  border: 1px solid var(--fl-dashboard-line);
 }
 
 .fiber-link-dashboard__flow a,
+.fiber-link-dashboard__flow a:visited,
 .fiber-link-dashboard__flow .active,
-.fiber-link-dashboard__flow [aria-current="page"] {
-  background: transparent;
-  color: #1e1f1b;
+.fiber-link-dashboard__flow [aria-current="page"],
+.fiber-link-dashboard__flow a[data-flow-primary],
+.fiber-link-dashboard__flow a[data-flow-primary]:visited {
+  background: transparent !important;
+  color: var(--fl-dashboard-muted) !important;
+  box-shadow: none !important;
 }
 
 .fiber-link-dashboard__flow a:hover,
+.fiber-link-dashboard__flow a:focus-visible {
+  background: transparent !important;
+  color: var(--fl-dashboard-black) !important;
+}
+
+.fiber-link-dashboard__flow a[data-flow-primary],
 .fiber-link-dashboard__flow .active,
 .fiber-link-dashboard__flow [aria-current="page"] {
-  background: rgba(213, 232, 92, 0.24);
-  box-shadow: inset 0 0 0 1px rgba(27, 28, 24, 0.1);
+  color: var(--fl-dashboard-black) !important;
+  box-shadow: inset 0 -2px 0 var(--fl-dashboard-black) !important;
+}
+
+.fiber-link-dashboard__flow a[data-flow-primary] strong {
+  color: var(--fl-dashboard-muted);
 }
 
 .fiber-link-analytics {
-  background:
-    linear-gradient(180deg, rgba(255, 253, 247, 0.94), rgba(255, 255, 255, 0.92)),
-    radial-gradient(circle at 92% 8%, rgba(213, 232, 92, 0.22), transparent 26%);
-  border-color: rgba(27, 28, 24, 0.1);
-  box-shadow: 0 18px 44px rgba(38, 35, 25, 0.08);
+  overflow: visible;
 }
 
-.fiber-link-analytics::before,
-.fiber-link-analytics::after {
-  opacity: 0.38;
+.fiber-link-analytics__eyebrow::before,
+.fiber-link-analytics__proof-strip span::before,
+.fiber-link-dashboard__live > span,
+.fiber-link-dashboard__live > span::after,
+.fiber-link-dashboard__live > span::before {
+  box-shadow: none !important;
 }
 
-.fiber-link-analytics__title {
-  letter-spacing: -0.06em;
+.fiber-link-analytics__brief {
+  color: var(--fl-dashboard-black);
 }
 
-.fiber-link-analytics__control-panel {
-  background: rgba(255, 255, 255, 0.72);
-  border-color: rgba(27, 28, 24, 0.1);
+.fiber-link-analytics__brief span,
+.fiber-link-analytics__brief p {
+  color: var(--fl-dashboard-muted);
 }
 
-.fiber-link-analytics__proof-chip {
-  background: rgba(255, 255, 255, 0.76);
-  border-color: rgba(27, 28, 24, 0.1);
+.fiber-link-analytics__brief strong {
+  color: var(--fl-dashboard-black);
+}
+
+.fiber-link-analytics__bar-fill {
+  background: var(--fl-dashboard-black);
+  box-shadow: none;
+}
+
+.fiber-link-analytics__bar-row.is-peak .fiber-link-analytics__bar-track::after {
+  color: var(--secondary, #fff);
+}
+
+.fiber-link-dashboard .fiber-link-dashboard__withdrawal-submit,
+.fiber-link-dashboard .fiber-link-dashboard__withdrawal-submit:hover,
+.fiber-link-dashboard .fiber-link-filter-chip.is-active,
+.fiber-link-dashboard .fiber-link-filter-chip.is-active:hover,
+.fiber-link-dashboard .fiber-link-transaction-dialog__explorer-link,
+.fiber-link-dashboard .fiber-link-transaction-dialog__explorer-link:link,
+.fiber-link-dashboard .fiber-link-transaction-dialog__explorer-link:visited,
+.fiber-link-dashboard .fiber-link-transaction-dialog__explorer-link:hover,
+.fiber-link-dashboard .fiber-link-transaction-dialog__explorer-link:focus-visible {
+  background: var(--fl-dashboard-black) !important;
+  color: var(--secondary, #fff) !important;
+}
+
+.fiber-link-dashboard :is(a, button, .btn, input, select, textarea):focus-visible,
+.fiber-link-tip-feed-row:focus-visible,
+.fiber-link-dashboard .fiber-link-transaction-dialog__close:focus-visible,
+.fiber-link-dashboard .fiber-link-transaction-dialog__copy:focus-visible {
+  outline: 2px solid var(--tertiary, var(--fl-dashboard-black)) !important;
+  outline-offset: 3px;
+}
+
+.fiber-link-dashboard :is(input, select, textarea):focus-visible {
+  border-color: var(--fl-dashboard-black) !important;
 }
 
 @media (max-width: 760px) {
@@ -4997,36 +5087,4 @@ body:has(.fiber-link-dashboard) .profiler-results {
   .fiber-link-dashboard__flow {
     margin-block-end: 22px;
   }
-
-  .fiber-link-dashboard__hero,
-  .fiber-link-analytics {
-    border-radius: 24px;
-  }
-}
-
-/* Hard override for Discourse dev CSS cache/order: the flow rail must never climb
-   into the per-asset balance row. */
-.fiber-link-dashboard > .fiber-link-dashboard__asset-balances {
-  margin-top: 18px !important;
-  margin-bottom: 28px !important;
-}
-
-.fiber-link-dashboard > .fiber-link-dashboard__flow {
-  margin-top: 0 !important;
-  margin-bottom: 32px !important;
-  background: rgba(255, 255, 255, 0.72) !important;
-  border: 1px solid rgba(27, 28, 24, 0.1) !important;
-}
-
-.fiber-link-dashboard > .fiber-link-dashboard__flow a,
-.fiber-link-dashboard > .fiber-link-dashboard__flow [aria-current="page"],
-.fiber-link-dashboard > .fiber-link-dashboard__flow .active {
-  background: transparent !important;
-  color: #1e1f1b !important;
-}
-
-.fiber-link-dashboard > .fiber-link-dashboard__flow a:hover,
-.fiber-link-dashboard > .fiber-link-dashboard__flow [aria-current="page"],
-.fiber-link-dashboard > .fiber-link-dashboard__flow .active {
-  background: rgba(213, 232, 92, 0.24) !important;
 }

--- a/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
+++ b/fiber-link-discourse-plugin/assets/stylesheets/common/fiber-link.scss
@@ -1687,12 +1687,18 @@ body:has(.fiber-link-dashboard) .profiler-results {
   --fl-dashboard-line: #ebe9e5;
   --fl-dashboard-chalk: #e5e5e5;
   --fl-dashboard-powder: #f5f3f1;
+  --fl-dashboard-cream: #fff8ea;
+  --fl-dashboard-chart: #d7f26b;
+  --fl-dashboard-copper: #b86f2e;
+  --fl-dashboard-blue: #204f63;
   --fl-dashboard-green: #1f6f4a;
   --fl-dashboard-red: #8a1f1f;
   --fl-dashboard-bg: transparent;
   --fl-dashboard-sans:
-    "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+    "Avenir Next", "Gill Sans", "Trebuchet MS", ui-sans-serif, sans-serif;
   --fl-dashboard-mono: "JetBrains Mono", ui-monospace, Menlo, Monaco, monospace;
+  position: relative;
+  isolation: isolate;
   box-sizing: border-box;
   display: block;
   width: 100%;
@@ -1704,6 +1710,20 @@ body:has(.fiber-link-dashboard) .profiler-results {
   font-family: var(--fl-dashboard-sans);
   -webkit-font-smoothing: antialiased;
   font-feature-settings: "kern" 1;
+}
+
+.fiber-link-dashboard::before {
+  content: "";
+  position: absolute;
+  inset: 24px -32px auto;
+  z-index: -1;
+  height: 460px;
+  border-radius: 48px;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(215, 242, 107, 0.28), transparent 32%),
+    radial-gradient(circle at 82% 8%, rgba(184, 111, 46, 0.18), transparent 28%),
+    linear-gradient(135deg, rgba(255, 248, 234, 0.78), rgba(245, 243, 241, 0));
+  pointer-events: none;
 }
 
 .fiber-link-dashboard button,
@@ -3119,6 +3139,12 @@ body:has(.fiber-link-dashboard) .profiler-results {
   gap: 0;
 }
 
+.fiber-link-dashboard__withdrawal-anchor {
+  display: grid;
+  min-width: 0;
+  scroll-margin-top: 32px;
+}
+
 .fiber-link-dashboard__section-kicker {
   gap: 10px;
   margin-bottom: 20px;
@@ -3559,13 +3585,1084 @@ body:has(.fiber-link-dashboard) .profiler-results {
   line-height: normal;
 }
 
+.fiber-link-dashboard__flow {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  margin: -34px 0 44px;
+  border-top: 1px solid var(--fl-dashboard-line);
+  border-bottom: 1px solid var(--fl-dashboard-line);
+}
+
+.fiber-link-dashboard__flow a,
+.fiber-link-dashboard__flow a:visited {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 54px;
+  padding: 0 18px;
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.fiber-link-dashboard__flow a + a {
+  border-left: 1px solid var(--fl-dashboard-line);
+}
+
+.fiber-link-dashboard__flow strong {
+  color: var(--fl-dashboard-faint);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.fiber-link-dashboard__flow a:hover,
+.fiber-link-dashboard__flow a:focus-visible {
+  background: rgba(0, 0, 0, 0.045);
+  color: var(--fl-dashboard-black);
+  outline: none;
+}
+
+.fiber-link-dashboard__flow a:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--fl-dashboard-black);
+}
+
+.fiber-link-dashboard__flow a[data-flow-primary],
+.fiber-link-dashboard__flow a[data-flow-primary]:visited {
+  background: var(--fl-dashboard-black);
+  color: #fdfcfc;
+}
+
+.fiber-link-dashboard__flow a[data-flow-primary]:hover,
+.fiber-link-dashboard__flow a[data-flow-primary]:focus-visible {
+  background: var(--fl-dashboard-black);
+  color: #fdfcfc;
+}
+
+.fiber-link-dashboard__flow a[data-flow-primary] strong {
+  color: rgba(253, 252, 252, 0.58);
+}
+
+.fiber-link-dashboard__metrics,
+.fiber-link-analytics,
+.fiber-link-dashboard__activity {
+  scroll-margin-top: 32px;
+}
+
+.fiber-link-analytics {
+  position: relative;
+  display: grid;
+  gap: 28px;
+  margin: -28px 0 72px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 32px;
+  padding: 30px;
+  background:
+    linear-gradient(135deg, rgba(255, 248, 234, 0.94), rgba(253, 252, 252, 0.88)),
+    radial-gradient(circle at 8% 0%, rgba(215, 242, 107, 0.42), transparent 34%);
+  box-shadow:
+    0 24px 80px rgba(40, 34, 24, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.82);
+  overflow: hidden;
+  animation: fiber-link-analytics-rise 0.55s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.fiber-link-analytics.is-stale {
+  border-color: rgba(184, 111, 46, 0.28);
+}
+
+.fiber-link-analytics::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.035) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.55), transparent 68%);
+  pointer-events: none;
+}
+
+.fiber-link-analytics::after {
+  content: "";
+  position: absolute;
+  top: -70px;
+  right: -48px;
+  width: 220px;
+  height: 220px;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 50%;
+  background: rgba(215, 242, 107, 0.22);
+  pointer-events: none;
+}
+
+@keyframes fiber-link-analytics-rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes fiber-link-analytics-section-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fiber-link-analytics > * {
+  position: relative;
+  z-index: 1;
+}
+
+.fiber-link-analytics__masthead,
+.fiber-link-analytics__proof-strip,
+.fiber-link-analytics__error,
+.fiber-link-analytics__loading,
+.fiber-link-analytics__kpis,
+.fiber-link-analytics__brief,
+.fiber-link-analytics__next-head,
+.fiber-link-analytics__actions,
+.fiber-link-analytics__body,
+.fiber-link-analytics__withdrawals,
+.fiber-link-analytics__empty {
+  animation: fiber-link-analytics-section-reveal 0.48s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.fiber-link-analytics__proof-strip {
+  animation-delay: 0.04s;
+}
+
+.fiber-link-analytics__error,
+.fiber-link-analytics__loading,
+.fiber-link-analytics__kpis {
+  animation-delay: 0.08s;
+}
+
+.fiber-link-analytics__brief {
+  animation-delay: 0.12s;
+}
+
+.fiber-link-analytics__next-head,
+.fiber-link-analytics__actions {
+  animation-delay: 0.16s;
+}
+
+.fiber-link-analytics__body,
+.fiber-link-analytics__withdrawals {
+  animation-delay: 0.2s;
+}
+
+.fiber-link-analytics__masthead {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 32px;
+  align-items: start;
+}
+
+.fiber-link-analytics__headline {
+  display: grid;
+  gap: 12px;
+  max-width: 680px;
+}
+
+.fiber-link-analytics__eyebrow,
+.fiber-link-analytics__range-control span,
+.fiber-link-analytics__scope-control span,
+.fiber-link-analytics__section-head,
+.fiber-link-analytics__kpis article span,
+.fiber-link-analytics__withdrawals li > span {
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.fiber-link-analytics__eyebrow::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--fl-dashboard-chart);
+  box-shadow: 0 0 0 5px rgba(215, 242, 107, 0.26);
+}
+
+.fiber-link-analytics__title {
+  max-width: 600px;
+  margin: 0;
+  color: var(--fl-dashboard-black);
+  font-size: clamp(32px, 4vw, 54px);
+  font-weight: 620;
+  line-height: 0.96;
+  letter-spacing: -0.05em;
+}
+
+.fiber-link-analytics__headline p {
+  max-width: 560px;
+  margin: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+.fiber-link-analytics__controls {
+  display: grid;
+  gap: 10px;
+  min-width: 168px;
+}
+
+.fiber-link-analytics__range-control,
+.fiber-link-analytics__scope-control {
+  display: grid;
+  gap: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 22px;
+  padding: 14px 16px;
+  background: rgba(253, 252, 252, 0.62);
+}
+
+.fiber-link-analytics__range-control {
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.fiber-link-analytics__range-control:hover,
+.fiber-link-analytics__range-control:focus-within {
+  border-color: rgba(0, 0, 0, 0.28);
+  background: rgba(253, 252, 252, 0.82);
+  box-shadow: 0 10px 28px rgba(40, 34, 24, 0.08);
+}
+
+.fiber-link-analytics__scope-control {
+  cursor: default;
+}
+
+.fiber-link-analytics__scope-control strong {
+  color: var(--fl-dashboard-black);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.fiber-link-analytics__range {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  border: 0;
+  border-radius: 0;
+  padding: 0 18px 0 0;
+  background:
+    linear-gradient(45deg, transparent 50%, var(--fl-dashboard-black) 50%) right 6px top 44% / 6px 6px no-repeat,
+    transparent;
+  color: var(--fl-dashboard-black);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.fiber-link-analytics__range-control em {
+  color: var(--fl-dashboard-muted);
+  font-size: 11px;
+  font-style: normal;
+  line-height: 1.25;
+}
+
+.fiber-link-analytics__range:focus-visible {
+  outline: 2px solid var(--fl-dashboard-black);
+  outline-offset: 4px;
+}
+
+.fiber-link-analytics__proof-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.fiber-link-analytics__proof-strip span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 999px;
+  padding: 0 12px;
+  background: rgba(253, 252, 252, 0.56);
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.07em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__proof-strip span::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--fl-dashboard-chart);
+}
+
+.fiber-link-analytics__loading,
+.fiber-link-analytics__empty {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 92px;
+  border: 1px dashed rgba(0, 0, 0, 0.18);
+  border-radius: 24px;
+  padding: 20px;
+  background: rgba(253, 252, 252, 0.56);
+  color: var(--fl-dashboard-muted);
+  font-size: 14px;
+}
+
+.fiber-link-analytics__loading.is-inline {
+  min-height: 0;
+  border-style: solid;
+  border-color: rgba(32, 79, 99, 0.16);
+  padding: 12px 14px;
+  background: rgba(215, 242, 107, 0.12);
+  color: var(--fl-dashboard-blue);
+}
+
+.fiber-link-analytics__loading em {
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  font-style: normal;
+}
+
+.fiber-link-analytics__loading span {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  background: var(--fl-dashboard-chart);
+  animation: fiber-link-analytics-pulse 1.1s ease-in-out infinite;
+}
+
+.fiber-link-analytics__error {
+  display: grid;
+  grid-template-columns: minmax(140px, auto) minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+  border: 1px solid rgba(138, 31, 31, 0.18);
+  border-radius: 24px;
+  padding: 16px;
+  background: rgba(138, 31, 31, 0.055);
+}
+
+.fiber-link-analytics__error span {
+  color: var(--fl-dashboard-red);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__error p {
+  margin: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.fiber-link-dashboard .fiber-link-analytics__error button {
+  min-height: 36px;
+  border: 1px solid rgba(138, 31, 31, 0.28);
+  border-radius: 999px;
+  padding: 0 14px;
+  background: rgba(253, 252, 252, 0.72);
+  color: var(--fl-dashboard-red);
+  font-size: 13px;
+  font-weight: 620;
+  white-space: nowrap;
+}
+
+.fiber-link-dashboard .fiber-link-analytics__error button:hover,
+.fiber-link-dashboard .fiber-link-analytics__error button:focus-visible {
+  border-color: var(--fl-dashboard-red);
+  background: rgba(253, 252, 252, 0.92);
+  color: var(--fl-dashboard-red);
+  outline: none;
+}
+
+@keyframes fiber-link-analytics-pulse {
+  0%,
+  100% {
+    opacity: 0.32;
+    transform: scale(0.7);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.fiber-link-analytics__empty {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.fiber-link-analytics__empty strong {
+  color: var(--fl-dashboard-black);
+  font-size: 18px;
+  font-weight: 620;
+}
+
+.fiber-link-analytics__empty span {
+  max-width: 560px;
+}
+
+.fiber-link-analytics__empty.is-compact {
+  min-height: 0;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.fiber-link-analytics__kpis {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.fiber-link-analytics__kpis article {
+  display: grid;
+  gap: 10px;
+  padding: 20px 24px 20px 0;
+}
+
+.fiber-link-analytics__kpis article + article {
+  border-left: 1px solid rgba(0, 0, 0, 0.12);
+  padding-left: 24px;
+}
+
+.fiber-link-analytics__kpis strong {
+  color: var(--fl-dashboard-black);
+  font-size: clamp(25px, 3vw, 38px);
+  font-weight: 620;
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+}
+
+.fiber-link-analytics__kpis strong,
+.fiber-link-analytics__freshness strong,
+.fiber-link-analytics__bar-fill,
+.fiber-link-analytics__rank-value,
+.fiber-link-analytics__withdrawal-signal strong {
+  transition: none;
+}
+
+.fiber-link-analytics__kpis em {
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  font-style: normal;
+  line-height: 1.25;
+}
+
+.fiber-link-analytics__brief {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.26fr) minmax(0, 0.9fr) minmax(0, 1fr);
+  gap: 22px;
+  align-items: center;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 28px;
+  padding: 22px 24px;
+  background:
+    linear-gradient(90deg, rgba(0, 0, 0, 0.94), rgba(32, 79, 99, 0.9)),
+    var(--fl-dashboard-black);
+  color: #fdfcfc;
+  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.14);
+}
+
+.fiber-link-analytics__brief span {
+  color: rgba(253, 252, 252, 0.62);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__brief strong {
+  color: #fdfcfc;
+  font-size: clamp(20px, 2.4vw, 29px);
+  font-weight: 620;
+  line-height: 1.04;
+  letter-spacing: -0.045em;
+}
+
+.fiber-link-analytics__brief p {
+  margin: 0;
+  color: rgba(253, 252, 252, 0.72);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.fiber-link-analytics__next-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: -10px;
+}
+
+.fiber-link-analytics__next-head span {
+  color: var(--fl-dashboard-black);
+  font-size: 22px;
+  font-weight: 640;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.fiber-link-analytics__next-head p {
+  max-width: 460px;
+  margin: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  text-align: right;
+}
+
+.fiber-link-analytics__actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.fiber-link-analytics__actions article {
+  display: grid;
+  gap: 9px;
+  align-content: start;
+  min-height: 158px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 24px;
+  padding: 18px;
+  background:
+    linear-gradient(145deg, rgba(253, 252, 252, 0.7), rgba(255, 248, 234, 0.54)),
+    rgba(255, 255, 255, 0.4);
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    transform 0.18s ease;
+}
+
+.fiber-link-analytics__actions article:hover,
+.fiber-link-analytics__actions article:focus-within {
+  border-color: rgba(32, 79, 99, 0.24);
+  box-shadow: 0 16px 38px rgba(40, 34, 24, 0.08);
+  transform: translateY(-2px);
+}
+
+.fiber-link-analytics__actions span {
+  color: var(--fl-dashboard-copper);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__actions strong {
+  min-width: 0;
+  color: var(--fl-dashboard-black);
+  font-size: 21px;
+  font-weight: 640;
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+  overflow-wrap: anywhere;
+}
+
+.fiber-link-analytics__actions em {
+  color: var(--fl-dashboard-muted);
+  font-size: 13px;
+  font-style: normal;
+  line-height: 1.35;
+}
+
+.fiber-link-analytics__actions a,
+.fiber-link-analytics__actions a:visited {
+  align-self: end;
+  width: fit-content;
+  margin-top: 4px;
+  border-bottom: 1px solid currentColor;
+  color: var(--fl-dashboard-black);
+  font-size: 13px;
+  font-weight: 620;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.fiber-link-analytics__actions a:hover,
+.fiber-link-analytics__actions a:focus-visible {
+  color: var(--fl-dashboard-copper);
+  outline: none;
+}
+
+.fiber-link-analytics__actions a:focus-visible {
+  border-radius: 8px;
+  box-shadow: 0 0 0 3px rgba(184, 111, 46, 0.18);
+}
+
+.fiber-link-analytics__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(300px, 0.88fr);
+  gap: 24px;
+  align-items: stretch;
+}
+
+.fiber-link-analytics__chart-card,
+.fiber-link-analytics__rank-card,
+.fiber-link-analytics__withdrawals {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 26px;
+  padding: 22px;
+  background: rgba(253, 252, 252, 0.68);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+.fiber-link-analytics__chart-card {
+  display: grid;
+  grid-template-rows: auto auto auto 1fr;
+  align-self: start;
+  min-height: 0;
+}
+
+.fiber-link-analytics__side {
+  display: grid;
+  gap: 24px;
+}
+
+.fiber-link-analytics__section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 22px;
+}
+
+.fiber-link-analytics__section-head span {
+  color: var(--fl-dashboard-black);
+  font-family: var(--fl-dashboard-sans);
+  font-size: 18px;
+  font-weight: 620;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  text-transform: none;
+}
+
+.fiber-link-analytics__section-head strong {
+  color: var(--fl-dashboard-muted);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.fiber-link-analytics__chart {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+
+.fiber-link-analytics__rhythm-note {
+  margin: -10px 0 24px;
+  color: var(--fl-dashboard-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.fiber-link-analytics__freshness {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  width: fit-content;
+  min-width: min(100%, 320px);
+  margin: -8px 0 20px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 999px;
+  padding: 8px 12px 8px 14px;
+  background: rgba(253, 252, 252, 0.68);
+}
+
+.fiber-link-analytics__freshness span {
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__freshness strong {
+  color: var(--fl-dashboard-black);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.fiber-link-analytics__freshness em {
+  border-radius: 999px;
+  padding: 5px 8px;
+  font-family: var(--fl-dashboard-mono);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__freshness-range {
+  background: rgba(32, 79, 99, 0.09);
+  color: var(--fl-dashboard-blue);
+}
+
+.fiber-link-analytics__freshness-warning {
+  background: rgba(184, 111, 46, 0.12);
+  color: var(--fl-dashboard-copper);
+}
+
+.fiber-link-analytics.is-stale .fiber-link-analytics__freshness {
+  border-color: rgba(184, 111, 46, 0.24);
+  background: rgba(255, 248, 234, 0.8);
+}
+
+.fiber-link-analytics__bar-row {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) minmax(64px, auto);
+  gap: 12px;
+  align-items: center;
+}
+
+.fiber-link-analytics__bar-label,
+.fiber-link-analytics__bar-value {
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.fiber-link-analytics__bar-value {
+  color: var(--fl-dashboard-black);
+  text-align: right;
+}
+
+.fiber-link-analytics__bar-track {
+  position: relative;
+  display: block;
+  height: 16px;
+  border-radius: 999px;
+  background:
+    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.08) 0 1px, transparent 1px 12px),
+    rgba(0, 0, 0, 0.055);
+  overflow: hidden;
+}
+
+.fiber-link-analytics__bar-row.is-peak .fiber-link-analytics__bar-track::after {
+  content: "Peak";
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  color: rgba(253, 252, 252, 0.78);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  text-transform: uppercase;
+  transform: translateY(-50%);
+}
+
+.fiber-link-analytics__bar-row.is-zero .fiber-link-analytics__bar-label,
+.fiber-link-analytics__bar-row.is-zero .fiber-link-analytics__bar-value {
+  color: var(--fl-dashboard-faint);
+}
+
+.fiber-link-analytics__bar-row.is-zero .fiber-link-analytics__bar-track {
+  background:
+    repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.07) 0 1px, transparent 1px 10px),
+    rgba(0, 0, 0, 0.035);
+}
+
+.fiber-link-analytics__bar-row.is-zero .fiber-link-analytics__bar-fill {
+  min-width: 0;
+  opacity: 0;
+}
+
+.fiber-link-analytics__bar-fill {
+  display: block;
+  min-width: 6px;
+  height: 100%;
+  border-radius: inherit;
+  background:
+    linear-gradient(90deg, var(--fl-dashboard-black), var(--fl-dashboard-blue) 62%, var(--fl-dashboard-chart));
+  box-shadow: 0 0 18px rgba(215, 242, 107, 0.32);
+}
+
+.fiber-link-analytics__rank-list,
+.fiber-link-analytics__withdrawals ol {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.fiber-link-analytics__rank-list li {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) minmax(98px, auto);
+  gap: 8px 12px;
+  align-items: baseline;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  padding-bottom: 12px;
+}
+
+.fiber-link-analytics__rank-list li:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.fiber-link-analytics__rank-index {
+  grid-row: span 2;
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--fl-dashboard-black);
+  color: #fdfcfc !important;
+  font-family: var(--fl-dashboard-mono) !important;
+  letter-spacing: 0 !important;
+}
+
+.fiber-link-analytics__rank-main,
+.fiber-link-analytics__rank-main:visited {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  color: var(--fl-dashboard-black);
+  font-size: 15px;
+  font-weight: 620;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.fiber-link-analytics__rank-main em {
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__rank-main:hover,
+.fiber-link-analytics__rank-main:focus-visible {
+  color: var(--fl-dashboard-copper);
+  outline: none;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.fiber-link-analytics__rank-main:focus-visible {
+  border-radius: 10px;
+  box-shadow: 0 0 0 3px rgba(184, 111, 46, 0.18);
+}
+
+.fiber-link-analytics__rank-main:hover em,
+.fiber-link-analytics__rank-main:focus-visible em {
+  color: var(--fl-dashboard-copper);
+}
+
+.fiber-link-analytics__rank-evidence {
+  justify-self: start;
+  width: fit-content;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 999px;
+  padding: 4px 8px;
+  background: rgba(253, 252, 252, 0.5);
+  color: var(--fl-dashboard-muted);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.07em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.fiber-link-analytics__rank-value {
+  grid-column: 3;
+  grid-row: 1 / span 2;
+  align-self: center;
+  color: var(--fl-dashboard-black);
+  font-family: var(--fl-dashboard-mono);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.fiber-link-analytics__rank-more {
+  margin: 16px 0 0;
+  border-top: 1px dashed rgba(0, 0, 0, 0.14);
+  padding-top: 14px;
+  color: var(--fl-dashboard-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.fiber-link-analytics__mono {
+  min-width: 0;
+  color: var(--fl-dashboard-black) !important;
+  font-family: var(--fl-dashboard-mono) !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+  overflow-wrap: anywhere;
+}
+
+.fiber-link-analytics__withdrawals {
+  padding-bottom: 22px;
+}
+
+.fiber-link-analytics__withdrawal-signal {
+  display: grid;
+  grid-template-columns: minmax(128px, auto) minmax(140px, 0.45fr) minmax(0, 1fr) minmax(0, 0.72fr);
+  gap: 16px;
+  align-items: center;
+}
+
+.fiber-link-analytics__withdrawal-signal strong {
+  color: var(--fl-dashboard-black);
+  font-size: 24px;
+  font-weight: 640;
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.fiber-link-analytics__withdrawal-signal p {
+  margin: 0;
+  color: var(--fl-dashboard-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.fiber-link-analytics__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  min-height: 28px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 999px;
+  padding: 0 12px;
+  background: rgba(255, 255, 255, 0.52);
+  color: var(--fl-dashboard-muted) !important;
+}
+
+.fiber-link-analytics__status::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.fiber-link-analytics__status.is-completed,
+.fiber-link-analytics__status.is-submitted {
+  color: var(--fl-dashboard-green) !important;
+}
+
+.fiber-link-analytics__status.is-failed,
+.fiber-link-analytics__status.is-rejected {
+  color: var(--fl-dashboard-red) !important;
+}
+
+.fiber-link-analytics__status.is-liquidity-pending,
+.fiber-link-analytics__status.is-pending {
+  color: var(--fl-dashboard-copper) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fiber-link-analytics,
+  .fiber-link-analytics__loading span,
+  .fiber-link-analytics__masthead,
+  .fiber-link-analytics__proof-strip,
+  .fiber-link-analytics__error,
+  .fiber-link-analytics__loading,
+  .fiber-link-analytics__kpis,
+  .fiber-link-analytics__brief,
+  .fiber-link-analytics__next-head,
+  .fiber-link-analytics__actions,
+  .fiber-link-analytics__body,
+  .fiber-link-analytics__withdrawals,
+  .fiber-link-analytics__empty {
+    animation: none;
+  }
+
+  .fiber-link-analytics__actions article,
+  .fiber-link-analytics__range-control {
+    transition: none;
+  }
+
+  .fiber-link-analytics__actions article:hover,
+  .fiber-link-analytics__actions article:focus-within {
+    transform: none;
+  }
+}
+
 @media (max-width: 1180px) {
   .fiber-link-dashboard {
     gap: 3rem;
   }
 
   .fiber-link-dashboard__hero,
-  .fiber-link-dashboard__content-grid {
+  .fiber-link-dashboard__content-grid,
+  .fiber-link-analytics__body {
     grid-template-columns: 1fr;
   }
 
@@ -3577,12 +4674,25 @@ body:has(.fiber-link-dashboard) .profiler-results {
   .fiber-link-dashboard__metric + .fiber-link-dashboard__metric {
     padding-inline: 1.4rem;
   }
+
+  .fiber-link-analytics__side {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 860px) {
   .fiber-link-dashboard__metrics,
   .fiber-link-dashboard__withdrawal-summary-grid,
-  .fiber-link-tip-feed-header {
+  .fiber-link-dashboard__flow,
+  .fiber-link-tip-feed-header,
+  .fiber-link-analytics__masthead,
+  .fiber-link-analytics__next-head,
+  .fiber-link-analytics__error,
+  .fiber-link-analytics__kpis,
+  .fiber-link-analytics__brief,
+  .fiber-link-analytics__actions,
+  .fiber-link-analytics__side,
+  .fiber-link-analytics__withdrawal-signal {
     grid-template-columns: 1fr;
   }
 
@@ -3590,9 +4700,30 @@ body:has(.fiber-link-dashboard) .profiler-results {
     white-space: normal;
   }
 
+  .fiber-link-dashboard__hero {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .fiber-link-dashboard::before {
+    inset: 16px 0 auto;
+    border-radius: 28px;
+  }
+
+  .fiber-link-dashboard__sync {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 14px;
+    width: 100%;
+    white-space: normal;
+  }
+
   .fiber-link-dashboard__metric + .fiber-link-dashboard__metric,
   .fiber-link-dashboard__withdrawal-summary-item
-    + .fiber-link-dashboard__withdrawal-summary-item {
+    + .fiber-link-dashboard__withdrawal-summary-item,
+  .fiber-link-dashboard__flow a + a,
+  .fiber-link-analytics__kpis article + article {
     border-left: 0;
     border-top: 1px solid var(--fl-dashboard-line);
     padding-left: 0;
@@ -3611,6 +4742,99 @@ body:has(.fiber-link-dashboard) .profiler-results {
     display: block;
     overflow-x: auto;
     white-space: nowrap;
+  }
+
+  .fiber-link-analytics {
+    gap: 22px;
+    margin-top: 0;
+    border-radius: 24px;
+    padding: 22px;
+  }
+
+  .fiber-link-analytics__proof-strip {
+    gap: 6px;
+  }
+
+  .fiber-link-analytics__proof-strip span {
+    min-height: 28px;
+    padding: 0 10px;
+    font-size: 10px;
+  }
+
+  .fiber-link-analytics__kpis article {
+    padding: 18px 0;
+  }
+
+  .fiber-link-analytics__brief {
+    gap: 14px;
+    padding: 18px;
+  }
+
+  .fiber-link-analytics__actions article {
+    min-height: 0;
+    padding: 16px;
+  }
+
+  .fiber-link-analytics__chart-card,
+  .fiber-link-analytics__rank-card,
+  .fiber-link-analytics__withdrawals {
+    border-radius: 22px;
+    padding: 18px;
+  }
+
+  .fiber-link-analytics__chart-card {
+    min-height: 0;
+  }
+
+  .fiber-link-analytics__freshness {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .fiber-link-analytics__bar-row {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+
+  .fiber-link-analytics__bar-value {
+    grid-column: 2;
+    text-align: left;
+  }
+
+  .fiber-link-analytics__rank-list li {
+    grid-template-columns: 28px minmax(0, 1fr);
+  }
+
+  .fiber-link-analytics__rank-value {
+    grid-column: 2;
+    grid-row: auto;
+    justify-self: start;
+    text-align: left;
+  }
+
+  .fiber-link-analytics__rank-evidence {
+    grid-column: 2;
+  }
+
+  .fiber-link-dashboard__flow {
+    margin: -24px 0 32px;
+  }
+
+  .fiber-link-dashboard__flow a {
+    padding: 0;
+  }
+
+  .fiber-link-analytics__next-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .fiber-link-analytics__next-head p {
+    text-align: left;
+  }
+
+  .fiber-link-analytics__controls {
+    width: 100%;
   }
 }
 
@@ -3677,4 +4901,132 @@ body:has(.fiber-link-dashboard) .profiler-results {
   .fiber-link-tip-footer__secondary > * {
     width: 100%;
   }
+}
+
+/* Creator dashboard visual reconciliation: keep the richer analytics structure, but
+   bring the page back toward Discourse's calmer plugin surface. */
+.fiber-link-dashboard {
+  --fiber-link-dashboard-bg: #fbfaf6;
+  --fiber-link-panel-bg: rgba(255, 253, 247, 0.86);
+  --fiber-link-panel-border: rgba(31, 31, 28, 0.1);
+  --fiber-link-accent-soft: rgba(213, 232, 92, 0.34);
+}
+
+.fiber-link-dashboard__hero {
+  background:
+    linear-gradient(135deg, rgba(255, 253, 240, 0.88), rgba(250, 246, 238, 0.72)),
+    radial-gradient(circle at 18% 12%, rgba(214, 232, 95, 0.24), transparent 34%);
+  border: 1px solid rgba(27, 28, 24, 0.08);
+  box-shadow: none;
+}
+
+.fiber-link-dashboard__hero-copy h1 {
+  letter-spacing: -0.065em;
+}
+
+.fiber-link-dashboard__metrics,
+.fiber-link-dashboard__asset-balances,
+.fiber-link-dashboard__flow,
+.fiber-link-dashboard__content-grid {
+  position: relative;
+  z-index: 1;
+}
+
+.fiber-link-dashboard__asset-balances {
+  margin-block: 18px 28px;
+  padding-block: 4px 0;
+}
+
+.fiber-link-dashboard__asset-balance-card {
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(27, 28, 24, 0.08);
+}
+
+.fiber-link-dashboard__flow {
+  margin-block: 0 26px;
+  border: 1px solid rgba(27, 28, 24, 0.1);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.fiber-link-dashboard__flow a,
+.fiber-link-dashboard__flow .active,
+.fiber-link-dashboard__flow [aria-current="page"] {
+  background: transparent;
+  color: #1e1f1b;
+}
+
+.fiber-link-dashboard__flow a:hover,
+.fiber-link-dashboard__flow .active,
+.fiber-link-dashboard__flow [aria-current="page"] {
+  background: rgba(213, 232, 92, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(27, 28, 24, 0.1);
+}
+
+.fiber-link-analytics {
+  background:
+    linear-gradient(180deg, rgba(255, 253, 247, 0.94), rgba(255, 255, 255, 0.92)),
+    radial-gradient(circle at 92% 8%, rgba(213, 232, 92, 0.22), transparent 26%);
+  border-color: rgba(27, 28, 24, 0.1);
+  box-shadow: 0 18px 44px rgba(38, 35, 25, 0.08);
+}
+
+.fiber-link-analytics::before,
+.fiber-link-analytics::after {
+  opacity: 0.38;
+}
+
+.fiber-link-analytics__title {
+  letter-spacing: -0.06em;
+}
+
+.fiber-link-analytics__control-panel {
+  background: rgba(255, 255, 255, 0.72);
+  border-color: rgba(27, 28, 24, 0.1);
+}
+
+.fiber-link-analytics__proof-chip {
+  background: rgba(255, 255, 255, 0.76);
+  border-color: rgba(27, 28, 24, 0.1);
+}
+
+@media (max-width: 760px) {
+  .fiber-link-dashboard__asset-balances {
+    margin-block: 16px 22px;
+  }
+
+  .fiber-link-dashboard__flow {
+    margin-block-end: 22px;
+  }
+
+  .fiber-link-dashboard__hero,
+  .fiber-link-analytics {
+    border-radius: 24px;
+  }
+}
+
+/* Hard override for Discourse dev CSS cache/order: the flow rail must never climb
+   into the per-asset balance row. */
+.fiber-link-dashboard > .fiber-link-dashboard__asset-balances {
+  margin-top: 18px !important;
+  margin-bottom: 28px !important;
+}
+
+.fiber-link-dashboard > .fiber-link-dashboard__flow {
+  margin-top: 0 !important;
+  margin-bottom: 32px !important;
+  background: rgba(255, 255, 255, 0.72) !important;
+  border: 1px solid rgba(27, 28, 24, 0.1) !important;
+}
+
+.fiber-link-dashboard > .fiber-link-dashboard__flow a,
+.fiber-link-dashboard > .fiber-link-dashboard__flow [aria-current="page"],
+.fiber-link-dashboard > .fiber-link-dashboard__flow .active {
+  background: transparent !important;
+  color: #1e1f1b !important;
+}
+
+.fiber-link-dashboard > .fiber-link-dashboard__flow a:hover,
+.fiber-link-dashboard > .fiber-link-dashboard__flow [aria-current="page"],
+.fiber-link-dashboard > .fiber-link-dashboard__flow .active {
+  background: rgba(213, 232, 92, 0.24) !important;
 }


### PR DESCRIPTION
## Summary

- Reworks the creator dashboard analytics section into an explanation-first view with range selection, evidence chips, creator brief, suggested next moves, ranking cards, rhythm chart, and withdrawal pressure state.
- Adds the analytics panel to the main Fiber Link dashboard flow while preserving summary, withdrawal, and activity sections.
- Refines the visual direction back toward a calmer Discourse plugin surface: lighter flow rail, reduced glow, softer panel styling, and fixed spacing between asset balances and the navigation rail.
- Fixes dashboard form/accessibility polish by adding stable `name`/`id` attributes to analytics range, auto-refresh, and withdrawal inputs.
- Handles initial analytics loading safely so empty or delayed analytics no longer produce an unhandled promise rejection.

## Validation

- Booted real local Discourse + Fiber Link runtime with Docker.
- Opened `http://127.0.0.1:4200/fiber-link` as `fiber_author`.
- Verified dashboard and analytics render successfully.
- Verified `dashboard.summary` and `dashboard.analytics` return `200`.
- Verified no horizontal overflow on desktop or mobile.
- Verified console has no errors after the latest fix.
- Screenshots:
  - Desktop: `/private/tmp/fiber-link-discourse-dashboard-desktop-fixed.png`
  - Mobile: `/private/tmp/fiber-link-discourse-dashboard-mobile-fixed.png`

## Notes

This is a visual/UX-heavy PR. The analytics data is still empty in the local seed, so the validated state is the empty creator analytics state.
