### PR TITLE
ci: enforce strict typechecking, gate all package tests, align bun version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: "/fiber-link-service"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+    ignore:
+      # Major upgrades need coordinated migration work; keep them manual.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: docker
+    directory: "/deploy/compose"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Install dependencies
         working-directory: fiber-link-service
         run: bun install --frozen-lockfile
+      - name: Typecheck workspaces
+        working-directory: fiber-link-service
+        run: |
+          set -euo pipefail
+          for pkg in apps/admin apps/rpc apps/worker packages/db packages/fiber-adapter packages/notifications packages/client; do
+            echo "--- typecheck ${pkg} ---"
+            (cd "${pkg}" && bun run typecheck)
+          done
       - name: Check db migration drift
         working-directory: fiber-link-service/packages/db
         run: bun run db:validate
@@ -62,6 +70,15 @@ jobs:
         run: bun run test -- --run --silent
       - name: Test db
         working-directory: fiber-link-service/packages/db
+        run: bun run test -- --run --silent
+      - name: Test fiber-adapter
+        working-directory: fiber-link-service/packages/fiber-adapter
+        run: bun run test -- --run --silent
+      - name: Test notifications
+        working-directory: fiber-link-service/packages/notifications
+        run: bun run test -- --run --silent
+      - name: Test client SDK
+        working-directory: fiber-link-service/packages/client
         run: bun run test -- --run --silent
 
 

--- a/fiber-link-service/apps/admin/package.json
+++ b/fiber-link-service/apps/admin/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest",
-    "policy:withdrawal": "bun run src/scripts/manage-withdrawal-policy.ts"
+    "policy:withdrawal": "bun run src/scripts/manage-withdrawal-policy.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.4",

--- a/fiber-link-service/apps/rpc/package.json
+++ b/fiber-link-service/apps/rpc/package.json
@@ -2,7 +2,8 @@
   "name": "@fiber-link/rpc",
   "private": true,
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@fiber-link/db": "workspace:*",

--- a/fiber-link-service/apps/rpc/src/methods/tip.ts
+++ b/fiber-link-service/apps/rpc/src/methods/tip.ts
@@ -13,8 +13,8 @@ import type { InvoiceState } from "@fiber-link/fiber-adapter";
 type SimpleLogger = { error: (obj: unknown, msg?: string) => void };
 
 let defaultTipIntentRepo: TipIntentRepo | null | undefined;
-let defaultLedgerRepo: LedgerRepo | null | undefined;
-let defaultAdapter: ReturnType<typeof createAdapterProvider> | null | undefined;
+let defaultLedgerRepo: LedgerRepo | undefined;
+let defaultAdapter: ReturnType<typeof createAdapterProvider> | undefined;
 let defaultTipIntentEventRepo: TipIntentEventRepo | null | undefined;
 
 function isInvoiceStateConflictError(error: unknown): boolean {

--- a/fiber-link-service/apps/rpc/tsconfig.json
+++ b/fiber-link-service/apps/rpc/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.e2e.test.ts",
+    "src/**/*.integration.test.ts"
+  ]
+}

--- a/fiber-link-service/apps/worker/package.json
+++ b/fiber-link-service/apps/worker/package.json
@@ -7,7 +7,8 @@
     "reconcile:tips": "bun run src/scripts/reconcile-tip-settlement-parity.ts",
     "reconcile:withdrawals": "bun run src/scripts/reconcile-withdrawal-parity.ts",
     "ops:summary": "bun run src/scripts/ops-summary.ts",
-    "demo:w5": "bun run src/scripts/w5-demo.ts"
+    "demo:w5": "bun run src/scripts/w5-demo.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@fiber-link/db": "workspace:*",

--- a/fiber-link-service/apps/worker/src/scripts/healthcheck.ts
+++ b/fiber-link-service/apps/worker/src/scripts/healthcheck.ts
@@ -7,7 +7,7 @@ if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
   process.exit(1);
 }
 
-const fiberRpcUrl = process.env.FIBER_RPC_URL ?? "";
+const fiberRpcUrl = process.env.FIBER_RPC_URL?.trim() ?? "";
 if (!fiberRpcUrl) {
   console.error("[worker-healthcheck] FIBER_RPC_URL is required");
   process.exit(1);

--- a/fiber-link-service/apps/worker/src/scripts/healthcheck.ts
+++ b/fiber-link-service/apps/worker/src/scripts/healthcheck.ts
@@ -7,7 +7,7 @@ if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
   process.exit(1);
 }
 
