### PR TITLE
feat(admin): verify proxy shared secret before trusting identity headers

### DIFF
--- a/docs/runbooks/withdrawal-policy-operations.md
+++ b/docs/runbooks/withdrawal-policy-operations.md
@@ -29,7 +29,11 @@ cd fiber-link-service/apps/admin
 bun run dev -- --hostname 127.0.0.1 --port 4318
 ```
 
-By default the dashboard expects `x-admin-role` and `x-admin-user-id` to be injected by the caller or upstream proxy. For local proof/demo mode you can point it at the bundled fixture:
+By default the dashboard expects `x-admin-role` and `x-admin-user-id` to be injected by the caller or upstream proxy.
+
+For any deployment where the console port could be reached without going through the auth proxy, set `ADMIN_PROXY_SHARED_SECRET` on the console and configure the proxy to inject a matching `x-admin-proxy-token` header alongside the identity headers. When the shared secret is configured, requests without a matching token resolve to no role (fail closed), so a direct request cannot claim `SUPER_ADMIN` by setting `x-admin-role` itself. In production the console logs a startup warning if the shared secret is not configured.
+
+For local proof/demo mode you can point it at the bundled fixture:
 
 ```bash
 cd fiber-link-service/apps/admin

--- a/fiber-link-service/apps/admin/src/server/api/context.test.ts
+++ b/fiber-link-service/apps/admin/src/server/api/context.test.ts
@@ -59,4 +59,47 @@ describe("createTrpcContext", () => {
     const ctx = createTrpcContext(reqWith({ "x-admin-role": "ROOT" }));
     expect(ctx.role).toBeUndefined();
   });
+
+  describe("with ADMIN_PROXY_SHARED_SECRET configured", () => {
+    beforeEach(() => {
+      process.env.ADMIN_PROXY_SHARED_SECRET = "proxy-secret";
+    });
+
+    it("honors identity headers when the proxy token matches", () => {
+      const ctx = createTrpcContext(
+        reqWith({
+          "x-admin-proxy-token": "proxy-secret",
+          "x-admin-role": "SUPER_ADMIN",
+          "x-admin-user-id": "ops-7",
+        }),
+      );
+      expect(ctx.role).toBe("SUPER_ADMIN");
+      expect(ctx.adminUserId).toBe("ops-7");
+    });
+
+    it("fails closed when the proxy token mismatches", () => {
+      const ctx = createTrpcContext(
+        reqWith({
+          "x-admin-proxy-token": "wrong",
+          "x-admin-role": "SUPER_ADMIN",
+          "x-admin-user-id": "ops-7",
+        }),
+      );
+      expect(ctx.role).toBeUndefined();
+      expect(ctx.adminUserId).toBeUndefined();
+    });
+
+    it("fails closed when the proxy token is absent", () => {
+      const ctx = createTrpcContext(reqWith({ "x-admin-role": "SUPER_ADMIN" }));
+      expect(ctx.role).toBeUndefined();
+    });
+
+    it("skips the dev env fallback identity on token mismatch", () => {
+      process.env.ADMIN_DASHBOARD_DEFAULT_ROLE = "SUPER_ADMIN";
+      process.env.ADMIN_DASHBOARD_DEFAULT_ADMIN_USER_ID = "default-admin";
+      const ctx = createTrpcContext(reqWith({ "x-admin-proxy-token": "wrong" }));
+      expect(ctx.role).toBeUndefined();
+      expect(ctx.adminUserId).toBeUndefined();
+    });
+  });
 });

--- a/fiber-link-service/apps/admin/src/server/api/context.ts
+++ b/fiber-link-service/apps/admin/src/server/api/context.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { CreateNextContextOptions } from "@trpc/server/adapters/next";
 import type { IncomingMessage } from "node:http";
 import { parseAdminRole } from "../../dashboard/dashboard-page-model";
@@ -12,11 +13,28 @@ function readHeader(req: IncomingMessage, key: string): string | undefined {
   return value;
 }
 
