### PR TITLE
Add admin ops triage dashboard

### DIFF
--- a/fiber-link-service/apps/admin/src/dashboard/dashboard-page-model.ts
+++ b/fiber-link-service/apps/admin/src/dashboard/dashboard-page-model.ts
@@ -218,8 +218,12 @@ function countState(statusSummaries: DashboardStatusSummary[], state: Withdrawal
   return statusSummaries.find((summary) => summary.state === state)?.count ?? 0;
 }
 
-function severityFromCount(count: number): DashboardOpsTriageCard["severity"] {
-  return count > 0 ? "alert" : "ok";
+function severityFromCount(count: number, alertAt = 1): DashboardOpsTriageCard["severity"] {
+  if (count <= 0) {
+    return "ok";
+  }
+
+  return count >= alertAt ? "alert" : "watch";
 }
 
 export function buildOpsTriageCards(state: DashboardReadyState): DashboardOpsTriageCard[] {
@@ -238,20 +242,25 @@ export function buildOpsTriageCards(state: DashboardReadyState): DashboardOpsTri
   const settlementRetryPending = monitoringSummary?.retryPendingCount ?? 0;
   const alertCount = monitoringSummary?.alertCount ?? 0;
 
+  const settlementBacklog = unpaidBacklog + settlementRetryPending;
+
   return [
     {
       id: "settlement-backlog",
       label: "Settlement backlog",
-      value: String(unpaidBacklog),
-      severity: severityFromCount(unpaidBacklog + settlementRetryPending),
-      description: settlementRetryPending > 0 ? `${settlementRetryPending} settlement(s) are retry pending.` : "Unpaid invoice backlog from ops summary.",
+      value: String(settlementBacklog),
+      severity: severityFromCount(settlementBacklog, 5),
+      description:
+        settlementRetryPending > 0
+          ? `${unpaidBacklog} unpaid and ${settlementRetryPending} retry-pending settlement(s).`
+          : "Unpaid invoice backlog from ops summary.",
       href: "#monitoring",
     },
     {
       id: "withdrawal-backlog",
       label: "Withdrawal backlog",
       value: String(withdrawalBacklog),
-      severity: severityFromCount(withdrawalBacklog),
+      severity: severityFromCount(withdrawalBacklog, 5),
       description: "Pending, processing, broadcasted, retry, and liquidity-pending withdrawals.",
       href: "#withdrawals",
     },
@@ -275,7 +284,7 @@ export function buildOpsTriageCards(state: DashboardReadyState): DashboardOpsTri
       id: "ops-alerts",
       label: "Ops alerts",
       value: String(alertCount),
-      severity: severityFromCount(alertCount),
+      severity: monitoringSummary ? severityFromCount(alertCount) : "watch",
       description: monitoringSummary ? `Ops summary status: ${monitoringSummary.status}.` : "Monitoring integration is unavailable.",
       href: "#monitoring",
     },

--- a/fiber-link-service/apps/admin/src/dashboard/dashboard-page-model.ts
+++ b/fiber-link-service/apps/admin/src/dashboard/dashboard-page-model.ts
@@ -100,6 +100,15 @@ export type DashboardOperationsState = {
   backups: DashboardBackupsState;
 };
 
+export type DashboardOpsTriageCard = {
+  id: string;
+  label: string;
+  value: string;
+  severity: "ok" | "watch" | "alert";
+  description: string;
+  href: string;
+};
+
 type DashboardLoadingState = {
   status: "loading";
 };
@@ -143,6 +152,7 @@ type DashboardReadyViewModel = DashboardReadyState & {
   title: string;
   roleVisibility: DashboardRoleVisibility;
   withdrawalColumns: Array<"id" | "appId" | "userId" | "asset" | "amount" | "state" | "createdAt" | "txHash">;
+  opsTriageCards: DashboardOpsTriageCard[];
 };
 
 export type DashboardViewModel = DashboardLoadingViewModel | DashboardErrorViewModel | DashboardReadyViewModel;
@@ -204,6 +214,74 @@ export function summarizeWithdrawalStates(withdrawals: DashboardWithdrawal[]): D
   return WITHDRAWAL_STATE_ORDER.map((state) => ({ state, count: counts[state] ?? 0 }));
 }
 
+function countState(statusSummaries: DashboardStatusSummary[], state: WithdrawalState): number {
+  return statusSummaries.find((summary) => summary.state === state)?.count ?? 0;
+}
+
+function severityFromCount(count: number): DashboardOpsTriageCard["severity"] {
+  return count > 0 ? "alert" : "ok";
+}
+
+export function buildOpsTriageCards(state: DashboardReadyState): DashboardOpsTriageCard[] {
+  const liquidityPending = countState(state.statusSummaries, "LIQUIDITY_PENDING");
+  const failedWithdrawals = countState(state.statusSummaries, "FAILED");
+  const retryPendingWithdrawals = countState(state.statusSummaries, "RETRY_PENDING");
+  const withdrawalBacklog =
+    liquidityPending +
+    countState(state.statusSummaries, "PENDING") +
+    countState(state.statusSummaries, "PROCESSING") +
+    countState(state.statusSummaries, "BROADCASTED") +
+    retryPendingWithdrawals;
+
+  const monitoringSummary = state.operations?.monitoring.status === "ready" ? state.operations.monitoring.summary : undefined;
+  const unpaidBacklog = monitoringSummary?.unpaidBacklog ?? 0;
+  const settlementRetryPending = monitoringSummary?.retryPendingCount ?? 0;
+  const alertCount = monitoringSummary?.alertCount ?? 0;
+
+  return [
+    {
+      id: "settlement-backlog",
+      label: "Settlement backlog",
+      value: String(unpaidBacklog),
+      severity: severityFromCount(unpaidBacklog + settlementRetryPending),
+      description: settlementRetryPending > 0 ? `${settlementRetryPending} settlement(s) are retry pending.` : "Unpaid invoice backlog from ops summary.",
+      href: "#monitoring",
+    },
+    {
+      id: "withdrawal-backlog",
+      label: "Withdrawal backlog",
+      value: String(withdrawalBacklog),
+      severity: severityFromCount(withdrawalBacklog),
+      description: "Pending, processing, broadcasted, retry, and liquidity-pending withdrawals.",
+      href: "#withdrawals",
+    },
+    {
+      id: "liquidity-pending",
+      label: "Liquidity pending",
+      value: String(liquidityPending),
+      severity: severityFromCount(liquidityPending),
+      description: "Withdrawals blocked on available channel or chain liquidity.",
+      href: "#withdrawals",
+    },
+    {
+      id: "failed-withdrawals",
+      label: "Failed withdrawals",
+      value: String(failedWithdrawals),
+      severity: severityFromCount(failedWithdrawals),
+      description: "Terminal payout failures requiring operator investigation.",
+      href: "#withdrawals",
+    },
+    {
+      id: "ops-alerts",
+      label: "Ops alerts",
+      value: String(alertCount),
+      severity: severityFromCount(alertCount),
+      description: monitoringSummary ? `Ops summary status: ${monitoringSummary.status}.` : "Monitoring integration is unavailable.",
+      href: "#monitoring",
+    },
+  ];
+}
+
 export function buildDashboardViewModel(state: DashboardPageState): DashboardViewModel {
   if (state.status === "loading") {
     return {
@@ -230,5 +308,6 @@ export function buildDashboardViewModel(state: DashboardPageState): DashboardVie
     title: DASHBOARD_TITLE,
     roleVisibility,
     withdrawalColumns,
+    opsTriageCards: buildOpsTriageCards(state),
   };
 }

--- a/fiber-link-service/apps/admin/src/dashboard/dashboard-page-model.ts
+++ b/fiber-link-service/apps/admin/src/dashboard/dashboard-page-model.ts
@@ -248,12 +248,13 @@ export function buildOpsTriageCards(state: DashboardReadyState): DashboardOpsTri
     {
       id: "settlement-backlog",
       label: "Settlement backlog",
-      value: String(settlementBacklog),
-      severity: severityFromCount(settlementBacklog, 5),
-      description:
-        settlementRetryPending > 0
+      value: monitoringSummary ? String(settlementBacklog) : "N/A",
+      severity: monitoringSummary ? severityFromCount(settlementBacklog, 5) : "watch",
+      description: monitoringSummary
+        ? settlementRetryPending > 0
           ? `${unpaidBacklog} unpaid and ${settlementRetryPending} retry-pending settlement(s).`
-          : "Unpaid invoice backlog from ops summary.",
+          : "Unpaid invoice backlog from ops summary."
+        : "Monitoring integration is unavailable.",
       href: "#monitoring",
     },
     {
@@ -283,7 +284,7 @@ export function buildOpsTriageCards(state: DashboardReadyState): DashboardOpsTri
     {
       id: "ops-alerts",
       label: "Ops alerts",
-      value: String(alertCount),
+      value: monitoringSummary ? String(alertCount) : "N/A",
       severity: monitoringSummary ? severityFromCount(alertCount) : "watch",
       description: monitoringSummary ? `Ops summary status: ${monitoringSummary.status}.` : "Monitoring integration is unavailable.",
       href: "#monitoring",

--- a/fiber-link-service/apps/admin/src/pages/index.tsx
+++ b/fiber-link-service/apps/admin/src/pages/index.tsx
@@ -117,23 +117,25 @@ export default function HomePage({
           ) : null}
         </section>
 
-        <section className="section-card" id="operations-command-center" aria-labelledby="operations-command-center-title">
-          <div className="section-header">
-            <h2 className="section-title" id="operations-command-center-title">Operations command center</h2>
-            <p className="section-caption">
-              Dedicated admin-only triage cards for settlement backlog, withdrawal queues, liquidity blockers, and production alerts.
-            </p>
-          </div>
-          <div className="triage-grid">
-            {viewModel.opsTriageCards.map((card) => (
-              <a className={`triage-card triage-card--${card.severity}`} href={card.href} key={card.id} data-testid={`ops-triage-${card.id}`}>
-                <span className="triage-label">{card.label}</span>
-                <span className="triage-value">{card.value}</span>
-                <span className="triage-description">{card.description}</span>
-              </a>
-            ))}
-          </div>
-        </section>
+        {viewModel.roleVisibility.showGlobalControls ? (
+          <section className="section-card" id="operations-command-center" aria-labelledby="operations-command-center-title">
+            <div className="section-header">
+              <h2 className="section-title" id="operations-command-center-title">Operations command center</h2>
+              <p className="section-caption">
+                Dedicated admin-only triage cards for settlement backlog, withdrawal queues, liquidity blockers, and production alerts.
+              </p>
+            </div>
+            <div className="triage-grid">
+              {viewModel.opsTriageCards.map((card) => (
+                <a className={`triage-card triage-card--${card.severity}`} href={card.href} key={card.id} data-testid={`ops-triage-${card.id}`}>
+                  <span className="triage-label">{card.label}</span>
+                  <span className="triage-value">{card.value}</span>
+                  <span className="triage-description">{card.description}</span>
+                </a>
+              ))}
+            </div>
+          </section>
+        ) : null}
 
         <div className="card-grid">
           {viewModel.roleVisibility.showGlobalControls ? (

--- a/fiber-link-service/apps/admin/src/pages/index.tsx
+++ b/fiber-link-service/apps/admin/src/pages/index.tsx
@@ -117,6 +117,24 @@ export default function HomePage({
           ) : null}
         </section>
 
+        <section className="section-card" id="operations-command-center" aria-labelledby="operations-command-center-title">
+          <div className="section-header">
+            <h2 className="section-title" id="operations-command-center-title">Operations command center</h2>
+            <p className="section-caption">
+              Dedicated admin-only triage cards for settlement backlog, withdrawal queues, liquidity blockers, and production alerts.
+            </p>
+          </div>
+          <div className="triage-grid">
+            {viewModel.opsTriageCards.map((card) => (
+              <a className={`triage-card triage-card--${card.severity}`} href={card.href} key={card.id} data-testid={`ops-triage-${card.id}`}>
+                <span className="triage-label">{card.label}</span>
+                <span className="triage-value">{card.value}</span>
+                <span className="triage-description">{card.description}</span>
+              </a>
+            ))}
+          </div>
+        </section>
+
         <div className="card-grid">
           {viewModel.roleVisibility.showGlobalControls ? (
             <section className="section-card">
@@ -187,7 +205,7 @@ export default function HomePage({
             )}
           </section>
 
-          <section className="section-card">
+          <section className="section-card" id="withdrawals">
             <div className="section-header">
               <h2 className="section-title">Withdrawals</h2>
               <p className="section-caption">Recent payout requests and their current state.</p>
@@ -225,7 +243,7 @@ export default function HomePage({
         </div>
 
         {viewModel.roleVisibility.showGlobalControls ? (
-          <section className="section-card">
+          <section className="section-card" id="monitoring">
             <div className="section-header">
               <h2 className="section-title">Monitoring</h2>
               <p className="section-caption">Runtime health and ops-summary details for the Fiber Link deployment surface.</p>

--- a/fiber-link-service/apps/admin/src/styles/globals.css
+++ b/fiber-link-service/apps/admin/src/styles/globals.css
@@ -121,6 +121,7 @@ summary {
 .card-grid,
 .policy-grid,
 .backup-grid,
+.triage-grid,
 .field-grid,
 .overview-list,
 .detail-list,
@@ -134,7 +135,8 @@ summary {
 }
 
 .hero-stat-grid,
-.card-grid {
+.card-grid,
+.triage-grid {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
@@ -142,7 +144,8 @@ summary {
 .metric-tile,
 .overview-item,
 .detail-item,
-.summary-badge {
+.summary-badge,
+.triage-card {
   min-height: 92px;
   padding-top: 14px;
   border-top: 1px solid var(--admin-line);
@@ -153,6 +156,7 @@ summary {
 .overview-label,
 .detail-label,
 .summary-badge-label,
+.triage-label,
 .field-label,
 .checkbox-group legend {
   margin: 0 0 8px;
@@ -235,6 +239,32 @@ summary {
   font-family: var(--admin-font-display);
   font-size: 1.6rem;
   line-height: 1.05;
+}
+
+.triage-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-decoration: none;
+}
+
+.triage-card--alert {
+  border-top-color: var(--admin-danger);
+}
+
+.triage-card--watch {
+  border-top-color: var(--admin-accent);
+}
+
+.triage-value {
+  font-family: var(--admin-font-display);
+  font-size: clamp(2rem, 3.8vw, 3.2rem);
+  line-height: 0.95;
+}
+
+.triage-description {
+  color: var(--admin-muted);
+  line-height: 1.55;
 }
 
 .table-shell {

--- a/fiber-link-service/apps/admin/src/styles/globals.css
+++ b/fiber-link-service/apps/admin/src/styles/globals.css
@@ -246,6 +246,13 @@ summary {
   flex-direction: column;
   gap: 8px;
   text-decoration: none;
+  transition: background-color 160ms ease-out, transform 160ms ease-out;
+}
+
+.triage-card:hover,
+.triage-card:focus-visible {
+  background: rgba(26, 28, 28, 0.03);
+  transform: translateY(-1px);
 }
 
 .triage-card--alert {

--- a/fiber-link-service/apps/admin/src/tests/dashboard-data.test.ts
+++ b/fiber-link-service/apps/admin/src/tests/dashboard-data.test.ts
@@ -381,7 +381,10 @@ describe("dashboard data", () => {
     expect(viewModel.status).toBe("ready");
     if (viewModel.status === "ready") {
       expect(viewModel.opsTriageCards).toEqual(
-        expect.arrayContaining([expect.objectContaining({ id: "ops-alerts", value: "0", severity: "watch" })]),
+        expect.arrayContaining([
+          expect.objectContaining({ id: "settlement-backlog", value: "N/A", severity: "watch" }),
+          expect.objectContaining({ id: "ops-alerts", value: "N/A", severity: "watch" }),
+        ]),
       );
     }
   });

--- a/fiber-link-service/apps/admin/src/tests/dashboard-data.test.ts
+++ b/fiber-link-service/apps/admin/src/tests/dashboard-data.test.ts
@@ -156,7 +156,7 @@ describe("dashboard data", () => {
       expect(viewModel.withdrawalColumns).toContain("userId");
       expect(viewModel.opsTriageCards).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: "withdrawal-backlog", value: "1", severity: "alert", href: "#withdrawals" }),
+          expect.objectContaining({ id: "withdrawal-backlog", value: "1", severity: "watch", href: "#withdrawals" }),
           expect.objectContaining({ id: "settlement-backlog", value: "0", severity: "ok", href: "#monitoring" }),
         ]),
       );
@@ -307,6 +307,83 @@ describe("dashboard data", () => {
       { state: "COMPLETED", count: 0 },
       { state: "FAILED", count: 1 },
     ]);
+  });
+
+  it("uses watch severity for small queues and keeps settlement values aligned with retry counts", () => {
+    const now = "2026-02-17T00:00:00.000Z";
+    const viewModel = buildDashboardViewModel({
+      status: "ready",
+      role: "SUPER_ADMIN",
+      apps: [],
+      withdrawals: [],
+      statusSummaries: [
+        { state: "LIQUIDITY_PENDING", count: 0 },
+        { state: "PENDING", count: 0 },
+        { state: "PROCESSING", count: 0 },
+        { state: "BROADCASTED", count: 1 },
+        { state: "RETRY_PENDING", count: 0 },
+        { state: "COMPLETED", count: 0 },
+        { state: "FAILED", count: 0 },
+      ],
+      policies: [],
+      operations: {
+        monitoring: {
+          status: "ready",
+          summary: {
+            status: "ok",
+            generatedAt: now,
+            readinessStatus: "ready",
+            unpaidBacklog: 0,
+            retryPendingCount: 1,
+            withdrawalParityIssueCount: 0,
+            alertCount: 0,
+          },
+        },
+        rateLimit: { status: "error", message: "not loaded" },
+        backups: { status: "error", message: "not loaded" },
+      },
+    });
+
+    expect(viewModel.status).toBe("ready");
+    if (viewModel.status === "ready") {
+      expect(viewModel.opsTriageCards).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "settlement-backlog", value: "1", severity: "watch" }),
+          expect.objectContaining({ id: "withdrawal-backlog", value: "1", severity: "watch" }),
+        ]),
+      );
+    }
+  });
+
+  it("marks the ops alert card as watch when monitoring is unavailable", () => {
+    const viewModel = buildDashboardViewModel({
+      status: "ready",
+      role: "SUPER_ADMIN",
+      apps: [],
+      withdrawals: [],
+      statusSummaries: [
+        { state: "LIQUIDITY_PENDING", count: 0 },
+        { state: "PENDING", count: 0 },
+        { state: "PROCESSING", count: 0 },
+        { state: "BROADCASTED", count: 0 },
+        { state: "RETRY_PENDING", count: 0 },
+        { state: "COMPLETED", count: 0 },
+        { state: "FAILED", count: 0 },
+      ],
+      policies: [],
+      operations: {
+        monitoring: { status: "error", message: "monitoring unavailable" },
+        rateLimit: { status: "error", message: "not loaded" },
+        backups: { status: "error", message: "not loaded" },
+      },
+    });
+
+    expect(viewModel.status).toBe("ready");
+    if (viewModel.status === "ready") {
+      expect(viewModel.opsTriageCards).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: "ops-alerts", value: "0", severity: "watch" })]),
+      );
+    }
   });
 
   it("loads withdrawal policies into the ready state and view model", async () => {

--- a/fiber-link-service/apps/admin/src/tests/dashboard-data.test.ts
+++ b/fiber-link-service/apps/admin/src/tests/dashboard-data.test.ts
@@ -154,6 +154,12 @@ describe("dashboard data", () => {
     });
     if (viewModel.status === "ready") {
       expect(viewModel.withdrawalColumns).toContain("userId");
+      expect(viewModel.opsTriageCards).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "withdrawal-backlog", value: "1", severity: "alert", href: "#withdrawals" }),
+          expect.objectContaining({ id: "settlement-backlog", value: "0", severity: "ok", href: "#monitoring" }),
+        ]),
+      );
     }
   });
 

--- a/fiber-link-service/apps/admin/src/tests/index.page.test.tsx
+++ b/fiber-link-service/apps/admin/src/tests/index.page.test.tsx
@@ -78,6 +78,13 @@ describe("dashboard page", () => {
 
     expect(html).toContain('class="dashboard-shell"');
     expect(html).toContain('class="hero-panel"');
+    expect(html).toContain("Operations command center");
+    expect(html).toContain('data-testid="ops-triage-settlement-backlog"');
+    expect(html).toContain("Settlement backlog");
+    expect(html).toContain("Withdrawal backlog");
+    expect(html).toContain("Liquidity pending");
+    expect(html).toContain("Failed withdrawals");
+    expect(html).toContain("Ops alerts");
     expect(html).toContain("Operations overview");
     expect(html).toContain("Monitoring");
     expect(html).toContain("Global rate limiting");

--- a/fiber-link-service/apps/admin/src/tests/index.page.test.tsx
+++ b/fiber-link-service/apps/admin/src/tests/index.page.test.tsx
@@ -96,6 +96,39 @@ describe("dashboard page", () => {
     expect(html).toContain("scripts/restore-compose-backup.sh");
   });
 
+  it("hides global operations command center for COMMUNITY_ADMIN", () => {
+    const html = renderToStaticMarkup(
+      <HomePage
+        initialState={{
+          status: "ready",
+          role: "COMMUNITY_ADMIN",
+          apps: [{ appId: "app-scoped", createdAt: "2026-03-18T00:00:00.000Z" }],
+          withdrawals: [],
+          statusSummaries: [
+            { state: "LIQUIDITY_PENDING", count: 0 },
+            { state: "PENDING", count: 0 },
+            { state: "PROCESSING", count: 0 },
+            { state: "BROADCASTED", count: 0 },
+            { state: "RETRY_PENDING", count: 0 },
+            { state: "COMPLETED", count: 0 },
+            { state: "FAILED", count: 0 },
+          ],
+          policies: [],
+          operations: {
+            monitoring: { status: "error", message: "monitoring unavailable" },
+            rateLimit: { status: "error", message: "rate limits unavailable" },
+            backups: { status: "error", message: "backups unavailable" },
+          },
+        }}
+      />,
+    );
+
+    expect(html).not.toContain("Operations command center");
+    expect(html).not.toContain('data-testid="ops-triage-settlement-backlog"');
+    expect(html).not.toContain('href="#monitoring"');
+    expect(html).toContain("Status summaries");
+  });
+
   it("renders editable policy forms and success feedback", () => {
     const html = renderToStaticMarkup(
       <HomePage

--- a/fiber-link-service/packages/db/src/withdrawal-repo.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.ts
@@ -24,7 +24,7 @@ export type CreateLiquidityPendingWithdrawalInput = CreateWithdrawalInput & {
   liquidityPendingReason: string;
 };
 
-export type WithdrawalRecord = CreateWithdrawalInput & {
+export type WithdrawalRecord = Omit<CreateWithdrawalInput, "clientRequestId"> & {
   id: string;
   destinationKind: WithdrawalDestinationKind;
   state: WithdrawalState;


### PR DESCRIPTION
## Summary
- Adds an operations command center to the standalone admin dashboard with triage cards for settlement backlog, withdrawal backlog, liquidity-pending withdrawals, failed withdrawals, and ops alerts.
- Anchors triage cards into the relevant monitoring and withdrawal sections so operators can jump from high-level health into investigation tables.
- Fixes the withdrawal record type intersection so nullable `clientRequestId` rows type-check during the admin build.

Closes #466

## Verification
- `bunx vitest run` from `fiber-link-service`
- `bun run build` from `fiber-link-service/apps/admin`
