### PR TITLE
fix: skip check_xhr for the SSE stream endpoint

### DIFF
--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -12,6 +12,9 @@ module ::FiberLink
 
     requires_plugin "fiber-link"
     prepend_before_action :apply_stream_cors_headers, only: [:stream]
+    # EventSource requests are not XHR and accept text/event-stream, so
+    # check_xhr would short-circuit them into the HTML app shell (RenderEmpty).
+    skip_before_action :check_xhr, only: [:stream]
     before_action :ensure_logged_in
 
     ALLOWED_WITHDRAWAL_STATES = ["ALL", "LIQUIDITY_PENDING", "PENDING", "PROCESSING", "RETRY_PENDING", "COMPLETED", "FAILED"].freeze


### PR DESCRIPTION
Root cause of the persistent exit-17 `flow verification failed`: EventSource requests are neither XHR nor JSON-format, so Discourse's `check_xhr` before_action raised `RenderEmpty` and served the Ember app shell (`200 text/html`) instead of the SSE stream. The run evidence confirms it — `streamResponses[0].contentType == "text/html; charset=utf-8"` on both `:4200` and `:9292`, with `sseEvents` empty, on every run since the strict gates landed.

Fix: `skip_before_action :check_xhr, only: [:stream]`. Authentication remains enforced by `ensure_logged_in`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4S5c8kaWfxwfNWAGi9NAw)_