+function timingSafeEquals(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.length !== right.length) return false;
+  return crypto.timingSafeEqual(left, right);
+}
+
+let warnedMissingProxySecret = false;
+
 /**
  * Resolve the trusted admin identity from the proxy-injected headers, falling
  * back to the development env defaults. The reverse proxy is responsible for
  * stripping any externally supplied `x-admin-*` headers before injecting the
  * trusted values (see the revamp design's authentication section).
+ *
+ * When ADMIN_PROXY_SHARED_SECRET is configured, identity headers are only
+ * honored if the request also carries a matching `x-admin-proxy-token` header
+ * (which the reverse proxy injects alongside the identity headers). This
+ * protects deployments where the console port is reachable without going
+ * through the proxy: a direct request can no longer claim a role by setting
+ * `x-admin-role` itself. A mismatching or missing token fails closed to "no
+ * role", including the dev env fallback.
  */
 export function createTrpcContext(opts: CreateNextContextOptions): TrpcContext {
   const env = process.env;
@@ -25,6 +43,21 @@ export function createTrpcContext(opts: CreateNextContextOptions): TrpcContext {
   // trusted identity headers, so a header-less request resolves to no role
   // rather than silently becoming ADMIN_DASHBOARD_DEFAULT_ROLE (e.g. SUPER_ADMIN).
   const allowEnvFallback = env.NODE_ENV !== "production";
+
+  const proxySharedSecret = env.ADMIN_PROXY_SHARED_SECRET?.trim();
+  if (proxySharedSecret) {
+    const proxyToken = readHeader(opts.req, "x-admin-proxy-token")?.trim() ?? "";
+    if (!timingSafeEquals(proxyToken, proxySharedSecret)) {
+      return { role: undefined, adminUserId: undefined, services: createAdminServices(env) };
+    }
+  } else if (env.NODE_ENV === "production" && !warnedMissingProxySecret) {
+    warnedMissingProxySecret = true;
+    console.warn(
+      "[admin] ADMIN_PROXY_SHARED_SECRET is not set: identity headers are trusted from any " +
+        "client that can reach this port. Set the shared secret and configure the reverse " +
+        "proxy to send x-admin-proxy-token so direct requests cannot spoof x-admin-role.",
+    );
+  }
 
   const headerRole = parseAdminRole(readHeader(opts.req, "x-admin-role"));
   const role = headerRole ?? (allowEnvFallback ? parseAdminRole(env.ADMIN_DASHBOARD_DEFAULT_ROLE) : undefined);

--- a/fiber-link-service/apps/admin/src/server/api/context.ts
+++ b/fiber-link-service/apps/admin/src/server/api/context.ts
@@ -14,9 +14,10 @@ function readHeader(req: IncomingMessage, key: string): string | undefined {
 }
 
 function timingSafeEquals(a: string, b: string): boolean {
-  const left = Buffer.from(a);
-  const right = Buffer.from(b);
-  if (left.length !== right.length) return false;
+  // Hash both sides to fixed-length digests so the comparison cost does not
+  // depend on either string's length (avoids leaking the secret's length).
+  const left = crypto.createHash("sha256").update(a).digest();
+  const right = crypto.createHash("sha256").update(b).digest();
   return crypto.timingSafeEqual(left, right);
 }
 


### PR DESCRIPTION
## Summary

- [x] Briefly summarize what changed and why.

The admin console trusted `x-admin-role` / `x-admin-user-id` headers unconditionally, relying entirely on the reverse proxy stripping them from external requests. If the console port is reachable without the proxy (or the proxy is misconfigured), any client could self-assign `SUPER_ADMIN`.

This PR hardens the existing trust-proxy model (real login/sessions remain out of scope per the Ops/Admin console revamp design):

- New `ADMIN_PROXY_SHARED_SECRET` env var. When set, identity headers are only honored if the request carries a matching `x-admin-proxy-token` header, compared with `crypto.timingSafeEqual`. A missing or mismatching token **fails closed** to no role — including the dev env fallback identity.
- When not set, behavior is unchanged (no breakage for existing deployments), but production now logs a startup warning telling operators to configure the shared secret.
- Documented the new variable in `docs/runbooks/withdrawal-policy-operations.md` next to the existing header-trust explanation.

## Scope

- [x] Filesystem scope is limited to this PR: `apps/admin/src/server/api/context.ts`, its test file, one runbook.

## Verification

- [x] Relevant local checks run
  - `apps/admin` tests: 105 passed (4 new tests: token match honors headers, token mismatch fails closed, absent token fails closed, mismatch also skips dev fallback identity).

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (if applicable) — follows up the project improvement review (admin header-trust finding)
- [x] Required discussions or follow-ups are documented

## Notes

- Risk note: opt-in change; deployments that don't set `ADMIN_PROXY_SHARED_SECRET` behave exactly as before. Once the secret is set, the reverse proxy must inject `x-admin-proxy-token` on every forwarded request (including `/api/trpc` XHR calls) or all requests resolve to no role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_