-const fiberRpcUrl = process.env.FIBER_RPC_URL;
+const fiberRpcUrl = process.env.FIBER_RPC_URL ?? "";
 if (!fiberRpcUrl) {
   console.error("[worker-healthcheck] FIBER_RPC_URL is required");
   process.exit(1);

--- a/fiber-link-service/apps/worker/tsconfig.json
+++ b/fiber-link-service/apps/worker/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.e2e.test.ts",
+    "src/**/*.integration.test.ts"
+  ]
+}

--- a/fiber-link-service/package.json
+++ b/fiber-link-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fiber-link-service",
   "private": true,
-  "packageManager": "bun@1.2.19",
+  "packageManager": "bun@1.3.11",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/fiber-link-service/packages/client/package.json
+++ b/fiber-link-service/packages/client/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "vitest": "^1.6.0",

--- a/fiber-link-service/packages/client/tsconfig.json
+++ b/fiber-link-service/packages/client/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.e2e.test.ts",
+    "src/**/*.integration.test.ts"
+  ]
+}

--- a/fiber-link-service/packages/db/package.json
+++ b/fiber-link-service/packages/db/package.json
@@ -8,7 +8,8 @@
     "db:migrate": "bunx drizzle-kit migrate --config=drizzle.config.ts",
     "db:migrate:local": "bash ./scripts/migrate-local-idempotent.sh",
     "db:drift:check": "bunx drizzle-kit check --dialect=postgresql --out=drizzle",
-    "db:validate": "bun run db:drift:check"
+    "db:validate": "bun run db:drift:check",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "drizzle-orm": "^0.32.0",

--- a/fiber-link-service/packages/db/tsconfig.json
+++ b/fiber-link-service/packages/db/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.e2e.test.ts",
+    "src/**/*.integration.test.ts"
+  ]
+}

