### PR TITLE
docs: re-trigger CI after transient infra failure

### DIFF
--- a/docs/runbooks/realtime-settlement-sse.md
+++ b/docs/runbooks/realtime-settlement-sse.md
@@ -92,3 +92,4 @@ The visual-acceptance harness performs a real CKB withdrawal in phase 5. Occasio
 withdrawal reaches `FAILED` due to transient chain/faucet conditions (exit code 14:
 `withdrawal <id> reached FAILED`). This is unrelated to the SSE settlement path — re-run
 the workflow when phases 1–4 pass and only the withdrawal gate fails.
+# Re-run trigger 20260611T021036Z


### PR DESCRIPTION
Re-trigger CI after transient infrastructure failure (Discourse unicorn restart + Lightning channel needing 13 attempts). No code changes — the `skip_before_action :check_xhr` fix from #459 is the substantive change already on the branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4S5c8kaWfxwfNWAGi9NAw)_