### PR TITLE
fix: extend waitForFunction timeout to 75s for SSE settlement

### DIFF
--- a/scripts/playwright/workflow-flow12.run-code.js
+++ b/scripts/playwright/workflow-flow12.run-code.js
@@ -794,7 +794,7 @@ async (page) => {
           (/Payment complete|Payment received/i).test(badgeText);
       },
       undefined,
-      { timeout: 45_000 },
+      { timeout: 75_000 },
     );
 
     realtimeEvidence.settlement.confirmedAt = Date.now();


### PR DESCRIPTION
With SSE now working correctly, the modal waits up to 60s for a SETTLED event before falling back to polling. The previous 45s `waitForFunction` timeout was shorter than the SSE 60s window — when the Lightning channel takes many retries to become ready and the payment routes slowly, the test timed out before SSE had a chance to deliver SETTLED or trigger the polling fallback.

Extending to 75s clears the SSE 60s window with 15s margin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4S5c8kaWfxwfNWAGi9NAw)_