--- a/fiber-link-service/packages/fiber-adapter/package.json
+++ b/fiber-link-service/packages/fiber-adapter/package.json
@@ -4,7 +4,8 @@
   "main": "src/index.ts",
   "scripts": {
     "test": "vitest",
-    "test:hot-wallet-inventory": "vitest --run src/hot-wallet-inventory.test.ts"
+    "test:hot-wallet-inventory": "vitest --run src/hot-wallet-inventory.test.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ckb-lumos/lumos": "^0.22.2"

--- a/fiber-link-service/packages/fiber-adapter/src/hot-wallet-inventory.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/hot-wallet-inventory.ts
@@ -1,4 +1,5 @@
 import { Indexer, config, hd, helpers } from "@ckb-lumos/lumos";
+import type { HashType } from "@ckb-lumos/lumos";
 import { shannonsToCkbDecimal } from "./ckb-onchain-withdrawal";
 import type { CkbNetwork, GetHotWalletInventoryArgs, HotWalletInventory } from "./types";
 
@@ -9,7 +10,7 @@ export type HotWalletCell = {
 
 export type HotWalletLockScript = {
   codeHash: string;
-  hashType: string;
+  hashType: HashType;
   args: string;
 };
 

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/invoice-ops.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/invoice-ops.ts
@@ -133,9 +133,16 @@ function pickPaymentHash(result: Record<string, unknown> | undefined): string | 
 export function toWithdrawalUdtTypeScript(script: RpcUdtTypeScript): UdtTypeScript {
   return {
     codeHash: script.code_hash,
-    hashType: script.hash_type,
+    hashType: parseScriptHashType(script.hash_type),
     args: script.args,
   };
+}
+
+function parseScriptHashType(value: string): UdtTypeScript["hashType"] {
+  if (value === "type" || value === "data" || value === "data1" || value === "data2") {
+    return value;
+  }
+  throw new Error(`unsupported hash_type in UDT type script: ${value}`);
 }
 
 export function toRpcUdtTypeScript(script: UdtTypeScript): RpcUdtTypeScript {

--- a/fiber-link-service/packages/fiber-adapter/src/types.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/types.ts
@@ -1,3 +1,4 @@
+import type { HashType } from "@ckb-lumos/lumos";
 export type Asset = "CKB" | "USDI";
 export type CkbNetwork = "AGGRON4" | "LINA";
 
@@ -11,7 +12,7 @@ export type WithdrawalDestination =
 
 export type UdtTypeScript = {
   codeHash: string;
-  hashType: string;
+  hashType: HashType;
   args: string;
 };
 

--- a/fiber-link-service/packages/fiber-adapter/src/udt-onchain-withdrawal.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/udt-onchain-withdrawal.ts
@@ -11,6 +11,7 @@ import {
   type LumosConfig,
 } from "./ckb-onchain-withdrawal";
 import type { ExecuteWithdrawalArgs, UdtTypeScript } from "./types";
+import type { HashType } from "@ckb-lumos/lumos";
 
 function normalizeHexLike(input: string): string {
   const normalized = input.trim().toLowerCase();
@@ -38,9 +39,20 @@ function normalizeUdtTypeScript(value: unknown): UdtTypeScript {
 
   return {
     codeHash: normalizeHexLike(codeHash),
-    hashType: hashType.trim(),
+    hashType: parseHashType(hashType),
     args: normalizeHexLike(args),
   };
+}
+
+function parseHashType(value: string): HashType {
+  const trimmed = value.trim();
+  if (trimmed === "type" || trimmed === "data" || trimmed === "data1" || trimmed === "data2") {
+    return trimmed;
+  }
+  throw new WithdrawalExecutionError(
+    `unsupported hash_type in UDT type script: ${trimmed}`,
+    "permanent",
+  );
 }
 
 function resolveUsdiUdtTypeScript(args: ExecuteWithdrawalArgs): UdtTypeScript {
@@ -98,7 +110,7 @@ function parseAmountToUdtUnits(amount: string, decimals: number): bigint {
   return amountUnits;
 }
 
-function buildUsdiLumosConfig(baseCfg: LumosConfig, udtTypeScript: UdtTypeScript): LumosConfig {
+function buildUsdiLumosConfig(baseCfg: LumosConfig, udtTypeScript: UdtTypeScript): config.Config {
   const sudtScript = baseCfg.SCRIPTS.SUDT;
   if (!sudtScript) {
     throw new WithdrawalExecutionError("provided CKB network config does not define an SUDT script", "permanent");

--- a/fiber-link-service/packages/fiber-adapter/tsconfig.json
+++ b/fiber-link-service/packages/fiber-adapter/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.e2e.test.ts",
+    "src/**/*.integration.test.ts"
+  ]
+}

--- a/fiber-link-service/packages/notifications/package.json
+++ b/fiber-link-service/packages/notifications/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "main": "src/index.ts",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@fiber-link/db": "workspace:*"

--- a/fiber-link-service/packages/notifications/tsconfig.json
+++ b/fiber-link-service/packages/notifications/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.e2e.test.ts",
+    "src/**/*.integration.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- [x] Briefly summarize what changed and why.

The `strict` settings in `tsconfig.base.json` were never actually enforced: only `apps/admin` had a `tsconfig.json`, vitest transpiles without typechecking, and CI had no typecheck step. CI also never ran the `fiber-adapter`, `notifications`, or `client` package test suites, and the root `packageManager` pin (`bun@1.2.19`) disagreed with the bun `1.3.11` CI installs.

- **Typecheck everywhere**: every workspace now has a `tsconfig.json` extending `tsconfig.base.json` plus a `typecheck` script; CI typechecks all seven workspaces. Test files are excluded from typecheck for now (the mock-typing cleanups are a follow-up); admin already checks clean including tests.
- **Fix the real strict-mode findings this surfaced** (all previously unchecked):
  - `UdtTypeScript.hashType` / `HotWalletLockScript.hashType` narrowed from `string` to the lumos `HashType` union, with runtime validation of RPC/env-supplied values (a bad `hash_type` now fails with a clear permanent error instead of building an invalid lumos config).
  - `buildUsdiLumosConfig` returns the general `config.Config` instead of the predefined-literal type.
  - Dropped stale `| null` arms from the `tip.ts` default singletons (`defaultLedgerRepo`, `defaultAdapter` are never assigned null).
  - Worker healthcheck defaults `FIBER_RPC_URL` to `""` before the exit guard.
- **Test gating**: `packages/fiber-adapter`, `packages/notifications`, `packages/client` test suites now run in the `test-service` job.
- **Toolchain hygiene**: `packageManager` aligned to `bun@1.3.11`; weekly Dependabot config added (github-actions grouped, npm with majors ignored, docker).

## Scope

- [x] Filesystem scope is limited to this PR: `fiber-link-service/**` (tsconfigs, package.json scripts, 5 src files), `.github/{workflows/ci.yml,dependabot.yml}`.

## Verification

- [x] Relevant local checks run
  - `tsc --noEmit` passes for all 7 workspaces (0 errors).
  - Test suites: admin 101, worker 149, db 133, fiber-adapter 58, notifications 15, client 17 — all pass; rpc 122/123 (the 1 failure is the known sandbox network-blocked test that passes in CI).
  - `bun install --frozen-lockfile` still passes (lockfile untouched).

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (if applicable) — follows up the project improvement review (typecheck/CI gap findings)
- [x] Required discussions or follow-ups are documented (test-file typing cleanup; adding new packages to the coverage report matrix)

## Notes

- Risk note: the hash-type validation is intentionally strict — values other than `type`/`data`/`data1`/`data2` were already invalid downstream in lumos; they now fail earlier with a clearer message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_