### PR TITLE
feat(sse): enforce invoice app ownership on /rpc/stream and publish settledAt

### DIFF
--- a/docs/runbooks/realtime-settlement-sse.md
+++ b/docs/runbooks/realtime-settlement-sse.md
@@ -6,9 +6,9 @@ This runbook closes the real-time settlement milestone tracked in [Issue #414](h
 
 1. The Discourse tip modal creates an invoice through the forum RPC proxy.
 2. Once an invoice exists, the modal calls `streamTipStatus(invoice, onEvent)` and opens an `EventSource` against `/fiber-link/rpc/stream?invoice=<id>`.
-3. The Discourse plugin proxies that stream to the backend RPC service endpoint `/rpc/stream?invoice=<id>`.
-4. The backend RPC stream route validates that the invoice exists, subscribes to the Redis channel `fiber-link:settlement:<invoice>`, and emits `LISTENING` once the SSE subscription is ready.
-5. When the worker settles the tip intent and credits the recipient ledger, it publishes `{ invoice, status: "SETTLED" }` to the same Redis channel.
+3. The Discourse plugin proxies that stream to the backend RPC service endpoint `/rpc/stream?invoice=<id>`, attaching the forum's `x-app-id` header.
+4. The backend RPC stream route resolves the requesting app id (`x-app-id` header, or the `appId` query param for direct `EventSource` clients that cannot set headers), validates that the invoice exists and belongs to that app (`401` when no app id is supplied, `403` on ownership mismatch), subscribes to the Redis channel `fiber-link:settlement:<invoice>`, and emits `LISTENING` once the SSE subscription is ready.
+5. When the worker settles the tip intent and credits the recipient ledger, it publishes `{ invoice, status: "SETTLED", settledAt }` to the same Redis channel.
 6. The browser receives the `SETTLED` event, closes the SSE handle, cancels pending status-poll timers, and moves the modal to the confirmation state.
 
 ## Fallback behavior
@@ -17,6 +17,7 @@ Polling is still intentionally available, but only as a fallback path:
 
 - If the browser does not support `EventSource`, the modal starts the existing status polling loop.
 - If the SSE connection times out or emits an error, the modal closes the stream and falls back to polling.
+- If the backend rejects the stream (for example `401`/`403` from the app-ownership check), the Discourse proxy emits a one-shot `SSE_ERROR` event and the modal falls back to polling.
 - If the invoice is already settled when `/rpc/stream` is opened, the RPC service immediately returns a one-shot `SETTLED` SSE response.
 - Worker-side Redis publish failures are non-blocking: settlement and ledger crediting still succeed, and clients can recover through fallback polling.
 

--- a/examples/vanilla-js/index.js
+++ b/examples/vanilla-js/index.js
@@ -87,7 +87,7 @@ document.getElementById("tipBtn").addEventListener("click", async () => {
     // set headers, so the app id rides along as a query param for the
     // backend's invoice-ownership check.
     const streamUrl =
-      endpoint.replace(/\/rpc$/, "/rpc/stream") +
+      endpoint.replace(/\/rpc\/?$/, "/rpc/stream") +
       `?invoice=${encodeURIComponent(invoice)}&appId=${encodeURIComponent(appId)}`;
     let sseHandled = false;
 

--- a/examples/vanilla-js/index.js
+++ b/examples/vanilla-js/index.js
@@ -83,8 +83,12 @@ document.getElementById("tipBtn").addEventListener("click", async () => {
 
     setStatus(`Invoice created: <code>${invoice.slice(0, 40)}…</code><br/>Waiting for payment…`);
 
-    // Try SSE first (requires /rpc/stream on the backend).
-    const streamUrl = endpoint.replace(/\/rpc$/, "/rpc/stream") + `?invoice=${encodeURIComponent(invoice)}`;
+    // Try SSE first (requires /rpc/stream on the backend). EventSource cannot
+    // set headers, so the app id rides along as a query param for the
+    // backend's invoice-ownership check.
+    const streamUrl =
+      endpoint.replace(/\/rpc$/, "/rpc/stream") +
+      `?invoice=${encodeURIComponent(invoice)}&appId=${encodeURIComponent(appId)}`;
     let sseHandled = false;
 
     if (typeof EventSource !== "undefined") {

--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -46,8 +46,17 @@ module ::FiberLink
 
       begin
         backend_url = URI("#{service_url}/rpc/stream?invoice=#{URI.encode_www_form_component(invoice)}")
+        backend_request = Net::HTTP::Get.new(backend_url)
+        # The backend validates that the invoice belongs to this forum's app.
+        backend_request["x-app-id"] = SiteSetting.fiber_link_app_id
         Net::HTTP.start(backend_url.host, backend_url.port, use_ssl: backend_url.scheme == "https", read_timeout: 65) do |http|
-          http.request(Net::HTTP::Get.new(backend_url)) do |resp|
+          http.request(backend_request) do |resp|
+            if resp.code != "200"
+              Rails.logger.warn("Fiber Link SSE stream rejected upstream: HTTP #{resp.code}")
+              response.stream.write("data: #{JSON.generate({ invoice: invoice, status: "SSE_ERROR", reason: "upstream_http_#{resp.code}" })}\n\n")
+              next
+            end
+
             resp.read_body do |chunk|
               break if response.stream.closed?
               response.stream.write(chunk)

--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -45,7 +45,7 @@ module ::FiberLink
       end
 
       begin
-        backend_url = URI("#{service_url}/rpc/stream?invoice=#{URI.encode_www_form_component(invoice)}")
+        backend_url = URI("#{service_url.chomp("/")}/rpc/stream?invoice=#{URI.encode_www_form_component(invoice)}")
         backend_request = Net::HTTP::Get.new(backend_url)
         # The backend validates that the invoice belongs to this forum's app.
         backend_request["x-app-id"] = SiteSetting.fiber_link_app_id
@@ -54,6 +54,7 @@ module ::FiberLink
             if resp.code != "200"
               Rails.logger.warn("Fiber Link SSE stream rejected upstream: HTTP #{resp.code}")
               response.stream.write("data: #{JSON.generate({ invoice: invoice, status: "SSE_ERROR", reason: "upstream_http_#{resp.code}" })}\n\n")
+              response.stream.flush if response.stream.respond_to?(:flush)
               next
             end
 

--- a/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
+++ b/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
@@ -494,4 +494,47 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
       expect(WebMock).not_to have_requested(:post, "https://fiber-link.example/rpc")
     end
   end
+
+  describe "GET /fiber-link/rpc/stream" do
+    it "returns 400 when the invoice param is blank" do
+      sign_in(user)
+
+      get "/fiber-link/rpc/stream"
+
+      expect(response).to have_http_status(:bad_request)
+      expect(JSON.parse(response.body).fetch("error")).to eq("Missing invoice")
+    end
+
+    it "proxies the backend SSE stream with the forum app id header" do
+      sign_in(user)
+
+      stub_request(:get, "https://fiber-link.example/rpc/stream?invoice=inv-1").to_return(
+        status: 200,
+        body: "data: {\"invoice\":\"inv-1\",\"status\":\"SETTLED\"}\n\n",
+        headers: { "Content-Type" => "text/event-stream" },
+      )
+
+      get "/fiber-link/rpc/stream", params: { invoice: "inv-1" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("\"status\":\"SETTLED\"")
+      expect(WebMock).to have_requested(:get, "https://fiber-link.example/rpc/stream?invoice=inv-1")
+        .with(headers: { "x-app-id" => "app1" })
+    end
+
+    it "emits SSE_ERROR when the backend rejects the stream" do
+      sign_in(user)
+
+      stub_request(:get, "https://fiber-link.example/rpc/stream?invoice=inv-foreign").to_return(
+        status: 403,
+        body: { error: "Invoice does not belong to this app" }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      get "/fiber-link/rpc/stream", params: { invoice: "inv-foreign" }
+
+      expect(response.body).to include("\"status\":\"SSE_ERROR\"")
+      expect(response.body).to include("upstream_http_403")
+    end
+  end
 end

--- a/fiber-link-service/apps/rpc/src/stream.test.ts
+++ b/fiber-link-service/apps/rpc/src/stream.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import Fastify from "fastify";
-import { registerStreamRoute } from "./stream";
+import { registerStreamRoute, type StreamInvoiceRecord } from "./stream";
+
+const APP_ID = "app1";
+const APP_HEADERS = { "x-app-id": APP_ID };
+
+function ownedInvoice(invoiceState: string, appId = APP_ID): StreamInvoiceRecord {
+  return { invoiceState, appId };
+}
 
 function buildTestApp(options: {
-  getInvoiceState?: (invoice: string) => Promise<string | null>;
+  getInvoice?: (invoice: string) => Promise<StreamInvoiceRecord | null>;
   createSubscriber?: Parameters<typeof registerStreamRoute>[1]["createSubscriber"];
 }) {
   const app = Fastify({ logger: false });
@@ -35,20 +42,55 @@ function makeMockSubscriber(onSubscribe?: (channel: string) => void) {
 
 describe("GET /rpc/stream", () => {
   it("returns 400 when invoice query param is missing", async () => {
-    const app = buildTestApp({ getInvoiceState: async () => "UNPAID" });
-    const res = await app.inject({ method: "GET", url: "/rpc/stream" });
+    const app = buildTestApp({ getInvoice: async () => ownedInvoice("UNPAID") });
+    const res = await app.inject({ method: "GET", url: "/rpc/stream", headers: APP_HEADERS });
     expect(res.statusCode).toBe(400);
   });
 
+  it("returns 401 when no app id is provided", async () => {
+    const app = buildTestApp({ getInvoice: async () => ownedInvoice("UNPAID") });
+    const res = await app.inject({ method: "GET", url: "/rpc/stream?invoice=inv-1" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 403 when the invoice belongs to a different app", async () => {
+    const app = buildTestApp({ getInvoice: async () => ownedInvoice("UNPAID", "other-app") });
+    const res = await app.inject({
+      method: "GET",
+      url: "/rpc/stream?invoice=inv-foreign",
+      headers: APP_HEADERS,
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({ error: "Invoice does not belong to this app" });
+  });
+
+  it("accepts the app id via the appId query param for EventSource clients", async () => {
+    const app = buildTestApp({ getInvoice: async () => ownedInvoice("SETTLED") });
+    const res = await app.inject({
+      method: "GET",
+      url: `/rpc/stream?invoice=inv-qs&appId=${APP_ID}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"status":"SETTLED"');
+  });
+
   it("returns 404 when invoice is not found", async () => {
-    const app = buildTestApp({ getInvoiceState: async () => null });
-    const res = await app.inject({ method: "GET", url: "/rpc/stream?invoice=missing" });
+    const app = buildTestApp({ getInvoice: async () => null });
+    const res = await app.inject({
+      method: "GET",
+      url: "/rpc/stream?invoice=missing",
+      headers: APP_HEADERS,
+    });
     expect(res.statusCode).toBe(404);
   });
 
   it("returns SETTLED immediately when invoice is already settled", async () => {
-    const app = buildTestApp({ getInvoiceState: async () => "SETTLED" });
-    const res = await app.inject({ method: "GET", url: "/rpc/stream?invoice=inv-settled" });
+    const app = buildTestApp({ getInvoice: async () => ownedInvoice("SETTLED") });
+    const res = await app.inject({
+      method: "GET",
+      url: "/rpc/stream?invoice=inv-settled",
+      headers: APP_HEADERS,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.headers["content-type"]).toMatch(/text\/event-stream/);
     expect(res.body).toContain('"status":"SETTLED"');
@@ -66,11 +108,15 @@ describe("GET /rpc/stream", () => {
     subscriberRef = subscriber;
 
     const app = buildTestApp({
-      getInvoiceState: async () => "UNPAID",
+      getInvoice: async () => ownedInvoice("UNPAID"),
       createSubscriber: () => subscriber as unknown as InstanceType<typeof import("ioredis").default>,
     });
 
-    const res = await app.inject({ method: "GET", url: "/rpc/stream?invoice=inv-1" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/rpc/stream?invoice=inv-1",
+      headers: APP_HEADERS,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain('"status":"LISTENING"');
     expect(res.body).toContain('"status":"SETTLED"');
@@ -81,12 +127,16 @@ describe("GET /rpc/stream", () => {
 
     const app = Fastify({ logger: false });
     registerStreamRoute(app, {
-      getInvoiceState: async () => "UNPAID",
+      getInvoice: async () => ownedInvoice("UNPAID"),
       createSubscriber: () => subscriber as unknown as InstanceType<typeof import("ioredis").default>,
       timeoutMs: 50,
     });
 
-    const res = await app.inject({ method: "GET", url: "/rpc/stream?invoice=inv-timeout" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/rpc/stream?invoice=inv-timeout",
+      headers: APP_HEADERS,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain('"status":"TIMEOUT"');
     expect(subscriber.subscribe).toHaveBeenCalledWith(
@@ -96,8 +146,12 @@ describe("GET /rpc/stream", () => {
   });
 
   it("sets SSE headers on successful connection", async () => {
-    const app = buildTestApp({ getInvoiceState: async () => "SETTLED" });
-    const res = await app.inject({ method: "GET", url: "/rpc/stream?invoice=inv-headers" });
+    const app = buildTestApp({ getInvoice: async () => ownedInvoice("SETTLED") });
+    const res = await app.inject({
+      method: "GET",
+      url: "/rpc/stream?invoice=inv-headers",
+      headers: APP_HEADERS,
+    });
     expect(res.headers["cache-control"]).toBe("no-cache");
     expect(res.headers["access-control-allow-origin"]).toBe("*");
   });
@@ -108,7 +162,7 @@ describe("GET /rpc/stream", () => {
 
     const app = Fastify({ logger: false });
     registerStreamRoute(app, {
-      getInvoiceState: async () => "UNPAID",
+      getInvoice: async () => ownedInvoice("UNPAID"),
       createSubscriber: () => subscriber as unknown as InstanceType<typeof import("ioredis").default>,
       timeoutMs: 5000,
       pollIntervalMs: 20,
@@ -118,7 +172,11 @@ describe("GET /rpc/stream", () => {
       },
     });
 
-    const res = await app.inject({ method: "GET", url: "/rpc/stream?invoice=inv-poll" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/rpc/stream?invoice=inv-poll",
+      headers: APP_HEADERS,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain('"status":"LISTENING"');
     expect(res.body).toContain('"status":"SETTLED"');

--- a/fiber-link-service/apps/rpc/src/stream.test.ts
+++ b/fiber-link-service/apps/rpc/src/stream.test.ts
@@ -74,6 +74,23 @@ describe("GET /rpc/stream", () => {
     expect(res.body).toContain('"status":"SETTLED"');
   });
 
+  it("takes the first value instead of crashing when query params are duplicated", async () => {
+    const seenInvoices: string[] = [];
+    const app = buildTestApp({
+      getInvoice: async (invoice) => {
+        seenInvoices.push(invoice);
+        return ownedInvoice("SETTLED");
+      },
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: `/rpc/stream?invoice=inv-dup&invoice=inv-other&appId=${APP_ID}&appId=other-app`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('"status":"SETTLED"');
+    expect(seenInvoices).toEqual(["inv-dup"]);
+  });
+
   it("returns 404 when invoice is not found", async () => {
     const app = buildTestApp({ getInvoice: async () => null });
     const res = await app.inject({

--- a/fiber-link-service/apps/rpc/src/stream.ts
+++ b/fiber-link-service/apps/rpc/src/stream.ts
@@ -78,20 +78,22 @@ export function registerStreamRoute(
       }
     });
 
+  // Duplicate query params arrive as arrays; take the first value.
+  function firstValue(value: string | string[] | undefined): string {
+    return (Array.isArray(value) ? value[0] : value) ?? "";
+  }
+
   app.get("/rpc/stream", async (req, reply) => {
-    const query = (req.query ?? {}) as Record<string, string>;
-    const invoice = (query.invoice ?? "").trim();
+    const query = (req.query ?? {}) as Record<string, string | string[]>;
+    const invoice = firstValue(query.invoice).trim();
     if (!invoice) {
       return reply.status(400).send({ error: "Missing invoice" });
     }
 
     // Server-side proxies identify via the x-app-id header; browser EventSource
     // clients cannot set headers, so the appId query param is the fallback.
-    const headerAppId = req.headers["x-app-id"];
     const requesterAppId = (
-      (Array.isArray(headerAppId) ? headerAppId[0] : headerAppId) ??
-      query.appId ??
-      ""
+      firstValue(req.headers["x-app-id"]) || firstValue(query.appId)
     ).trim();
     if (!requesterAppId) {
       return reply.status(401).send({ error: "Missing app id" });

--- a/fiber-link-service/apps/rpc/src/stream.ts
+++ b/fiber-link-service/apps/rpc/src/stream.ts
@@ -53,23 +53,25 @@ function removeChannelListener(sub: Redis, channel: string, fn: (msg: string) =>
 
 const POLL_INTERVAL_MS = 800;
 
+export type StreamInvoiceRecord = { invoiceState: string; appId: string };
+
 export function registerStreamRoute(
   app: FastifyInstance,
   options: {
-    getInvoiceState?: (invoice: string) => Promise<string | null>;
+    getInvoice?: (invoice: string) => Promise<StreamInvoiceRecord | null>;
     pollInvoiceStateFn?: (invoice: string) => Promise<string | null>;
     pollIntervalMs?: number;
     createSubscriber?: (redisUrl: string) => Redis;
     timeoutMs?: number;
   } = {},
 ) {
-  const getInvoiceState =
-    options.getInvoiceState ??
-    (async (invoice: string) => {
+  const getInvoice =
+    options.getInvoice ??
+    (async (invoice: string): Promise<StreamInvoiceRecord | null> => {
       try {
         const repo = createDbTipIntentRepo(getDefaultDb());
         const intent = await repo.findByInvoiceOrThrow(invoice);
-        return intent.invoiceState;
+        return { invoiceState: intent.invoiceState, appId: intent.appId };
       } catch (e) {
         if (e instanceof TipIntentNotFoundError) return null;
         throw e;
@@ -77,21 +79,40 @@ export function registerStreamRoute(
     });
 
   app.get("/rpc/stream", async (req, reply) => {
-    const invoice = ((req.query as Record<string, string>)?.invoice ?? "").trim();
+    const query = (req.query ?? {}) as Record<string, string>;
+    const invoice = (query.invoice ?? "").trim();
     if (!invoice) {
       return reply.status(400).send({ error: "Missing invoice" });
     }
 
-    let currentState: string | null;
+    // Server-side proxies identify via the x-app-id header; browser EventSource
+    // clients cannot set headers, so the appId query param is the fallback.
+    const headerAppId = req.headers["x-app-id"];
+    const requesterAppId = (
+      (Array.isArray(headerAppId) ? headerAppId[0] : headerAppId) ??
+      query.appId ??
+      ""
+    ).trim();
+    if (!requesterAppId) {
+      return reply.status(401).send({ error: "Missing app id" });
+    }
+
+    let intent: StreamInvoiceRecord | null;
     try {
-      currentState = await getInvoiceState(invoice);
+      intent = await getInvoice(invoice);
     } catch {
       return reply.status(503).send({ error: "Stream temporarily unavailable" });
     }
 
-    if (currentState === null) {
+    if (intent === null) {
       return reply.status(404).send({ error: "Invoice not found" });
     }
+
+    if (intent.appId !== requesterAppId) {
+      return reply.status(403).send({ error: "Invoice does not belong to this app" });
+    }
+
+    const currentState = intent.invoiceState;
 
     if (currentState === "SETTLED") {
       reply.raw.setHeader("Content-Type", "text/event-stream");

--- a/fiber-link-service/apps/worker/src/settlement-publisher.test.ts
+++ b/fiber-link-service/apps/worker/src/settlement-publisher.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  NoopSettlementPublisher,
+  RedisSettlementPublisher,
+  createSettlementPublisher,
+} from "./settlement-publisher";
+
+describe("RedisSettlementPublisher", () => {
+  it("publishes the SETTLED payload to the per-invoice channel", async () => {
+    const redisPublish = vi.fn().mockResolvedValue(1);
+    const publisher = new RedisSettlementPublisher(redisPublish);
+    const settledAt = new Date("2026-06-11T12:00:00.000Z");
+
+    await publisher.publish("inv-42", { settledAt });
+
+    expect(redisPublish).toHaveBeenCalledOnce();
+    expect(redisPublish).toHaveBeenCalledWith(
+      "fiber-link:settlement:inv-42",
+      JSON.stringify({
+        invoice: "inv-42",
+        status: "SETTLED",
+        settledAt: "2026-06-11T12:00:00.000Z",
+      }),
+    );
+  });
+
+  it("defaults settledAt to the publish time when not provided", async () => {
+    const redisPublish = vi.fn().mockResolvedValue(1);
+    const publisher = new RedisSettlementPublisher(redisPublish);
+
+    const before = Date.now();
+    await publisher.publish("inv-now");
+    const after = Date.now();
+
+    const payload = JSON.parse(redisPublish.mock.calls[0][1]);
+    expect(payload.invoice).toBe("inv-now");
+    expect(payload.status).toBe("SETTLED");
+    const settledAtMs = Date.parse(payload.settledAt);
+    expect(settledAtMs).toBeGreaterThanOrEqual(before);
+    expect(settledAtMs).toBeLessThanOrEqual(after);
+  });
+
+  it("propagates publish failures so callers can log and swallow them", async () => {
+    const redisPublish = vi.fn().mockRejectedValue(new Error("Redis unavailable"));
+    const publisher = new RedisSettlementPublisher(redisPublish);
+
+    await expect(publisher.publish("inv-err")).rejects.toThrow("Redis unavailable");
+  });
+
+  it("closes the underlying client on close", async () => {
+    const closeClient = vi.fn().mockResolvedValue(undefined);
+    const publisher = new RedisSettlementPublisher(vi.fn().mockResolvedValue(1), closeClient);
+
+    await publisher.close();
+
+    expect(closeClient).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createSettlementPublisher", () => {
+  const originalNonceUrl = process.env.FIBER_LINK_NONCE_REDIS_URL;
+  const originalRedisUrl = process.env.REDIS_URL;
+
+  afterEach(() => {
+    if (originalNonceUrl === undefined) {
+      delete process.env.FIBER_LINK_NONCE_REDIS_URL;
+    } else {
+      process.env.FIBER_LINK_NONCE_REDIS_URL = originalNonceUrl;
+    }
+    if (originalRedisUrl === undefined) {
+      delete process.env.REDIS_URL;
+    } else {
+      process.env.REDIS_URL = originalRedisUrl;
+    }
+  });
+
+  it("returns a noop publisher when no Redis URL is configured", () => {
+    delete process.env.FIBER_LINK_NONCE_REDIS_URL;
+    delete process.env.REDIS_URL;
+
+    const publisher = createSettlementPublisher();
+
+    expect(publisher).toBeInstanceOf(NoopSettlementPublisher);
+  });
+});

--- a/fiber-link-service/apps/worker/src/settlement-publisher.ts
+++ b/fiber-link-service/apps/worker/src/settlement-publisher.ts
@@ -1,10 +1,14 @@
+export type SettlementPublishOptions = {
+  settledAt?: Date | null;
+};
+
 export interface SettlementPublisher {
-  publish(invoice: string): Promise<void>;
+  publish(invoice: string, options?: SettlementPublishOptions): Promise<void>;
   close(): Promise<void>;
 }
 
 export class NoopSettlementPublisher implements SettlementPublisher {
-  async publish(_invoice: string): Promise<void> {}
+  async publish(_invoice: string, _options?: SettlementPublishOptions): Promise<void> {}
   async close(): Promise<void> {}
 }
 
@@ -14,9 +18,14 @@ export class RedisSettlementPublisher implements SettlementPublisher {
     private readonly closeClient: () => Promise<void> = async () => {},
   ) {}
 
-  async publish(invoice: string): Promise<void> {
+  async publish(invoice: string, options?: SettlementPublishOptions): Promise<void> {
     const channel = `fiber-link:settlement:${invoice}`;
-    const message = JSON.stringify({ invoice, status: "SETTLED" });
+    const settledAt = options?.settledAt ?? new Date();
+    const message = JSON.stringify({
+      invoice,
+      status: "SETTLED",
+      settledAt: settledAt.toISOString(),
+    });
     await this.redisPublish(channel, message);
   }
 

--- a/fiber-link-service/apps/worker/src/settlement.test.ts
+++ b/fiber-link-service/apps/worker/src/settlement.test.ts
@@ -5,7 +5,7 @@ import {
   settlementCreditIdempotencyKey,
 } from "@fiber-link/db";
 import { markSettled } from "./settlement";
-import { type SettlementPublisher } from "./settlement-publisher";
+import { RedisSettlementPublisher, type SettlementPublisher } from "./settlement-publisher";
 
 describe("settlement worker", () => {
   const tipIntentRepo = createInMemoryTipIntentRepo();
@@ -127,7 +127,36 @@ describe("settlement worker", () => {
       };
       await markSettled({ invoice: "inv-pub-1" }, { tipIntentRepo, ledgerRepo, publisher });
       expect(publisher.publish).toHaveBeenCalledOnce();
-      expect(publisher.publish).toHaveBeenCalledWith("inv-pub-1");
+      expect(publisher.publish).toHaveBeenCalledWith("inv-pub-1", { settledAt: expect.any(Date) });
+    });
+
+    it("publishes the settlement payload to the invoice Redis channel after credit", async () => {
+      await tipIntentRepo.create({
+        appId: "app1",
+        postId: "p-pub-redis",
+        fromUserId: "u1",
+        toUserId: "u2",
+        asset: "USDI",
+        amount: "5",
+        invoice: "inv-pub-redis",
+      });
+
+      const redisPublish = vi.fn().mockResolvedValue(1);
+      const publisher = new RedisSettlementPublisher(redisPublish);
+
+      await markSettled({ invoice: "inv-pub-redis" }, { tipIntentRepo, ledgerRepo, publisher });
+
+      expect(redisPublish).toHaveBeenCalledOnce();
+      const [channel, message] = redisPublish.mock.calls[0];
+      expect(channel).toBe("fiber-link:settlement:inv-pub-redis");
+      const payload = JSON.parse(message);
+      expect(payload).toEqual({
+        invoice: "inv-pub-redis",
+        status: "SETTLED",
+        settledAt: expect.any(String),
+      });
+      const saved = await tipIntentRepo.findByInvoiceOrThrow("inv-pub-redis");
+      expect(payload.settledAt).toBe(saved.settledAt?.toISOString());
     });
 
     it("does not block settlement when publisher.publish throws", async () => {

--- a/fiber-link-service/apps/worker/src/settlement.ts
+++ b/fiber-link-service/apps/worker/src/settlement.ts
@@ -60,8 +60,10 @@ export async function markSettled(
   });
 
   // Keep invoice state convergent even if credit was already written earlier.
+  let settledAt = tipIntent.settledAt;
   if (tipIntent.invoiceState !== "SETTLED") {
-    await tipIntentRepo.updateInvoiceState(invoice, "SETTLED");
+    const updated = await tipIntentRepo.updateInvoiceState(invoice, "SETTLED");
+    settledAt = updated.settledAt;
   }
 
   if (options.dispatcher) {
@@ -82,7 +84,7 @@ export async function markSettled(
 
   // Publish settlement event for real-time SSE subscribers. Failure is non-blocking.
   if (options.publisher) {
-    await options.publisher.publish(invoice).catch((err) => {
+    await options.publisher.publish(invoice, { settledAt }).catch((err) => {
       console.warn("settlement-publisher: publish failed", err);
     });
   }

--- a/fiber-link-service/packages/client/README.md
+++ b/fiber-link-service/packages/client/README.md
@@ -91,7 +91,7 @@ Opens a Server-Sent Events stream for real-time settlement. Falls back gracefull
 The server only streams invoices that belong to the requesting app. In `signed` mode the configured `appId` is appended as a query param (`EventSource` cannot set headers); in `presigned` mode the server-side proxy supplies the `x-app-id` header.
 
 **Returns:** `StreamHandle | null`  
-**`onEvent` receives:** `{ invoice, status: "LISTENING" | "SETTLED" | "TIMEOUT" | "SSE_ERROR" }`
+**`onEvent` receives:** `{ invoice, status: "LISTENING" | "SETTLED" | "TIMEOUT" | "SSE_ERROR", settledAt? }` — `settledAt` is an ISO timestamp present on `SETTLED` events published by the settlement worker.
 
 ## Error types
 

--- a/fiber-link-service/packages/client/README.md
+++ b/fiber-link-service/packages/client/README.md
@@ -88,6 +88,8 @@ Polls the settlement state of an invoice.
 
 Opens a Server-Sent Events stream for real-time settlement. Falls back gracefully when `EventSource` is unavailable.
 
+The server only streams invoices that belong to the requesting app. In `signed` mode the configured `appId` is appended as a query param (`EventSource` cannot set headers); in `presigned` mode the server-side proxy supplies the `x-app-id` header.
+
 **Returns:** `StreamHandle | null`  
 **`onEvent` receives:** `{ invoice, status: "LISTENING" | "SETTLED" | "TIMEOUT" | "SSE_ERROR" }`
 

--- a/fiber-link-service/packages/client/src/client.test.ts
+++ b/fiber-link-service/packages/client/src/client.test.ts
@@ -171,6 +171,37 @@ describe("FiberLinkClient#streamTipStatus", () => {
     const client = makeClient();
     expect(() => client.streamTipStatus("", vi.fn())).toThrow(FiberLinkValidationError);
   });
+
+  it("appends the appId query param in signed mode so the server can check ownership", () => {
+    const seenUrls: string[] = [];
+    class FakeEventSource {
+      onmessage: unknown = null;
+      onerror: unknown = null;
+      constructor(url: string) {
+        seenUrls.push(url);
+      }
+      close() {}
+    }
+    vi.stubGlobal("EventSource", FakeEventSource);
+
+    try {
+      const signedClient = makeClient({ mode: "signed", appId: "app1", hmacSecret: "s" });
+      const handle = signedClient.streamTipStatus(FAKE_INVOICE, vi.fn());
+      expect(handle).not.toBeNull();
+      expect(seenUrls[0]).toBe(
+        `http://localhost:3000/rpc/stream?invoice=${encodeURIComponent(FAKE_INVOICE)}&appId=app1`,
+      );
+      handle?.close();
+
+      const presignedClient = makeClient();
+      presignedClient.streamTipStatus(FAKE_INVOICE, vi.fn())?.close();
+      expect(seenUrls[1]).toBe(
+        `http://localhost:3000/rpc/stream?invoice=${encodeURIComponent(FAKE_INVOICE)}`,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe("FiberLinkClient signed mode header generation", () => {

--- a/fiber-link-service/packages/client/src/client.ts
+++ b/fiber-link-service/packages/client/src/client.ts
@@ -193,12 +193,18 @@ export class FiberLinkClient {
    * Falls back gracefully when `EventSource` is unavailable (e.g., Node.js).
    * Returns a `StreamHandle` with `.close()`, or `null` if SSE is not available.
    *
+   * In "signed" mode the configured appId is sent as a query param —
+   * `EventSource` cannot set headers — so the server can verify the invoice
+   * belongs to this app. In "presigned" mode the server-side proxy injects
+   * the `x-app-id` header instead.
+   *
    * `onEvent` receives `StreamEvent` objects: LISTENING → SETTLED | TIMEOUT | SSE_ERROR.
    */
   streamTipStatus(invoice: string, onEvent: (event: StreamEvent) => void): StreamHandle | null {
     if (!invoice?.trim()) throw new FiberLinkValidationError("invoice", "invoice is required");
 
-    const streamUrl = `${this.endpoint}/stream?invoice=${encodeURIComponent(invoice)}`;
+    const appIdParam = this.appId ? `&appId=${encodeURIComponent(this.appId)}` : "";
+    const streamUrl = `${this.endpoint}/stream?invoice=${encodeURIComponent(invoice)}${appIdParam}`;
 
     if (typeof EventSource === "undefined") {
       return null;

--- a/fiber-link-service/packages/client/src/client.ts
+++ b/fiber-link-service/packages/client/src/client.ts
@@ -21,7 +21,12 @@ export type TipStatus = "UNPAID" | "SETTLED" | "FAILED";
 export type StreamStatus = "LISTENING" | "SETTLED" | "TIMEOUT" | "SSE_ERROR";
 
 export type StreamHandle = { close(): void };
-export type StreamEvent = { invoice: string; status: StreamStatus };
+export type StreamEvent = {
+  invoice: string;
+  status: StreamStatus;
+  /** ISO timestamp; present on SETTLED events published by the settlement worker. */
+  settledAt?: string;
+};
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 


### PR DESCRIPTION
## Summary

Plan #419 (real-time settlement via SSE) was largely shipped in #445 and wired/fixed through the #452 closeout chain, but its four unit issues (#424–#427) were never auto-closed and an audit against their acceptance criteria found two real gaps. This PR closes those gaps:

**App-ownership validation on the SSE endpoint (#425, #427)**
- `GET /rpc/stream` now resolves the requesting app id from the `x-app-id` header, falling back to an `appId` query param for browser `EventSource` clients that cannot set headers.
- Responses: `401` when no app id is supplied, `403` when the invoice belongs to a different app. Previously any caller could stream any invoice's settlement status.
- The Discourse stream proxy (`rpc_controller.rb`) forwards the forum's `x-app-id` (the same `SiteSetting.fiber_link_app_id` used to create the tip intent, so existing flows keep matching) and now emits a one-shot `SSE_ERROR` event when the backend rejects the stream, so the tip modal falls back to polling instead of silently stalling (#426).
- `@fiber-link/client` appends `appId` to the stream URL in signed mode; the vanilla-js example does the same.

**`settledAt` in the published payload (#424)**
- The worker's Redis settlement event is now `{ invoice, status: "SETTLED", settledAt }`, with `settledAt` taken from the tip intent record (falling back to publish time).

Docs: the real-time settlement runbook and client README are updated to describe the ownership check and the new payload shape.

## Test plan

- [x] `bunx vitest run apps/worker/src/settlement.test.ts apps/worker/src/settlement-publisher.test.ts apps/rpc/src/stream.test.ts packages/client/src/client.test.ts` — 41 tests passed
  - stream: new 401 / 403 / `appId`-query-param coverage; all prior scenarios updated to send `x-app-id`
  - worker: publish payload asserted against a mocked Redis client (channel + JSON including `settledAt`) after `creditOnce`; new `settlement-publisher.test.ts`
  - client: stream URL includes `appId` in signed mode and omits it in presigned mode
- [x] Full `apps/rpc`, `apps/worker`, `packages/client` suites — 287 passed; the single failure (`withdrawal.test.ts`) is a live call to `https://testnet.ckb.dev` blocked by the sandbox network policy, unrelated to this change
- [ ] Hosted `plugin-smoke` — runs the new Ruby request specs for the stream proxy (header forwarding, upstream-rejection `SSE_ERROR`)
- [ ] Hosted `visual-acceptance` — tip flow exercises the proxied stream with the header end-to-end

## Closes issues

Closes #424
Closes #425
Closes #426
Closes #427
Closes #419

## Related

Milestone #414 (closed) · prior work #445, #452, #462

https://claude.ai/code/session_01ECZ8p9GAxKBcQxLAZ3H2Bh

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECZ8p9GAxKBcQxLAZ3H2Bh)_