### PR TITLE
feat(admin): add withdrawal operations queue actions

### DIFF
--- a/fiber-link-service/apps/admin/src/dashboard/dashboard-model.ts
+++ b/fiber-link-service/apps/admin/src/dashboard/dashboard-model.ts
@@ -113,7 +113,7 @@ export async function loadDashboardState(ctx: TrpcContext): Promise<DashboardSta
   try {
     const appCaller = appRouter.createCaller(ctx);
     const withdrawalCaller = withdrawalRouter.createCaller(ctx);
-    const [apps, withdrawals] = await Promise.all([appCaller.list(), withdrawalCaller.list()]);
+    const [apps, withdrawals] = await Promise.all([appCaller.list(), withdrawalCaller.list({})]);
 
     return createReadyDashboardState(ctx.role, apps, withdrawals);
   } catch (error) {

--- a/fiber-link-service/apps/admin/src/dashboard/dashboard-page-model.ts
+++ b/fiber-link-service/apps/admin/src/dashboard/dashboard-page-model.ts
@@ -14,8 +14,16 @@ export type DashboardWithdrawal = {
   asset: "CKB" | "USDI";
   amount: string;
   state: WithdrawalState;
+  retryCount?: number;
+  nextRetryAt?: string | null;
+  lastError?: string | null;
+  liquidityRequestId?: string | null;
+  liquidityPendingReason?: string | null;
+  liquidityCheckedAt?: string | null;
+  ageSeconds?: number;
   createdAt: string;
   txHash: string | null;
+  txExplorerUrl?: string | null;
 };
 
 export type DashboardStatusSummary = {
@@ -151,7 +159,21 @@ type DashboardErrorViewModel = {
 type DashboardReadyViewModel = DashboardReadyState & {
   title: string;
   roleVisibility: DashboardRoleVisibility;
-  withdrawalColumns: Array<"id" | "appId" | "userId" | "asset" | "amount" | "state" | "createdAt" | "txHash">;
+  withdrawalColumns: Array<
+    | "id"
+    | "appId"
+    | "userId"
+    | "asset"
+    | "amount"
+    | "state"
+    | "ageSeconds"
+    | "retryCount"
+    | "lastError"
+    | "liquidityPendingReason"
+    | "liquidityCheckedAt"
+    | "createdAt"
+    | "txHash"
+  >;
   opsTriageCards: DashboardOpsTriageCard[];
 };
 
@@ -310,8 +332,35 @@ export function buildDashboardViewModel(state: DashboardPageState): DashboardVie
 
   const roleVisibility = getRoleVisibility(state.role);
   const withdrawalColumns: DashboardReadyViewModel["withdrawalColumns"] = roleVisibility.showUserId
-    ? ["id", "appId", "userId", "asset", "amount", "state", "createdAt", "txHash"]
-    : ["id", "appId", "asset", "amount", "state", "createdAt", "txHash"];
+    ? [
+        "id",
+        "appId",
+        "userId",
+        "asset",
+        "amount",
+        "state",
+        "ageSeconds",
+        "retryCount",
+        "lastError",
+        "liquidityPendingReason",
+        "liquidityCheckedAt",
+        "createdAt",
+        "txHash",
+      ]
+    : [
+        "id",
+        "appId",
+        "asset",
+        "amount",
+        "state",
+        "ageSeconds",
+        "retryCount",
+        "lastError",
+        "liquidityPendingReason",
+        "liquidityCheckedAt",
+        "createdAt",
+        "txHash",
+      ];
 
   return {
     ...state,

--- a/fiber-link-service/apps/admin/src/pages/index.tsx
+++ b/fiber-link-service/apps/admin/src/pages/index.tsx
@@ -5,6 +5,7 @@ import {
   type DashboardBackupBundle,
   type DashboardPageState,
   type DashboardRateLimitConfig,
+  type DashboardWithdrawal,
   type DashboardWithdrawalPolicy,
 } from "../dashboard/dashboard-page-model";
 import {
@@ -227,14 +228,9 @@ export default function HomePage({
                   <tbody>
                     {viewModel.withdrawals.map((withdrawal) => (
                       <tr key={withdrawal.id}>
-                        <td>{withdrawal.id}</td>
-                        <td>{withdrawal.appId}</td>
-                        {viewModel.roleVisibility.showUserId ? <td>{withdrawal.userId}</td> : null}
-                        <td>{withdrawal.asset}</td>
-                        <td>{withdrawal.amount}</td>
-                        <td>{withdrawal.state}</td>
-                        <td>{formatDate(withdrawal.createdAt)}</td>
-                        <td>{withdrawal.txHash ?? "N/A"}</td>
+                        {viewModel.withdrawalColumns.map((column) => (
+                          <td key={column}>{formatWithdrawalCell(withdrawal, column)}</td>
+                        ))}
                       </tr>
                     ))}
                   </tbody>
@@ -535,8 +531,41 @@ function getHeader(headers: RequestHeaders, key: string): string | undefined {
   return value;
 }
 
-function formatDate(dateText: string): string {
-  return dateText;
+function formatDate(dateText: string | null | undefined): string {
+  return dateText ?? "N/A";
+}
+
+function formatAge(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function formatWithdrawalCell(withdrawal: DashboardWithdrawal, column: keyof DashboardWithdrawal): React.ReactNode {
+  switch (column) {
+    case "createdAt":
+      return formatDate(withdrawal.createdAt);
+    case "ageSeconds":
+      return formatAge(withdrawal.ageSeconds ?? 0);
+    case "nextRetryAt":
+    case "liquidityCheckedAt":
+      return formatDate(withdrawal[column]);
+    case "lastError":
+      return withdrawal.lastError ?? "N/A";
+    case "liquidityPendingReason":
+      return withdrawal.liquidityPendingReason ?? "N/A";
+    case "txHash":
+      return withdrawal.txHash && withdrawal.txExplorerUrl ? (
+        <a href={withdrawal.txExplorerUrl}>{withdrawal.txHash}</a>
+      ) : (
+        "N/A"
+      );
+    default:
+      return String(withdrawal[column as keyof DashboardWithdrawal] ?? "N/A");
+  }
 }
 
 function toSearchParams(query: ParsedUrlQuery): URLSearchParams {
@@ -658,6 +687,16 @@ function toColumnLabel(column: string): string {
       return "Created At";
     case "txHash":
       return "Tx Hash";
+    case "ageSeconds":
+      return "Age";
+    case "retryCount":
+      return "Retries";
+    case "lastError":
+      return "Last Error";
+    case "liquidityPendingReason":
+      return "Liquidity Status";
+    case "liquidityCheckedAt":
+      return "Liquidity Checked";
     default:
       return column.toUpperCase();
   }

--- a/fiber-link-service/apps/admin/src/server/api/routers/withdrawal.test.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/withdrawal.test.ts
@@ -3,34 +3,89 @@ import type { DbClient } from "@fiber-link/db";
 import { withdrawalRouter } from "./withdrawal";
 import type { TrpcContext } from "../trpc";
 
+type WithdrawalRow = {
+  id: string;
+  appId: string;
+  userId: string;
+  asset: "CKB" | "USDI";
+  amount: string;
+  destinationKind: "CKB_ADDRESS" | "PAYMENT_REQUEST";
+  toAddress: string;
+  state: string;
+  retryCount: number;
+  nextRetryAt: Date | null;
+  lastError: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  completedAt: Date | null;
+  txHash: string | null;
+  liquidityRequestId: string | null;
+  liquidityPendingReason: string | null;
+  liquidityCheckedAt: Date | null;
+};
+
+function baseWithdrawal(overrides: Partial<WithdrawalRow> = {}): WithdrawalRow {
+  const now = new Date("2026-02-08T00:00:00.000Z");
+  return {
+    id: "w1",
+    appId: "app1",
+    userId: "u1",
+    asset: "USDI",
+    amount: "10",
+    destinationKind: "CKB_ADDRESS",
+    toAddress: "ckt1q...",
+    state: "PENDING",
+    retryCount: 0,
+    nextRetryAt: null,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+    completedAt: null,
+    txHash: null,
+    liquidityRequestId: null,
+    liquidityPendingReason: null,
+    liquidityCheckedAt: null,
+    ...overrides,
+  };
+}
+
 function createDbMock({
   withdrawalsRows,
   appAdminsRows,
 }: {
-  withdrawalsRows: Array<{
-    id: string;
-    appId: string;
-    userId: string;
-    asset: string;
-    amount: string;
-    toAddress: string;
-    state: string;
-    retryCount: number;
-    nextRetryAt: Date | null;
-    lastError: string | null;
-    createdAt: Date;
-    updatedAt: Date;
-    completedAt: Date | null;
-    txHash: string | null;
-  }>;
+  withdrawalsRows: WithdrawalRow[];
   appAdminsRows: Array<{ appId: string; adminUserId: string }>;
-}): DbClient {
+}): DbClient & { auditEvents: unknown[] } {
+  const auditEvents: unknown[] = [];
+  type Clause =
+    | { type: "and"; clauses: Clause[] }
+    | { type: "eq"; field: keyof WithdrawalRow; value: unknown }
+    | { type: "inArray"; field: keyof WithdrawalRow; values: unknown[] }
+    | { type: "lte" | "gte"; field: keyof WithdrawalRow; value: Date };
+
   const whereOps = {
-    eq: (_: unknown, value: unknown) => ({ type: "eq" as const, value }),
-    inArray: (_: unknown, values: unknown[]) => ({ type: "inArray" as const, values }),
+    and: (...clauses: Clause[]) => ({ type: "and" as const, clauses }),
+    eq: (field: keyof WithdrawalRow, value: unknown) => ({ type: "eq" as const, field, value }),
+    inArray: (field: keyof WithdrawalRow, values: unknown[]) => ({ type: "inArray" as const, field, values }),
+    lte: (field: keyof WithdrawalRow, value: Date) => ({ type: "lte" as const, field, value }),
+    gte: (field: keyof WithdrawalRow, value: Date) => ({ type: "gte" as const, field, value }),
   };
 
+  function matchesClause(row: WithdrawalRow, clause: Clause | undefined): boolean {
+    if (!clause || !("type" in clause)) return true;
+    if (clause.type === "and") return clause.clauses.every((item) => matchesClause(row, item));
+    if (clause.type === "eq") return row[clause.field] === clause.value;
+    if (clause.type === "inArray") return clause.values.includes(row[clause.field]);
+    if (clause.type === "lte" || clause.type === "gte") {
+      const value = row[clause.field];
+      if (!(value instanceof Date)) return false;
+      return clause.type === "lte" ? value <= clause.value : value >= clause.value;
+    }
+    return true;
+  }
+
   return {
+    auditEvents,
     query: {
       appAdmins: {
         findMany: async (opts?: any) => {
@@ -48,84 +103,91 @@ function createDbMock({
         findMany: async (opts?: any) => {
           let rows = withdrawalsRows;
           if (opts?.where) {
-            const clause = opts.where({ appId: "appId" }, whereOps);
-            if (clause?.type === "inArray") {
-              rows = rows.filter((r) => clause.values.includes(r.appId));
-            }
+            const clause = opts.where(
+              {
+                id: "id",
+                appId: "appId",
+                userId: "userId",
+                state: "state",
+                txHash: "txHash",
+                createdAt: "createdAt",
+              },
+              whereOps,
+            );
+            rows = rows.filter((row) => matchesClause(row, clause));
           }
           return rows;
         },
       },
     },
-  } as unknown as DbClient;
+    update: () => {
+      let values: Record<string, unknown> = {};
+      let clause: Clause | undefined;
+      return {
+        set(nextValues: Record<string, unknown>) {
+          values = nextValues;
+          return this;
+        },
+        where(nextClause: Clause) {
+          clause = nextClause;
+          return this;
+        },
+        returning: async () => {
+          const row = withdrawalsRows.find((item) => matchesClause(item, clause));
+          if (!row) return [];
+          Object.assign(row, values);
+          return [row];
+        },
+      };
+    },
+    insert: () => ({
+      values: async (event: unknown) => {
+        auditEvents.push(event);
+      },
+    }),
+  } as unknown as DbClient & { auditEvents: unknown[] };
 }
 
 describe("withdrawal router", () => {
-  it("returns withdrawals for allowed role", async () => {
-    const now = new Date("2026-02-08T00:00:00.000Z");
-    const rows = [
-      {
-        id: "w1",
-        appId: "app1",
-        userId: "u1",
-        asset: "USDI",
-        amount: "10",
-        toAddress: "ckt1q...",
-        state: "PENDING",
-        retryCount: 0,
-        nextRetryAt: null,
-        lastError: null,
-        createdAt: now,
-        updatedAt: now,
-        completedAt: null,
-        txHash: null,
-      },
-    ];
+  it("returns withdrawals for allowed role with queue fields", async () => {
+    const rows = [baseWithdrawal({ txHash: "0xabc" })];
     const db = createDbMock({ withdrawalsRows: rows, appAdminsRows: [] });
 
     const ctx = { role: "SUPER_ADMIN", db } satisfies TrpcContext;
     const caller = withdrawalRouter.createCaller(ctx);
-    const result = await caller.list();
+    const result = await caller.list({});
 
-    expect(result).toEqual(rows);
+    expect(result[0]).toMatchObject({
+      id: "w1",
+      appId: "app1",
+      userId: "u1",
+      asset: "USDI",
+      amount: "10",
+      destinationKind: "CKB_ADDRESS",
+      state: "PENDING",
+      retryCount: 0,
+      txHash: "0xabc",
+      txExplorerUrl: "https://explorer.nervos.org/transaction/0xabc",
+    });
+    expect(result[0]?.ageSeconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it("filters withdrawals by state, app, user, age, and tx hash", async () => {
+    const now = new Date();
+    const rows = [
+      baseWithdrawal({ id: "match", appId: "app1", userId: "u1", state: "FAILED", txHash: "0xabc", createdAt: new Date(now.getTime() - 3_600_000) }),
+      baseWithdrawal({ id: "miss", appId: "app2", userId: "u2", state: "PENDING", txHash: "0xdef", createdAt: now }),
+    ];
+    const db = createDbMock({ withdrawalsRows: rows, appAdminsRows: [] });
+    const caller = withdrawalRouter.createCaller({ role: "SUPER_ADMIN", db } satisfies TrpcContext);
+
+    const result = await caller.list({ state: "FAILED", appId: "app1", userId: "u1", txHash: "abc", minAgeSeconds: 60 });
+
+    expect(result.map((row) => row.id)).toEqual(["match"]);
   });
 
   it("scopes COMMUNITY_ADMIN to withdrawals for apps they admin", async () => {
-    const now = new Date("2026-02-08T00:00:00.000Z");
-    const rows = [
-      {
-        id: "w1",
-        appId: "app1",
-        userId: "u1",
-        asset: "USDI",
-        amount: "10",
-        toAddress: "ckt1q...",
-        state: "PENDING",
-        retryCount: 0,
-        nextRetryAt: null,
-        lastError: null,
-        createdAt: now,
-        updatedAt: now,
-        completedAt: null,
-        txHash: null,
-      },
-      {
-        id: "w2",
-        appId: "app2",
-        userId: "u2",
-        asset: "USDI",
-        amount: "20",
-        toAddress: "ckt1q...",
-        state: "PENDING",
-        retryCount: 0,
-        nextRetryAt: null,
-        lastError: null,
-        createdAt: now,
-        updatedAt: now,
-        completedAt: null,
-        txHash: null,
-      },
-    ];
+    const rows = [baseWithdrawal({ id: "w1", appId: "app1" }), baseWithdrawal({ id: "w2", appId: "app2", userId: "u2" })];
     const db = createDbMock({
       withdrawalsRows: rows,
       appAdminsRows: [
@@ -136,9 +198,69 @@ describe("withdrawal router", () => {
 
     const ctx = { role: "COMMUNITY_ADMIN", adminUserId: "au1", db } satisfies TrpcContext;
     const caller = withdrawalRouter.createCaller(ctx);
-    const result = await caller.list();
+    const result = await caller.list({});
 
-    expect(result).toEqual([rows[0]]);
+    expect(result.map((row) => row.id)).toEqual(["w1"]);
+  });
+
+  it("writes an audit event for retryNow", async () => {
+    const rows = [baseWithdrawal({ state: "FAILED", lastError: "boom" })];
+    const db = createDbMock({ withdrawalsRows: rows, appAdminsRows: [] });
+    const caller = withdrawalRouter.createCaller({ role: "SUPER_ADMIN", adminUserId: "admin-1", db } satisfies TrpcContext);
+
+    const result = await caller.retryNow({ id: "w1", reason: "operator retry", requestId: "req-1" });
+
+    expect(result.state).toBe("PENDING");
+    expect(result.lastError).toBeNull();
+    expect(db.auditEvents).toHaveLength(1);
+    expect(db.auditEvents[0]).toMatchObject({
+      actorId: "admin-1",
+      actorRole: "SUPER_ADMIN",
+      action: "withdrawal.retryNow",
+      targetType: "withdrawal",
+      targetId: "w1",
+      requestId: "req-1",
+      reason: "operator retry",
+    });
+  });
+
+  it("does not re-queue failed withdrawals that already have a broadcast tx", async () => {
+    const db = createDbMock({ withdrawalsRows: [baseWithdrawal({ state: "FAILED", txHash: "0xpaid" })], appAdminsRows: [] });
+    const caller = withdrawalRouter.createCaller({ role: "SUPER_ADMIN", adminUserId: "admin-1", db } satisfies TrpcContext);
+
+    await expect(caller.retryNow({ id: "w1" })).rejects.toMatchObject({ code: "CONFLICT" });
+    await expect(caller.resume({ id: "w1" })).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("rejects PROCESSING manual broadcast/cancel actions to avoid worker races", async () => {
+    const db = createDbMock({ withdrawalsRows: [baseWithdrawal({ state: "PROCESSING" })], appAdminsRows: [] });
+    const caller = withdrawalRouter.createCaller({ role: "SUPER_ADMIN", adminUserId: "admin-1", db } satisfies TrpcContext);
+
+    await expect(caller.attachTx({ id: "w1", txHash: "0xabc" })).rejects.toMatchObject({ code: "CONFLICT" });
+    await expect(caller.cancelBeforeBroadcast({ id: "w1", reason: "stop" })).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("appends ops notes instead of replacing the original error", async () => {
+    const db = createDbMock({ withdrawalsRows: [baseWithdrawal({ state: "FAILED", lastError: "broadcast failed" })], appAdminsRows: [] });
+    const caller = withdrawalRouter.createCaller({ role: "SUPER_ADMIN", adminUserId: "admin-1", db } satisfies TrpcContext);
+
+    const result = await caller.addOpsNote({ id: "w1", note: "watching retry" });
+
+    expect(result.lastError).toBe("broadcast failed\nOps note: watching retry");
+  });
+
+  it("denies manual actions when admin actor is missing", async () => {
+    const db = createDbMock({ withdrawalsRows: [baseWithdrawal({ state: "FAILED" })], appAdminsRows: [] });
+    const caller = withdrawalRouter.createCaller({ role: "SUPER_ADMIN", db } satisfies TrpcContext);
+
+    await expect(caller.retryNow({ id: "w1" })).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+  });
+
+  it("rejects invalid attachTx transitions", async () => {
+    const db = createDbMock({ withdrawalsRows: [baseWithdrawal({ state: "COMPLETED" })], appAdminsRows: [] });
+    const caller = withdrawalRouter.createCaller({ role: "SUPER_ADMIN", adminUserId: "admin-1", db } satisfies TrpcContext);
+
+    await expect(caller.attachTx({ id: "w1", txHash: "0xabc" })).rejects.toMatchObject({ code: "CONFLICT" });
   });
 
   it("rejects forbidden role", async () => {
@@ -146,14 +268,14 @@ describe("withdrawal router", () => {
     const ctx = { db } satisfies TrpcContext;
     const caller = withdrawalRouter.createCaller(ctx);
 
-    await expect(caller.list()).rejects.toMatchObject({ code: "FORBIDDEN" });
+    await expect(caller.list({})).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("fails closed with INTERNAL_SERVER_ERROR when DB is missing", async () => {
     const ctx = { role: "SUPER_ADMIN" } satisfies TrpcContext;
     const caller = withdrawalRouter.createCaller(ctx);
 
-    await expect(caller.list()).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+    await expect(caller.list({})).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
   });
 
   it("fails closed with INTERNAL_SERVER_ERROR when COMMUNITY_ADMIN has no identity", async () => {
@@ -161,37 +283,18 @@ describe("withdrawal router", () => {
     const ctx = { role: "COMMUNITY_ADMIN", db } satisfies TrpcContext;
     const caller = withdrawalRouter.createCaller(ctx);
 
-    await expect(caller.list()).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+    await expect(caller.list({})).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
   });
 
   it("returns empty list when COMMUNITY_ADMIN has no app memberships", async () => {
-    const now = new Date("2026-02-08T00:00:00.000Z");
-    const rows = [
-      {
-        id: "w1",
-        appId: "app1",
-        userId: "u1",
-        asset: "USDI",
-        amount: "10",
-        toAddress: "ckt1q...",
-        state: "PENDING",
-        retryCount: 0,
-        nextRetryAt: null,
-        lastError: null,
-        createdAt: now,
-        updatedAt: now,
-        completedAt: null,
-        txHash: null,
-      },
-    ];
     const db = createDbMock({
-      withdrawalsRows: rows,
+      withdrawalsRows: [baseWithdrawal()],
       appAdminsRows: [{ appId: "app2", adminUserId: "au2" }],
     });
 
     const ctx = { role: "COMMUNITY_ADMIN", adminUserId: "au1", db } satisfies TrpcContext;
     const caller = withdrawalRouter.createCaller(ctx);
-    const result = await caller.list();
+    const result = await caller.list({});
 
     expect(result).toEqual([]);
   });

--- a/fiber-link-service/apps/admin/src/server/api/routers/withdrawal.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/withdrawal.ts
@@ -1,55 +1,417 @@
+import { randomUUID } from "crypto";
 import { TRPCError } from "@trpc/server";
+import { and, eq, inArray, isNull, sql, type SQL } from "drizzle-orm";
+import { adminAuditEvents, withdrawals, type DbClient, type UserRole, type WithdrawalState } from "@fiber-link/db";
 import { requireRole } from "../../auth/roles";
 import { t } from "../trpc";
 
+type WithdrawalListInput = {
+  id?: string;
+  state?: WithdrawalState | WithdrawalState[];
+  appId?: string;
+  userId?: string;
+  txHash?: string;
+  minAgeSeconds?: number;
+  maxAgeSeconds?: number;
+};
+
+type WithdrawalActionInput = {
+  id: string;
+  reason?: string;
+  requestId?: string;
+  txHash?: string;
+  note?: string;
+};
+
+type WithdrawalRow = typeof withdrawals.$inferSelect;
+
+type ScopedWithdrawalRow = Pick<
+  WithdrawalRow,
+  | "id"
+  | "appId"
+  | "userId"
+  | "asset"
+  | "amount"
+  | "destinationKind"
+  | "toAddress"
+  | "state"
+  | "retryCount"
+  | "nextRetryAt"
+  | "lastError"
+  | "createdAt"
+  | "updatedAt"
+  | "completedAt"
+  | "txHash"
+  | "liquidityRequestId"
+  | "liquidityPendingReason"
+  | "liquidityCheckedAt"
+>;
+
+const withdrawalColumns = {
+  id: true,
+  appId: true,
+  userId: true,
+  asset: true,
+  amount: true,
+  destinationKind: true,
+  toAddress: true,
+  state: true,
+  retryCount: true,
+  nextRetryAt: true,
+  lastError: true,
+  createdAt: true,
+  updatedAt: true,
+  completedAt: true,
+  txHash: true,
+  liquidityRequestId: true,
+  liquidityPendingReason: true,
+  liquidityCheckedAt: true,
+} as const;
+
+function parseInput<T extends object>(value: unknown): T {
+  return (value && typeof value === "object" ? value : {}) as T;
+}
+
+function normalizeReason(reason: unknown, fallback: string): string {
+  const text = typeof reason === "string" ? reason.trim() : "";
+  return text || fallback;
+}
+
+function normalizeRequiredText(value: unknown, label: string): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: `${label} is required` });
+  }
+  return text;
+}
+
+function txExplorerUrl(txHash: string | null): string | null {
+  if (!txHash) return null;
+  const baseUrl =
+    process.env.CKB_EXPLORER_BASE_URL?.trim() || process.env.NERVOS_EXPLORER_BASE_URL?.trim() || "https://explorer.nervos.org";
+  return `${baseUrl.replace(/\/$/, "")}/transaction/${txHash}`;
+}
+
+function serializeWithdrawal(row: ScopedWithdrawalRow, now = new Date()) {
+  return {
+    id: row.id,
+    appId: row.appId,
+    userId: row.userId,
+    asset: row.asset,
+    amount: typeof row.amount === "string" ? row.amount : String(row.amount),
+    destinationKind: row.destinationKind,
+    toAddress: row.toAddress,
+    state: row.state,
+    retryCount: row.retryCount,
+    nextRetryAt: row.nextRetryAt,
+    lastError: row.lastError,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    completedAt: row.completedAt,
+    txHash: row.txHash,
+    txExplorerUrl: txExplorerUrl(row.txHash),
+    liquidityRequestId: row.liquidityRequestId,
+    liquidityPendingReason: row.liquidityPendingReason,
+    liquidityCheckedAt: row.liquidityCheckedAt,
+    ageSeconds: Math.max(0, Math.floor((now.getTime() - row.createdAt.getTime()) / 1000)),
+  };
+}
+
+async function getCommunityAdminAppIds(ctx: { db: DbClient; adminUserId?: string }): Promise<string[]> {
+  if (!ctx.adminUserId) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Admin identity not configured",
+    });
+  }
+  const adminUserId = ctx.adminUserId;
+  const memberships = await ctx.db.query.appAdmins.findMany({
+    columns: { appId: true },
+    where: (a, { eq: dbEq }) => dbEq(a.adminUserId, adminUserId),
+  });
+  return memberships.map((m) => m.appId);
+}
+
+async function listScopedWithdrawals(
+  ctx: { db: DbClient; role?: UserRole; adminUserId?: string },
+  input: WithdrawalListInput = {},
+  now = new Date(),
+): Promise<ScopedWithdrawalRow[]> {
+  const scopedAppIds = ctx.role === "SUPER_ADMIN" ? undefined : await getCommunityAdminAppIds(ctx);
+  if (scopedAppIds?.length === 0) {
+    return [];
+  }
+
+  return ctx.db.query.withdrawals.findMany({
+    columns: withdrawalColumns,
+    where: (w, { and: dbAnd, eq: dbEq, gte: dbGte, inArray: dbInArray, lte: dbLte }) => {
+      const states = input.state ? (Array.isArray(input.state) ? input.state : [input.state]) : undefined;
+      const predicates: SQL[] = [];
+      if (input.id) predicates.push(dbEq(w.id, input.id));
+      if (scopedAppIds) predicates.push(dbInArray(w.appId, scopedAppIds));
+      if (states?.length) predicates.push(dbInArray(w.state, states));
+      if (input.appId) predicates.push(dbEq(w.appId, input.appId));
+      if (input.userId) predicates.push(dbEq(w.userId, input.userId));
+      const txHash = input.txHash?.trim().toLowerCase();
+      if (txHash) predicates.push(sql`lower(coalesce(${w.txHash}, '')) like ${`%${txHash}%`}`);
+      if (typeof input.minAgeSeconds === "number") {
+        predicates.push(dbLte(w.createdAt, new Date(now.getTime() - input.minAgeSeconds * 1000)));
+      }
+      if (typeof input.maxAgeSeconds === "number") {
+        predicates.push(dbGte(w.createdAt, new Date(now.getTime() - input.maxAgeSeconds * 1000)));
+      }
+      return predicates.length ? dbAnd(...predicates) : undefined;
+    },
+  }) as Promise<ScopedWithdrawalRow[]>;
+}
+
+async function findAuthorizedWithdrawalOrThrow(ctx: { db: DbClient; role?: UserRole; adminUserId?: string }, id: string) {
+  const rows = await listScopedWithdrawals(ctx, { id });
+  const row = rows.find((item) => item.id === id);
+  if (!row) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "withdrawal not found in admin scope" });
+  }
+  return row;
+}
+
+function assertAdminActor(ctx: { role?: UserRole; adminUserId?: string }) {
+  requireRole(["SUPER_ADMIN", "COMMUNITY_ADMIN"], ctx.role);
+  if (!ctx.adminUserId) {
+    throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Admin identity not configured" });
+  }
+}
+
+function assertNoPriorBroadcastTx(before: ScopedWithdrawalRow, targetAction: string) {
+  if (!before.txHash) return;
+  throw new TRPCError({
+    code: "CONFLICT",
+    message: `${targetAction} cannot re-queue a withdrawal that already has a transaction hash`,
+  });
+}
+
+function assertCurrentState(before: ScopedWithdrawalRow, allowedStates: WithdrawalState[], targetAction: string) {
+  if (allowedStates.includes(before.state)) return;
+  throw new TRPCError({
+    code: "CONFLICT",
+    message: `${targetAction} is not valid for the current withdrawal state`,
+  });
+}
+
+async function writeAuditEvent(args: {
+  db: DbClient;
+  actorId: string;
+  actorRole: UserRole;
+  action: string;
+  targetId: string;
+  requestId: string;
+  reason?: string;
+  before: ScopedWithdrawalRow | null;
+  after: ScopedWithdrawalRow | null;
+}) {
+  await args.db.insert(adminAuditEvents).values({
+    actorId: args.actorId,
+    actorRole: args.actorRole,
+    action: args.action,
+    targetType: "withdrawal",
+    targetId: args.targetId,
+    requestId: args.requestId,
+    reason: args.reason ?? null,
+    before: args.before ? serializeWithdrawal(args.before) : null,
+    after: args.after ? serializeWithdrawal(args.after) : null,
+  });
+}
+
+async function runWithdrawalAction(
+  ctx: { db?: DbClient; role?: UserRole; adminUserId?: string },
+  action: string,
+  rawInput: unknown,
+  update: (db: DbClient, before: ScopedWithdrawalRow, now: Date, input: WithdrawalActionInput) => Promise<ScopedWithdrawalRow>,
+) {
+  requireRole(["SUPER_ADMIN", "COMMUNITY_ADMIN"], ctx.role);
+  if (!ctx.db) {
+    throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "DB not configured" });
+  }
+  assertAdminActor({ role: ctx.role, adminUserId: ctx.adminUserId });
+  const input = parseInput<WithdrawalActionInput>(rawInput);
+  const id = normalizeRequiredText(input.id, "id");
+  const requestId = input.requestId?.trim() || randomUUID();
+  const before = await findAuthorizedWithdrawalOrThrow({ db: ctx.db, role: ctx.role, adminUserId: ctx.adminUserId }, id);
+  const now = new Date();
+  const after = await update(ctx.db, before, now, input);
+  await writeAuditEvent({
+    db: ctx.db,
+    actorId: ctx.adminUserId!,
+    actorRole: ctx.role!,
+    action,
+    targetId: id,
+    requestId,
+    reason: input.reason ?? input.note,
+    before,
+    after,
+  });
+  return serializeWithdrawal(after, now);
+}
+
+async function updateByIdOrConflict(
+  db: DbClient,
+  id: string,
+  allowedStates: WithdrawalState[],
+  values: Partial<typeof withdrawals.$inferInsert>,
+  targetAction: string,
+): Promise<ScopedWithdrawalRow> {
+  const rows = await db
+    .update(withdrawals)
+    .set(values)
+    .where(and(eq(withdrawals.id, id), inArray(withdrawals.state, allowedStates)))
+    .returning();
+  const row = rows[0] as ScopedWithdrawalRow | undefined;
+  if (!row) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: `${targetAction} is not valid for the current withdrawal state`,
+    });
+  }
+  return row;
+}
+
+async function updateByIdWithNullTxOrConflict(
+  db: DbClient,
+  id: string,
+  allowedStates: WithdrawalState[],
+  values: Partial<typeof withdrawals.$inferInsert>,
+  targetAction: string,
+): Promise<ScopedWithdrawalRow> {
+  const rows = await db
+    .update(withdrawals)
+    .set(values)
+    .where(and(eq(withdrawals.id, id), inArray(withdrawals.state, allowedStates), isNull(withdrawals.txHash)))
+    .returning();
+  const row = rows[0] as ScopedWithdrawalRow | undefined;
+  if (!row) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: `${targetAction} is not valid for the current withdrawal state or already has a transaction hash`,
+    });
+  }
+  return row;
+}
+
 export const withdrawalRouter = t.router({
-  list: t.procedure.query(async ({ ctx }) => {
+  list: t.procedure.input({ parse: parseInput<WithdrawalListInput> }).query(async ({ ctx, input }) => {
     requireRole(["SUPER_ADMIN", "COMMUNITY_ADMIN"], ctx.role);
     if (!ctx.db) {
       throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "DB not configured" });
     }
 
-    const columns = {
-      id: true,
-      appId: true,
-      userId: true,
-      asset: true,
-      amount: true,
-      toAddress: true,
-      state: true,
-      retryCount: true,
-      nextRetryAt: true,
-      lastError: true,
-      createdAt: true,
-      updatedAt: true,
-      completedAt: true,
-      txHash: true,
-    } as const;
-
-    if (ctx.role === "SUPER_ADMIN") {
-      return ctx.db.query.withdrawals.findMany({ columns });
-    }
-
-    if (!ctx.adminUserId) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Admin identity not configured",
-      });
-    }
-    const adminUserId = ctx.adminUserId;
-
-    const memberships = await ctx.db.query.appAdmins.findMany({
-      columns: { appId: true },
-      where: (a, { eq }) => eq(a.adminUserId, adminUserId),
-    });
-    const appIds = memberships.map((m) => m.appId);
-    if (appIds.length === 0) {
-      return [];
-    }
-
-    return ctx.db.query.withdrawals.findMany({
-      columns,
-      where: (w, { inArray }) => inArray(w.appId, appIds),
-    });
+    const now = new Date();
+    const rows = await listScopedWithdrawals({ db: ctx.db, role: ctx.role, adminUserId: ctx.adminUserId }, input, now);
+    return rows.map((row) => serializeWithdrawal(row, now));
   }),
+
+  retryNow: t.procedure.input({ parse: parseInput<WithdrawalActionInput> }).mutation(({ ctx, input }) =>
+    runWithdrawalAction(ctx, "withdrawal.retryNow", input, (db, before, now) => {
+      assertNoPriorBroadcastTx(before, "retryNow");
+      return updateByIdWithNullTxOrConflict(
+        db,
+        before.id,
+        ["FAILED", "RETRY_PENDING"],
+        { state: "PENDING", nextRetryAt: null, lastError: null, updatedAt: now },
+        "retryNow",
+      );
+    }),
+  ),
+
+  pause: t.procedure.input({ parse: parseInput<WithdrawalActionInput> }).mutation(({ ctx, input }) =>
+    runWithdrawalAction(ctx, "withdrawal.pause", input, (db, before, now, parsed) =>
+      updateByIdOrConflict(
+        db,
+        before.id,
+        ["PENDING", "RETRY_PENDING", "LIQUIDITY_PENDING"],
+        {
+          state: "FAILED",
+          nextRetryAt: null,
+          lastError: `Paused by admin: ${normalizeReason(parsed.reason, "manual pause")}`,
+          updatedAt: now,
+        },
+        "pause",
+      ),
+    ),
+  ),
+
+  resume: t.procedure.input({ parse: parseInput<WithdrawalActionInput> }).mutation(({ ctx, input }) =>
+    runWithdrawalAction(ctx, "withdrawal.resume", input, (db, before, now) => {
+      const state = before.state === "LIQUIDITY_PENDING" ? "LIQUIDITY_PENDING" : "RETRY_PENDING";
+      const updateWithdrawal = before.state === "FAILED" ? updateByIdWithNullTxOrConflict : updateByIdOrConflict;
+      if (before.state === "FAILED") assertNoPriorBroadcastTx(before, "resume");
+      return updateWithdrawal(
+        db,
+        before.id,
+        ["PENDING", "RETRY_PENDING", "LIQUIDITY_PENDING", "FAILED"],
+        { state, nextRetryAt: now, lastError: null, updatedAt: now },
+        "resume",
+      );
+    }),
+  ),
+
+  cancelBeforeBroadcast: t.procedure.input({ parse: parseInput<WithdrawalActionInput> }).mutation(({ ctx, input }) =>
+    runWithdrawalAction(ctx, "withdrawal.cancelBeforeBroadcast", input, (db, before, now, parsed) => {
+      assertCurrentState(before, ["LIQUIDITY_PENDING", "PENDING", "RETRY_PENDING", "FAILED"], "cancelBeforeBroadcast");
+      return updateByIdOrConflict(
+        db,
+        before.id,
+        ["LIQUIDITY_PENDING", "PENDING", "RETRY_PENDING", "FAILED"],
+        {
+          state: "FAILED",
+          nextRetryAt: null,
+          lastError: `Cancelled by admin before broadcast: ${normalizeReason(parsed.reason, "manual cancellation")}`,
+          updatedAt: now,
+        },
+        "cancelBeforeBroadcast",
+      );
+    }),
+  ),
+
+  recheckConfirmation: t.procedure.input({ parse: parseInput<WithdrawalActionInput> }).mutation(({ ctx, input }) =>
+    runWithdrawalAction(ctx, "withdrawal.recheckConfirmation", input, (db, before, now) =>
+      updateByIdOrConflict(
+        db,
+        before.id,
+        ["BROADCASTED"],
+        { state: "BROADCASTED", lastError: null, updatedAt: now },
+        "recheckConfirmation",
+      ),
+    ),
+  ),
+
+  attachTx: t.procedure.input({ parse: parseInput<WithdrawalActionInput> }).mutation(({ ctx, input }) =>
+    runWithdrawalAction(ctx, "withdrawal.attachTx", input, (db, before, now, parsed) => {
+      const txHash = normalizeRequiredText(parsed.txHash, "txHash");
+      assertCurrentState(before, ["BROADCASTED"], "attachTx");
+      return updateByIdOrConflict(
+        db,
+        before.id,
+        ["BROADCASTED"],
+        {
+          state: "BROADCASTED",
+          txHash,
+          nextRetryAt: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        "attachTx",
+      );
+    }),
+  ),
+
+  addOpsNote: t.procedure.input({ parse: parseInput<WithdrawalActionInput> }).mutation(({ ctx, input }) =>
+    runWithdrawalAction(ctx, "withdrawal.addOpsNote", input, async (db, before, now, parsed) => {
+      const note = normalizeRequiredText(parsed.note, "note");
+      const rows = await db
+        .update(withdrawals)
+        .set({ lastError: before.lastError ? `${before.lastError}\nOps note: ${note}` : `Ops note: ${note}`, updatedAt: now })
+        .where(eq(withdrawals.id, before.id))
+        .returning();
+      return rows[0] as ScopedWithdrawalRow;
+    }),
+  ),
 });

--- a/fiber-link-service/apps/admin/src/server/dashboard-data.ts
+++ b/fiber-link-service/apps/admin/src/server/dashboard-data.ts
@@ -40,7 +40,7 @@ const DEFAULT_DATA_DEPENDENCIES: DashboardDataDependencies = {
     }));
   },
   listWithdrawals: async (ctx) => {
-    const rows = await withdrawalRouter.createCaller(ctx).list();
+    const rows = await withdrawalRouter.createCaller(ctx).list({});
     return rows.map((row) => ({
       id: row.id,
       appId: row.appId,
@@ -48,8 +48,16 @@ const DEFAULT_DATA_DEPENDENCIES: DashboardDataDependencies = {
       asset: row.asset,
       amount: row.amount,
       state: row.state,
+      retryCount: row.retryCount,
+      nextRetryAt: row.nextRetryAt ? row.nextRetryAt.toISOString() : null,
+      lastError: row.lastError ?? null,
+      liquidityRequestId: row.liquidityRequestId ?? null,
+      liquidityPendingReason: row.liquidityPendingReason ?? null,
+      liquidityCheckedAt: row.liquidityCheckedAt ? row.liquidityCheckedAt.toISOString() : null,
+      ageSeconds: row.ageSeconds,
       createdAt: row.createdAt.toISOString(),
       txHash: row.txHash ?? null,
+      txExplorerUrl: row.txExplorerUrl ?? null,
     }));
   },
   listPolicies: async (ctx) => {

--- a/fiber-link-service/apps/admin/src/tests/dashboard-view.test.ts
+++ b/fiber-link-service/apps/admin/src/tests/dashboard-view.test.ts
@@ -9,6 +9,28 @@ import {
 } from "../dashboard/dashboard-model";
 import { buildDashboardRenderModel } from "../dashboard/dashboard-view";
 
+function createWithdrawalFixture(
+  overrides: Partial<DashboardWithdrawal> & Pick<DashboardWithdrawal, "id" | "appId" | "userId" | "asset" | "amount" | "toAddress" | "state">,
+): DashboardWithdrawal {
+  const now = new Date("2026-02-17T10:00:00.000Z");
+  return {
+    destinationKind: "CKB_ADDRESS",
+    retryCount: 0,
+    nextRetryAt: null,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+    completedAt: null,
+    txHash: null,
+    txExplorerUrl: null,
+    liquidityRequestId: null,
+    liquidityPendingReason: null,
+    liquidityCheckedAt: null,
+    ageSeconds: 0,
+    ...overrides,
+  };
+}
+
 function createFixtures() {
   const now = new Date("2026-02-17T10:00:00.000Z");
   const apps: DashboardApp[] = [
@@ -16,7 +38,7 @@ function createFixtures() {
     { appId: "app-beta", createdAt: now },
   ];
   const withdrawals: DashboardWithdrawal[] = [
-    {
+    createWithdrawalFixture({
       id: "w-1",
       appId: "app-alpha",
       userId: "u-1",
@@ -24,15 +46,8 @@ function createFixtures() {
       amount: "10",
       toAddress: "ckt1q000",
       state: "PENDING",
-      retryCount: 0,
-      nextRetryAt: null,
-      lastError: null,
-      createdAt: now,
-      updatedAt: now,
-      completedAt: null,
-      txHash: null,
-    },
-    {
+    }),
+    createWithdrawalFixture({
       id: "w-2",
       appId: "app-beta",
       userId: "u-3",
@@ -40,15 +55,8 @@ function createFixtures() {
       amount: "15",
       toAddress: "ckt1q222",
       state: "LIQUIDITY_PENDING",
-      retryCount: 0,
-      nextRetryAt: null,
-      lastError: null,
-      createdAt: now,
-      updatedAt: now,
-      completedAt: null,
-      txHash: null,
-    },
-    {
+    }),
+    createWithdrawalFixture({
       id: "w-3",
       appId: "app-beta",
       userId: "u-2",
@@ -57,13 +65,8 @@ function createFixtures() {
       toAddress: "ckt1q111",
       state: "FAILED",
       retryCount: 2,
-      nextRetryAt: null,
       lastError: "insufficient balance",
-      createdAt: now,
-      updatedAt: now,
-      completedAt: null,
-      txHash: null,
-    },
+    }),
   ];
 
   return { apps, withdrawals };
@@ -136,7 +139,7 @@ describe("withdrawal summary", () => {
   it("does not produce NaN for unexpected withdrawal states during staggered deploys", () => {
     const now = new Date("2026-02-17T10:00:00.000Z");
     const summary = summarizeWithdrawalStates([
-      {
+      createWithdrawalFixture({
         id: "w-expected",
         appId: "app-alpha",
         userId: "u-1",
@@ -144,30 +147,20 @@ describe("withdrawal summary", () => {
         amount: "5",
         toAddress: "ckt1qexpected",
         state: "PENDING",
-        retryCount: 0,
-        nextRetryAt: null,
-        lastError: null,
         createdAt: now,
         updatedAt: now,
-        completedAt: null,
-        txHash: null,
-      },
-      {
+      }),
+      createWithdrawalFixture({
         id: "w-unknown",
         appId: "app-beta",
         userId: "u-2",
         asset: "CKB",
         amount: "7",
         toAddress: "ckt1qunknown",
-        state: "WAITING_FOR_BATCH",
-        retryCount: 0,
-        nextRetryAt: null,
-        lastError: null,
+        state: "WAITING_FOR_BATCH" as DashboardWithdrawal["state"],
         createdAt: now,
         updatedAt: now,
-        completedAt: null,
-        txHash: null,
-      } as unknown as DashboardWithdrawal,
+      }),
     ]);
 
     const dynamicCounts = summary.byState as Record<string, number>;

--- a/fiber-link-service/packages/db/drizzle/0011_admin_withdrawal_audit_events.sql
+++ b/fiber-link-service/packages/db/drizzle/0011_admin_withdrawal_audit_events.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS admin_audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_id text NOT NULL,
+  actor_role user_role NOT NULL,
+  action text NOT NULL,
+  target_type text NOT NULL,
+  target_id text NOT NULL,
+  request_id text NOT NULL,
+  reason text,
+  before jsonb,
+  after jsonb,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS admin_audit_events_target_created_at_idx
+  ON admin_audit_events (target_type, target_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS admin_audit_events_actor_created_at_idx
+  ON admin_audit_events (actor_id, created_at DESC);

--- a/fiber-link-service/packages/db/src/schema.ts
+++ b/fiber-link-service/packages/db/src/schema.ts
@@ -110,6 +110,31 @@ export const appAdmins = pgTable("app_admins", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
+export const adminAuditEvents = pgTable(
+  "admin_audit_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    actorId: text("actor_id").notNull(),
+    actorRole: userRoleEnum("actor_role").notNull(),
+    action: text("action").notNull(),
+    targetType: text("target_type").notNull(),
+    targetId: text("target_id").notNull(),
+    requestId: text("request_id").notNull(),
+    reason: text("reason"),
+    before: jsonb("before").$type<Record<string, unknown> | null>(),
+    after: jsonb("after").$type<Record<string, unknown> | null>(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    byTargetCreatedAt: index("admin_audit_events_target_created_at_idx").on(
+      table.targetType,
+      table.targetId,
+      table.createdAt,
+    ),
+    byActorCreatedAt: index("admin_audit_events_actor_created_at_idx").on(table.actorId, table.createdAt),
+  }),
+);
+
 export const withdrawalPolicies = pgTable(
   "withdrawal_policies",
   {


### PR DESCRIPTION
## Summary
- Adds an admin withdrawal operations queue projection with state/app/user/age/tx-hash filters, age/explorer/liquidity fields, and richer dashboard columns.
- Adds manual recovery mutations for retry, pause, resume, cancel-before-broadcast, confirmation recheck, tx attachment, and ops notes.
- Persists every manual action to a new `admin_audit_events` table with actor, action, request id, reason, before snapshot, and after snapshot.
- Tightens withdrawal record typing for nullable `clientRequestId` to match the DB row shape.

## Test Plan
- `bun run --filter @fiber-link/admin test --run`
- `bun run --filter @fiber-link/db test --run`
- `bun run --filter @fiber-link/admin build`

Closes #467
