### PR TITLE
test: include test files in strict typechecking and fix all findings

### DIFF
--- a/fiber-link-service/apps/rpc/src/methods/dashboard.test.ts
+++ b/fiber-link-service/apps/rpc/src/methods/dashboard.test.ts
@@ -11,9 +11,17 @@ function createMockDb(selectQueue: MockSelectQueue) {
     return next;
   };
 
+  type QueryChain = {
+    from: (...args: unknown[]) => QueryChain;
+    where: (...args: unknown[]) => QueryChain;
+    orderBy: (...args: unknown[]) => QueryChain;
+    limit: (...args: unknown[]) => Promise<unknown>;
+    groupBy: (...args: unknown[]) => Promise<unknown>;
+    then: (resolve: (value: unknown) => unknown) => Promise<unknown>;
+  };
   return {
     select: vi.fn(() => {
-      const chain = {
+      const chain: QueryChain = {
         from: vi.fn(() => chain),
         where: vi.fn(() => chain),
         orderBy: vi.fn(() => chain),

--- a/fiber-link-service/apps/rpc/src/methods/withdrawal.test.ts
+++ b/fiber-link-service/apps/rpc/src/methods/withdrawal.test.ts
@@ -273,7 +273,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger, policyRepo },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "MAX_PER_REQUEST_EXCEEDED",
     });
@@ -329,7 +329,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger, policyRepo, now },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "COOLDOWN_ACTIVE",
     });
@@ -360,7 +360,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "AMOUNT_BELOW_MIN_CAPACITY",
     });
@@ -401,7 +401,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger, policyRepo },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "ASSET_NOT_ALLOWED",
     });
@@ -456,7 +456,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger, policyRepo, now: new Date("2026-02-27T12:00:00.000Z") },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "PER_USER_DAILY_LIMIT_EXCEEDED",
     });
@@ -511,7 +511,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger, policyRepo, now: new Date("2026-02-27T12:00:00.000Z") },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "PER_APP_DAILY_LIMIT_EXCEEDED",
     });
@@ -542,7 +542,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "INVALID_DESTINATION_ADDRESS",
     });
@@ -573,7 +573,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "INVALID_DESTINATION_ADDRESS",
     });
@@ -636,7 +636,7 @@ describe("requestWithdrawal", () => {
         },
         { repo, ledgerRepo: ledger },
       ),
-    ).rejects.toMatchObject<Partial<WithdrawalPolicyViolationError>>({
+    ).rejects.toMatchObject({
       name: "WithdrawalPolicyViolationError",
       reason: "WITHDRAWAL_SIGNER_UNAVAILABLE",
       message: expect.stringContaining("withdrawal signer"),
@@ -1097,7 +1097,7 @@ describe("requestWithdrawal", () => {
       await vi.waitFor(() => {
         expect(hotWalletInventoryProvider).toHaveBeenCalledTimes(1);
       });
-      releaseFirstInventoryCall?.();
+      (releaseFirstInventoryCall as (() => void) | null)?.();
 
       const [firstResult, secondResult] = await Promise.all([firstRequest, secondRequest]);
       expect([firstResult.state, secondResult.state].sort()).toEqual([

--- a/fiber-link-service/apps/rpc/src/nonce-store.test.ts
+++ b/fiber-link-service/apps/rpc/src/nonce-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import Redis from "ioredis-mock";
+import type { Redis as RedisClient } from "ioredis";
 import { InMemoryNonceStore, RedisNonceStore, FaultTolerantRedisNonceStore } from "./nonce-store";
 
 describe("nonce store", () => {
@@ -49,7 +50,7 @@ describe("nonce store", () => {
       const failingRedis = {
         set: async () => { throw new Error("Redis connection refused"); },
         quit: async () => {},
-      } as unknown as Redis;
+      } as unknown as RedisClient;
 
       const primary = new RedisNonceStore(failingRedis);
       const store = new FaultTolerantRedisNonceStore(primary, {
@@ -70,7 +71,7 @@ describe("nonce store", () => {
       const failingRedis = {
         set: async () => { throw new Error("Redis unavailable"); },
         quit: async () => {},
-      } as unknown as Redis;
+      } as unknown as RedisClient;
 
       const primary = new RedisNonceStore(failingRedis);
       const store = new FaultTolerantRedisNonceStore(primary, {
@@ -89,7 +90,7 @@ describe("nonce store", () => {
       const failingRedis = {
         set: async () => { throw new Error("Redis unavailable"); },
         quit: async () => {},
-      } as unknown as Redis;
+      } as unknown as RedisClient;
 
       const primary = new RedisNonceStore(failingRedis);
       const store = new FaultTolerantRedisNonceStore(primary);

--- a/fiber-link-service/apps/rpc/src/rate-limit.test.ts
+++ b/fiber-link-service/apps/rpc/src/rate-limit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import Redis from "ioredis-mock";
+import type { Redis as RedisClient } from "ioredis";
 import {
   InMemoryRateLimitStore,
   RedisRateLimitStore,
@@ -88,12 +89,12 @@ describe("rpc rate limit", () => {
 
     // Seed a key with no TTL directly via the mock client.
     const rawKey = `rate:${rateLimitKey("recover", "tip.create")}`;
-    await (client as unknown as Redis).set(rawKey, "5");
+    await (client as unknown as RedisClient).set(rawKey, "5");
 
     const result = await store.consume({ key: rateLimitKey("recover", "tip.create"), limit: 100, windowMs: 60_000 });
 
     // After the consume the key must have a TTL so it will eventually expire.
-    const pttl = await (client as unknown as Redis).pttl(rawKey);
+    const pttl = await (client as unknown as RedisClient).pttl(rawKey);
     expect(pttl).toBeGreaterThan(0);
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(94); // 100 - 6

--- a/fiber-link-service/apps/rpc/src/rpc.test.ts
+++ b/fiber-link-service/apps/rpc/src/rpc.test.ts
@@ -16,6 +16,8 @@ import * as tipMethods from "./methods/tip";
 import * as dashboardMethods from "./methods/dashboard";
 import * as withdrawalMethods from "./methods/withdrawal";
 
+declare const Bun: unknown;
+
 function ensureBunInjectHeaderCompat() {
   if (typeof Bun === "undefined") {
     return;
@@ -527,6 +529,11 @@ describe("json-rpc", () => {
           createdAt: "2026-02-16T00:00:00.000Z",
           message: null,
           settledAt: null,
+          activityType: "TIP" as const,
+          txHash: null,
+          explorerUrl: null,
+          destinationKind: null,
+          destination: null,
         },
       ],
       admin: {
@@ -622,6 +629,11 @@ describe("json-rpc", () => {
               createdAt: "2026-02-16T00:00:00.000Z",
               message: null,
               settledAt: null,
+              activityType: "TIP",
+              txHash: null,
+              explorerUrl: null,
+              destinationKind: null,
+              destination: null,
             },
           ],
           admin: {

--- a/fiber-link-service/apps/rpc/tsconfig.json
+++ b/fiber-link-service/apps/rpc/tsconfig.json
@@ -10,9 +10,6 @@
     "src/**/*"
   ],
   "exclude": [
-    "node_modules",
-    "src/**/*.test.ts",
-    "src/**/*.e2e.test.ts",
-    "src/**/*.integration.test.ts"
+    "node_modules"
   ]
 }

--- a/fiber-link-service/apps/worker/src/liquidity-batch.test.ts
+++ b/fiber-link-service/apps/worker/src/liquidity-batch.test.ts
@@ -4,6 +4,7 @@ import {
   createInMemoryWithdrawalRepo,
 } from "@fiber-link/db";
 import { runLiquidityBatch } from "./liquidity-batch";
+import type { EnsureChainLiquidityResult, GetRebalanceStatusResult } from "@fiber-link/fiber-adapter";
 
 const originalWithdrawalPrivateKey = process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY;
 
@@ -35,13 +36,14 @@ describe("runLiquidityBatch", () => {
       liquidityRequestId: liquidityRequest.id,
       liquidityPendingReason: "hot wallet underfunded",
     });
-    const ensureChainLiquidity = vi.fn(async () => ({
+    const ensureChainLiquidity = vi.fn(async (..._args: unknown[]): Promise<EnsureChainLiquidityResult> => ({
       state: "PENDING" as const,
       started: true,
+      recoveryStrategy: "LOCAL_CKB_SWEEP" as const,
       txHash: "0xsweep",
       trackingNetwork: "AGGRON4" as const,
     }));
-    const getRebalanceStatus = vi.fn(async () => ({
+    const getRebalanceStatus = vi.fn(async (..._args: unknown[]): Promise<GetRebalanceStatusResult> => ({
       state: "IDLE" as const,
     }));
     const getLiquidityCapabilities = vi.fn(async () => ({
@@ -110,11 +112,11 @@ describe("runLiquidityBatch", () => {
       liquidityPendingReason: "hot wallet underfunded",
     });
 
-    const ensureChainLiquidity = vi.fn(async () => ({
+    const ensureChainLiquidity = vi.fn(async (..._args: unknown[]): Promise<EnsureChainLiquidityResult> => ({
       state: "PENDING" as const,
       started: true,
     }));
-    const getRebalanceStatus = vi.fn(async () => ({
+    const getRebalanceStatus = vi.fn(async (..._args: unknown[]): Promise<GetRebalanceStatusResult> => ({
       state: "IDLE" as const,
     }));
 
@@ -186,11 +188,11 @@ describe("runLiquidityBatch", () => {
       liquidityRequestId: liquidityRequest.id,
       liquidityPendingReason: "hot wallet underfunded",
     });
-    const ensureChainLiquidity = vi.fn(async () => ({
+    const ensureChainLiquidity = vi.fn(async (..._args: unknown[]): Promise<EnsureChainLiquidityResult> => ({
       state: "FUNDED" as const,
       started: false,
     }));
-    const getRebalanceStatus = vi.fn(async () => ({
+    const getRebalanceStatus = vi.fn(async (..._args: unknown[]): Promise<GetRebalanceStatusResult> => ({
       state: "FUNDED" as const,
     }));
     const getLiquidityCapabilities = vi.fn(async () => ({
@@ -263,11 +265,11 @@ describe("runLiquidityBatch", () => {
       liquidityRequestId: liquidityRequest.id,
       liquidityPendingReason: "hot wallet underfunded",
     });
-    const ensureChainLiquidity = vi.fn(async () => ({
+    const ensureChainLiquidity = vi.fn(async (..._args: unknown[]): Promise<EnsureChainLiquidityResult> => ({
       state: "PENDING" as const,
       started: true,
     }));
-    const getRebalanceStatus = vi.fn(async () => ({
+    const getRebalanceStatus = vi.fn(async (..._args: unknown[]): Promise<GetRebalanceStatusResult> => ({
       state: "IDLE" as const,
     }));
     const getLiquidityCapabilities = vi.fn(async () => ({
@@ -355,14 +357,14 @@ describe("runLiquidityBatch", () => {
       network: "AGGRON4" as const,
       availableAmount: "0",
     }));
-    const ensureChainLiquidity = vi.fn(async () => ({
+    const ensureChainLiquidity = vi.fn(async (..._args: unknown[]): Promise<EnsureChainLiquidityResult> => ({
       state: "PENDING" as const,
       started: true,
       recoveryStrategy: "LOCAL_CKB_SWEEP" as const,
       txHash: "0xsweep",
       trackingNetwork: "AGGRON4" as const,
     }));
-    const getRebalanceStatus = vi.fn(async () => ({
+    const getRebalanceStatus = vi.fn(async (..._args: unknown[]): Promise<GetRebalanceStatusResult> => ({
       state: "IDLE" as const,
     }));
 
@@ -450,11 +452,11 @@ describe("runLiquidityBatch", () => {
       liquidityPendingReason: "hot wallet underfunded",
     });
 
-    const ensureChainLiquidity = vi.fn(async () => ({
+    const ensureChainLiquidity = vi.fn(async (..._args: unknown[]): Promise<EnsureChainLiquidityResult> => ({
       state: "PENDING" as const,
       started: true,
     }));
-    const getRebalanceStatus = vi.fn(async () => ({
+    const getRebalanceStatus = vi.fn(async (..._args: unknown[]): Promise<GetRebalanceStatusResult> => ({
       state: "IDLE" as const,
     }));
 
@@ -517,12 +519,12 @@ describe("runLiquidityBatch", () => {
       liquidityRequestId: liquidityRequest.id,
       liquidityPendingReason: "hot wallet underfunded",
     });
-    const ensureChainLiquidity = vi.fn(async () => ({
+    const ensureChainLiquidity = vi.fn(async (..._args: unknown[]): Promise<EnsureChainLiquidityResult> => ({
       state: "FAILED" as const,
       started: false,
       error: "unsupported",
     }));
-    const getRebalanceStatus = vi.fn(async () => {
+    const getRebalanceStatus = vi.fn(async (..._args: unknown[]): Promise<GetRebalanceStatusResult> => {
       throw new Error("getRebalanceStatus should not be called when direct rebalance is unsupported");
     });
     const getLiquidityCapabilities = vi.fn(async () => ({

--- a/fiber-link-service/apps/worker/src/logger-contract.test.ts
+++ b/fiber-link-service/apps/worker/src/logger-contract.test.ts
@@ -43,7 +43,7 @@ describe("worker structured logging contract", () => {
       shutdownTimeoutMs: 100,
       runWithdrawalBatch: async () => undefined,
       exitFn: () => undefined,
-      setIntervalFn: () => 1 as unknown as ReturnType<typeof setInterval>,
+      setIntervalFn: (() => 1) as unknown as typeof setInterval,
       clearIntervalFn: () => undefined,
     });
     await runtime.start();
@@ -104,7 +104,7 @@ describe("worker structured logging contract", () => {
       ledgerRepo,
     });
 
-    await emit?.(intent.invoice);
+    await (emit as ((invoice: string) => void | Promise<void>) | null)?.(intent.invoice);
     await runner.close();
 
     const payload = logs.find(

--- a/fiber-link-service/apps/worker/src/settlement-subscription-runner.integration.test.ts
+++ b/fiber-link-service/apps/worker/src/settlement-subscription-runner.integration.test.ts
@@ -69,8 +69,8 @@ describe("settlement subscription strategy integration", () => {
       },
     });
 
-    await emit?.(subscriptionIntent.invoice);
-    await emit?.(subscriptionIntent.invoice);
+    await (emit as ((invoice: string) => void | Promise<void>) | null)?.(subscriptionIntent.invoice);
+    await (emit as ((invoice: string) => void | Promise<void>) | null)?.(subscriptionIntent.invoice);
 
     const summary = await runSettlementDiscovery({
       limit: 10,
@@ -132,7 +132,7 @@ describe("settlement subscription strategy integration", () => {
       },
     });
 
-    await emit?.("missing-invoice");
+    await (emit as ((invoice: string) => void | Promise<void>) | null)?.("missing-invoice");
 
     const summary = await runSettlementDiscovery({
       limit: 10,
@@ -217,7 +217,7 @@ describe("settlement subscription strategy integration", () => {
       },
     });
 
-    emitBurst?.([first.invoice, second.invoice, third.invoice]);
+    (emitBurst as ((invoices: string[]) => void) | null)?.([first.invoice, second.invoice, third.invoice]);
     await runner.close();
 
     expect(overflowed).toHaveLength(2);

--- a/fiber-link-service/apps/worker/src/settlement-subscription-runner.test.ts
+++ b/fiber-link-service/apps/worker/src/settlement-subscription-runner.test.ts
@@ -49,9 +49,9 @@ describe("startSettlementSubscriptionRunner", () => {
       },
     });
 
-    await onSettled?.("inv-1");
-    await onSettled?.("inv-2");
-    await onSettled?.("inv-3");
+    await (onSettled as ((invoice: string) => void | Promise<void>) | null)?.("inv-1");
+    await (onSettled as ((invoice: string) => void | Promise<void>) | null)?.("inv-2");
+    await (onSettled as ((invoice: string) => void | Promise<void>) | null)?.("inv-3");
     await Promise.resolve();
 
     expect(settleMock).toHaveBeenCalledTimes(1);
@@ -91,9 +91,9 @@ describe("startSettlementSubscriptionRunner", () => {
       },
     });
 
-    await onSettled?.("inv-dup");
-    await onSettled?.("inv-dup");
-    await onSettled?.("inv-dup");
+    await (onSettled as ((invoice: string) => void | Promise<void>) | null)?.("inv-dup");
+    await (onSettled as ((invoice: string) => void | Promise<void>) | null)?.("inv-dup");
+    await (onSettled as ((invoice: string) => void | Promise<void>) | null)?.("inv-dup");
     await runner.close();
 
     expect(settleMock).toHaveBeenCalledTimes(1);
@@ -127,7 +127,7 @@ describe("startSettlementSubscriptionRunner", () => {
       },
     });
 
-    await onSettled?.("inv-close");
+    await (onSettled as ((invoice: string) => void | Promise<void>) | null)?.("inv-close");
     await Promise.resolve();
 
     let closed = false;

--- a/fiber-link-service/apps/worker/src/settlement.test.ts
+++ b/fiber-link-service/apps/worker/src/settlement.test.ts
@@ -30,7 +30,7 @@ describe("settlement worker", () => {
     const res = await markSettled({ invoice: "inv-1" }, { tipIntentRepo, ledgerRepo });
     expect(res.credited).toBe(true);
 
-    const ledgerEntries = ledgerRepo.__listForTests();
+    const ledgerEntries = ledgerRepo.__listForTests!();
     expect(ledgerEntries).toHaveLength(1);
     expect(ledgerEntries[0].idempotencyKey).toBe(settlementCreditIdempotencyKey(intent.id));
   });
@@ -72,7 +72,7 @@ describe("settlement worker", () => {
     const second = await markSettled({ invoice: "inv-2" }, { tipIntentRepo, ledgerRepo });
     expect(first.credited).toBe(true);
     expect(second.credited).toBe(false);
-    expect(ledgerRepo.__listForTests()).toHaveLength(1);
+    expect(ledgerRepo.__listForTests!()).toHaveLength(1);
   });
 
   it("marks invoice SETTLED even when credit already exists from previous attempt", async () => {

--- a/fiber-link-service/apps/worker/src/withdrawal-batch.test.ts
+++ b/fiber-link-service/apps/worker/src/withdrawal-batch.test.ts
@@ -6,12 +6,16 @@ import {
 } from "@fiber-link/db";
 import { FiberRpcError, WithdrawalExecutionError } from "@fiber-link/fiber-adapter";
 import { runWithdrawalBatch } from "./withdrawal-batch";
+import type { NotificationDispatchSummary, WithdrawalNotificationEvent } from "@fiber-link/notifications";
+
+const dispatchTipSettledEvent = async (): Promise<NotificationDispatchSummary> =>
+  ({ matched: 0, attempted: 0, delivered: 0, failed: 0 });
 
 describe("runWithdrawalBatch", () => {
   const repo = createInMemoryWithdrawalRepo();
 
   beforeEach(() => {
-    repo.__resetForTests();
+    repo.__resetForTests!();
   });
 
   afterEach(() => {
@@ -322,7 +326,7 @@ describe("runWithdrawalBatch", () => {
       amount: "10",
       toAddress: "fiber:invoice:ok-notify",
     });
-    const dispatchWithdrawalEvent = vi.fn(async () => ({
+    const dispatchWithdrawalEvent = vi.fn(async (_event: WithdrawalNotificationEvent) => ({
       matched: 0,
       attempted: 0,
       delivered: 0,
@@ -334,7 +338,7 @@ describe("runWithdrawalBatch", () => {
       executeWithdrawal: async () => ({ ok: true, txHash: "0xnotifyok" }),
       repo,
       ledgerRepo: ledger,
-      notificationDispatcher: { dispatchWithdrawalEvent },
+      notificationDispatcher: { dispatchWithdrawalEvent, dispatchTipSettledEvent },
     });
 
     expect(res.completed).toBe(1);
@@ -358,7 +362,7 @@ describe("runWithdrawalBatch", () => {
       amount: "10",
       toAddress: "fiber:invoice:retry-notify",
     });
-    const dispatchWithdrawalEvent = vi.fn(async () => ({
+    const dispatchWithdrawalEvent = vi.fn(async (_event: WithdrawalNotificationEvent) => ({
       matched: 0,
       attempted: 0,
       delivered: 0,
@@ -374,13 +378,16 @@ describe("runWithdrawalBatch", () => {
         reason: "rpc overloaded",
       }),
       repo,
-      notificationDispatcher: { dispatchWithdrawalEvent },
+      notificationDispatcher: { dispatchWithdrawalEvent, dispatchTipSettledEvent },
     });
 
     expect(res.retryPending).toBe(1);
     expect(dispatchWithdrawalEvent).toHaveBeenCalledTimes(1);
-    const [event] = dispatchWithdrawalEvent.mock.calls[0];
+    const [event] = dispatchWithdrawalEvent.mock.calls[0]!;
     expect(event.type).toBe("WITHDRAWAL_RETRY_PENDING");
+    if (event.type !== "WITHDRAWAL_RETRY_PENDING") {
+      throw new Error("expected a WITHDRAWAL_RETRY_PENDING event");
+    }
     expect(event.error).toContain("rpc overloaded");
     expect(event.retryCount).toBe(1);
     expect(event.nextRetryAt?.toISOString()).toBe("2026-02-07T12:21:00.000Z");
@@ -394,7 +401,7 @@ describe("runWithdrawalBatch", () => {
       amount: "10",
       toAddress: "fiber:invoice:failed-notify",
     });
-    const dispatchWithdrawalEvent = vi.fn(async () => ({
+    const dispatchWithdrawalEvent = vi.fn(async (_event: WithdrawalNotificationEvent) => ({
       matched: 0,
       attempted: 0,
       delivered: 0,
@@ -409,7 +416,7 @@ describe("runWithdrawalBatch", () => {
         reason: "bad address format",
       }),
       repo,
-      notificationDispatcher: { dispatchWithdrawalEvent },
+      notificationDispatcher: { dispatchWithdrawalEvent, dispatchTipSettledEvent },
     });
 
     expect(res.failed).toBe(1);
@@ -442,6 +449,7 @@ describe("runWithdrawalBatch", () => {
         dispatchWithdrawalEvent: vi.fn(async () => {
           throw new Error("notification provider unavailable");
         }),
+        dispatchTipSettledEvent,
       },
     });
 

--- a/fiber-link-service/apps/worker/src/worker-runtime.test.ts
+++ b/fiber-link-service/apps/worker/src/worker-runtime.test.ts
@@ -33,10 +33,10 @@ describe("createWorkerRuntime", () => {
           await aborted;
         }
       },
-      setIntervalFn: (tick) => {
+      setIntervalFn: ((tick: () => void) => {
         ticks.push(tick);
         return 1 as unknown as ReturnType<typeof setInterval>;
-      },
+      }) as unknown as typeof setInterval,
       clearIntervalFn: () => {},
       exitFn: (code) => {
         exitCodes.push(code);
@@ -73,10 +73,10 @@ describe("createWorkerRuntime", () => {
           await deferred.promise;
         }
       },
-      setIntervalFn: (tick) => {
+      setIntervalFn: ((tick: () => void) => {
         ticks.push(tick);
         return 1 as unknown as ReturnType<typeof setInterval>;
-      },
+      }) as unknown as typeof setInterval,
       clearIntervalFn: () => {},
       exitFn: (code) => {
         exitCodes.push(code);
@@ -115,10 +115,10 @@ describe("createWorkerRuntime", () => {
           await deferred.promise;
         }
       },
-      setIntervalFn: (tick) => {
+      setIntervalFn: ((tick: () => void) => {
         ticks.push(tick);
         return 1 as unknown as ReturnType<typeof setInterval>;
-      },
+      }) as unknown as typeof setInterval,
       clearIntervalFn: () => {},
       exitFn: (code) => {
         exitCodes.push(code);
@@ -153,10 +153,10 @@ describe("createWorkerRuntime", () => {
       pollSettlements: async ({ limit }) => {
         pollCalls.push(limit);
       },
-      setIntervalFn: (tick) => {
+      setIntervalFn: ((tick: () => void) => {
         ticks.push(tick);
         return 1 as unknown as ReturnType<typeof setInterval>;
-      },
+      }) as unknown as typeof setInterval,
       clearIntervalFn: () => {},
       exitFn: () => {},
       logger: {
@@ -197,10 +197,10 @@ describe("createWorkerRuntime", () => {
           await deferred.promise;
         }
       },
-      setIntervalFn: (tick) => {
+      setIntervalFn: ((tick: () => void) => {
         ticks.push(tick);
         return 1 as unknown as ReturnType<typeof setInterval>;
-      },
+      }) as unknown as typeof setInterval,
       clearIntervalFn: () => {},
       exitFn: () => {},
       logger: {

--- a/fiber-link-service/apps/worker/tsconfig.json
+++ b/fiber-link-service/apps/worker/tsconfig.json
@@ -10,9 +10,6 @@
     "src/**/*"
   ],
   "exclude": [
-    "node_modules",
-    "src/**/*.test.ts",
-    "src/**/*.e2e.test.ts",
-    "src/**/*.integration.test.ts"
+    "node_modules"
   ]
 }

--- a/fiber-link-service/packages/client/tsconfig.json
+++ b/fiber-link-service/packages/client/tsconfig.json
@@ -10,9 +10,6 @@
     "src/**/*"
   ],
   "exclude": [
-    "node_modules",
-    "src/**/*.test.ts",
-    "src/**/*.e2e.test.ts",
-    "src/**/*.integration.test.ts"
+    "node_modules"
   ]
 }

--- a/fiber-link-service/packages/db/src/liquidity-request-repo.test.ts
+++ b/fiber-link-service/packages/db/src/liquidity-request-repo.test.ts
@@ -6,9 +6,10 @@ import {
   LiquidityRequestStateTransitionError,
   createDbLiquidityRequestRepo,
   createInMemoryLiquidityRequestRepo,
+  type LiquidityRequestRecord,
 } from "./liquidity-request-repo";
 
-function mockRow(overrides: Record<string, unknown> = {}) {
+function mockRow(overrides: Partial<LiquidityRequestRecord> = {}): LiquidityRequestRecord {
   return {
     id: "liq1",
     appId: "app1",
@@ -30,7 +31,7 @@ function mockRow(overrides: Record<string, unknown> = {}) {
 function createDbMock() {
   const insertReturning = vi.fn();
   const insertOnConflictDoUpdate = vi.fn(() => ({ returning: insertReturning }));
-  const insertValues = vi.fn(() => ({ returning: insertReturning, onConflictDoUpdate: insertOnConflictDoUpdate }));
+  const insertValues = vi.fn((..._args: unknown[]) => ({ returning: insertReturning, onConflictDoUpdate: insertOnConflictDoUpdate }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
   const selectLimit = vi.fn();

--- a/fiber-link-service/packages/db/src/schema.test.ts
+++ b/fiber-link-service/packages/db/src/schema.test.ts
@@ -142,7 +142,7 @@ describe("schema", () => {
 
     expect(openUnique).toBeDefined();
     expect(openUnique?.config.unique).toBe(true);
-    expect(openUnique?.config.columns.map((column) => column.name)).toEqual([
+    expect(openUnique?.config.columns.map((column) => (column as { name: string }).name)).toEqual([
       "app_id",
       "asset",
       "network",

--- a/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
@@ -196,8 +196,8 @@ describe("createDbWithdrawalRepo", () => {
       ),
     ).rejects.toBeInstanceOf(InsufficientFundsError);
 
-    expect((db as unknown as { transaction: ReturnType<typeof vi.fn> }).transaction).toHaveBeenCalledTimes(1);
-    expect((tx as unknown as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(db.transaction)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(tx.execute)).toHaveBeenCalledTimes(1);
   });
 
   it("infers destination kind from CKB address in create()", async () => {
@@ -338,7 +338,7 @@ describe("createDbWithdrawalRepo", () => {
     );
 
     expect(created.state).toBe("LIQUIDITY_PENDING");
-    expect((tx as unknown as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(tx.execute)).toHaveBeenCalledTimes(1);
     const valuesArg = txInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(valuesArg.state).toBe("LIQUIDITY_PENDING");
     expect(valuesArg.liquidityRequestId).toBe("liq1");
@@ -433,7 +433,7 @@ describe("createDbWithdrawalRepo", () => {
     );
 
     expect(created.id).toBe("w2");
-    expect((tx as unknown as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(tx.execute)).toHaveBeenCalledTimes(1);
     expect(txInsert).toHaveBeenCalledTimes(1);
   });
 

--- a/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
+++ b/fiber-link-service/packages/db/src/withdrawal-repo.test.ts
@@ -12,13 +12,7 @@ import {
   createInMemoryWithdrawalRepo,
 } from "./withdrawal-repo";
 
-type DbMock = {
-  db: DbClient;
-  updateSet: ReturnType<typeof vi.fn>;
-  updateReturning: ReturnType<typeof vi.fn>;
-  selectLimit: ReturnType<typeof vi.fn>;
-  selectWhere: ReturnType<typeof vi.fn>;
-};
+type DbMock = ReturnType<typeof createDbMock>;
 
 function mockRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -44,19 +38,19 @@ function mockRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function createDbMock(): DbMock {
+function createDbMock() {
   const insertReturning = vi.fn();
-  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insertValues = vi.fn((..._args: unknown[]) => ({ returning: insertReturning }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
-  const selectLimit = vi.fn();
-  const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+  const selectLimit = vi.fn<unknown[], unknown>();
+  const selectWhere = vi.fn((..._args: unknown[]): unknown => ({ limit: selectLimit }));
   const selectFrom = vi.fn(() => ({ where: selectWhere }));
   const select = vi.fn(() => ({ from: selectFrom }));
 
   const updateReturning = vi.fn();
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
-  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const updateSet = vi.fn((..._args: unknown[]) => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
 
   const db = {
@@ -202,8 +196,8 @@ describe("createDbWithdrawalRepo", () => {
       ),
     ).rejects.toBeInstanceOf(InsufficientFundsError);
 
-    expect((db as { transaction: ReturnType<typeof vi.fn> }).transaction).toHaveBeenCalledTimes(1);
-    expect((tx as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+    expect((db as unknown as { transaction: ReturnType<typeof vi.fn> }).transaction).toHaveBeenCalledTimes(1);
+    expect((tx as unknown as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
   });
 
   it("infers destination kind from CKB address in create()", async () => {
@@ -213,7 +207,7 @@ describe("createDbWithdrawalRepo", () => {
         toAddress: "ckt1qyqfth8m4fevfzh5hhd088s78qcdjjp8cehs7z8jhw",
       }),
     ]);
-    const insertValues = vi.fn(() => ({ returning: insertReturning }));
+    const insertValues = vi.fn((..._args: unknown[]) => ({ returning: insertReturning }));
     const insert = vi.fn(() => ({ values: insertValues }));
     const db = { insert } as unknown as DbClient;
     const repo = createDbWithdrawalRepo(db);
@@ -238,7 +232,7 @@ describe("createDbWithdrawalRepo", () => {
         toAddress: "fiber:invoice:abc",
       }),
     ]);
-    const insertValues = vi.fn(() => ({ returning: insertReturning }));
+    const insertValues = vi.fn((..._args: unknown[]) => ({ returning: insertReturning }));
     const insert = vi.fn(() => ({ values: insertValues }));
     const db = { insert } as unknown as DbClient;
     const repo = createDbWithdrawalRepo(db);
@@ -270,7 +264,7 @@ describe("createDbWithdrawalRepo", () => {
         liquidityCheckedAt: new Date("2026-03-07T00:00:00.000Z"),
       }),
     ]);
-    const insertValues = vi.fn(() => ({ returning: insertReturning }));
+    const insertValues = vi.fn((..._args: unknown[]) => ({ returning: insertReturning }));
     const insert = vi.fn(() => ({ values: insertValues }));
     const db = { insert } as unknown as DbClient;
     const repo = createDbWithdrawalRepo(db);
@@ -316,7 +310,7 @@ describe("createDbWithdrawalRepo", () => {
         liquidityCheckedAt: new Date("2026-03-07T00:00:00.000Z"),
       }),
     ]);
-    const txInsertValues = vi.fn(() => ({ returning: txInsertReturning }));
+    const txInsertValues = vi.fn((..._args: unknown[]) => ({ returning: txInsertReturning }));
     const txInsert = vi.fn(() => ({ values: txInsertValues }));
 
     const tx = {
@@ -344,7 +338,7 @@ describe("createDbWithdrawalRepo", () => {
     );
 
     expect(created.state).toBe("LIQUIDITY_PENDING");
-    expect((tx as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+    expect((tx as unknown as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
     const valuesArg = txInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(valuesArg.state).toBe("LIQUIDITY_PENDING");
     expect(valuesArg.liquidityRequestId).toBe("liq1");
@@ -413,7 +407,7 @@ describe("createDbWithdrawalRepo", () => {
         toAddress: "fiber:invoice:new",
       }),
     ]);
-    const txInsertValues = vi.fn(() => ({ returning: txInsertReturning }));
+    const txInsertValues = vi.fn((..._args: unknown[]) => ({ returning: txInsertReturning }));
     const txInsert = vi.fn(() => ({ values: txInsertValues }));
 
     const tx = {
@@ -439,7 +433,7 @@ describe("createDbWithdrawalRepo", () => {
     );
 
     expect(created.id).toBe("w2");
-    expect((tx as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+    expect((tx as unknown as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
     expect(txInsert).toHaveBeenCalledTimes(1);
   });
 

--- a/fiber-link-service/packages/db/tsconfig.json
+++ b/fiber-link-service/packages/db/tsconfig.json
@@ -10,9 +10,6 @@
     "src/**/*"
   ],
   "exclude": [
-    "node_modules",
-    "src/**/*.test.ts",
-    "src/**/*.e2e.test.ts",
-    "src/**/*.integration.test.ts"
+    "node_modules"
   ]
 }

--- a/fiber-link-service/packages/fiber-adapter/src/fiber-client.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/fiber-client.test.ts
@@ -14,7 +14,7 @@ describe("rpcCall", () => {
       json: async () => {
         throw new SyntaxError("Unexpected token <");
       },
-    } as Response);
+    } as unknown as Response);
 
     await expect(rpcCall("http://localhost:8119", "health", {}, { retryCount: 0 })).rejects.toBeInstanceOf(FiberRpcError);
     await expect(rpcCall("http://localhost:8119", "health", {}, { retryCount: 0 })).rejects.toMatchObject({
@@ -28,7 +28,7 @@ describe("rpcCall", () => {
     const fetchFn = vi
       .fn()
       .mockResolvedValueOnce({ ok: false, status: 503 } as Response)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as Response);
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as unknown as Response);
 
     const pending = rpcCall("http://localhost:8119", "health", {}, { fetchFn, retryCount: 1, retryDelayMs: 10 });
     await vi.advanceTimersByTimeAsync(10);
@@ -64,7 +64,7 @@ describe("rpcCall", () => {
           init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
         });
       })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as Response);
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as unknown as Response);
 
     const pending = rpcCall("http://localhost:8119", "health", {}, { fetchFn, timeoutMs: 25, retryCount: 1, retryDelayMs: 10 });
     await vi.advanceTimersByTimeAsync(25);
@@ -94,7 +94,7 @@ describe("rpcCall", () => {
     const fetchFn = vi
       .fn()
       .mockRejectedValueOnce(new TypeError("socket hang up"))
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as Response);
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: "ok" }) } as unknown as Response);
 
     const pending = rpcCall("http://localhost:8119", "health", {}, { fetchFn, retryCount: 1, retryDelayMs: 10 });
     await vi.advanceTimersByTimeAsync(10);
@@ -107,7 +107,7 @@ describe("rpcCall", () => {
     const fetchFn = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ error: { code: -32602, message: "invalid params" } }),
-    } as Response);
+    } as unknown as Response);
 
     await expect(rpcCall("http://localhost:8119", "health", {}, { fetchFn, retryCount: 2 })).rejects.toMatchObject({
       name: "FiberRpcError",

--- a/fiber-link-service/packages/fiber-adapter/src/hot-wallet-inventory.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/hot-wallet-inventory.test.ts
@@ -15,6 +15,13 @@ function encodeUdtAmount(amount: bigint): string {
   return `0x${Buffer.from(bytes).toString("hex")}`;
 }
 
+function expectUsdi(inventory: { availableAmount: string }): { availableAmount: string; supportingCkbAmount: string } {
+  if (!("supportingCkbAmount" in inventory)) {
+    throw new Error("expected a USDI inventory with supportingCkbAmount");
+  }
+  return inventory as { availableAmount: string; supportingCkbAmount: string };
+}
+
 describe("getHotWalletInventory", () => {
   const deps = {
     getNativeCells: async () => [{ capacity: ckbToHexShannons(120n) }, { capacity: ckbToHexShannons(80n) }],
@@ -34,7 +41,7 @@ describe("getHotWalletInventory", () => {
   it("returns USDI liquidity plus required CKB support capacity", async () => {
     const inventory = await getHotWalletInventory({ asset: "USDI", network: "AGGRON4" }, deps);
     expect(inventory.availableAmount).toBe("500");
-    expect(inventory.supportingCkbAmount).toBe("120");
+    expect(expectUsdi(inventory).supportingCkbAmount).toBe("120");
   });
 
   it("formats USDI availableAmount as a canonical decimal asset-unit string when decimals are configured", async () => {
@@ -48,7 +55,7 @@ describe("getHotWalletInventory", () => {
     );
 
     expect(inventory.availableAmount).toBe("5.5");
-    expect(inventory.supportingCkbAmount).toBe("62");
+    expect(expectUsdi(inventory).supportingCkbAmount).toBe("62");
   });
 
   it("uses zero supporting fee when estimateUsdiFeeShannons is omitted", async () => {
@@ -56,7 +63,7 @@ describe("getHotWalletInventory", () => {
     const inventory = await getHotWalletInventory({ asset: "USDI", network: "AGGRON4" }, depsWithoutFee);
 
     expect(inventory.availableAmount).toBe("500");
-    expect(inventory.supportingCkbAmount).toBe("119");
+    expect(expectUsdi(inventory).supportingCkbAmount).toBe("119");
   });
 
   it("throws when USDI decimals dependency is missing", async () => {
@@ -65,7 +72,7 @@ describe("getHotWalletInventory", () => {
     await expect(
       getHotWalletInventory(
         { asset: "USDI", network: "AGGRON4" },
-        depsWithoutDecimals as Parameters<typeof getHotWalletInventory>[1],
+        depsWithoutDecimals as unknown as Parameters<typeof getHotWalletInventory>[1],
       ),
     ).rejects.toThrow("getUsdiDecimals is required for USDI inventory");
   });

--- a/fiber-link-service/packages/fiber-adapter/tsconfig.json
+++ b/fiber-link-service/packages/fiber-adapter/tsconfig.json
@@ -10,9 +10,6 @@
     "src/**/*"
   ],
   "exclude": [
-    "node_modules",
-    "src/**/*.test.ts",
-    "src/**/*.e2e.test.ts",
-    "src/**/*.integration.test.ts"
+    "node_modules"
   ]
 }

--- a/fiber-link-service/packages/notifications/src/webhook-handler.test.ts
+++ b/fiber-link-service/packages/notifications/src/webhook-handler.test.ts
@@ -29,7 +29,7 @@ const COMPLETED_EVENT: WithdrawalCompletedNotificationEvent = {
 describe("createWebhookChannelHandler", () => {
   it("POSTs JSON payload to the target URL", async () => {
     const requests: Request[] = [];
-    const mockFetch = vi.fn(async (input: RequestInfo | URL) => {
+    const mockFetch = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
       requests.push(input as Request);
       return new Response(null, { status: 200 });
     });
@@ -51,7 +51,7 @@ describe("createWebhookChannelHandler", () => {
 
   it("adds HMAC-SHA256 signature header when channel has a secret", async () => {
     const secret = "super-secret";
-    const mockFetch = vi.fn(async () => new Response(null, { status: 200 }));
+    const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => new Response(null, { status: 200 }));
 
     const handler = createWebhookChannelHandler({ fetch: mockFetch as unknown as typeof fetch });
     await handler({
@@ -68,7 +68,7 @@ describe("createWebhookChannelHandler", () => {
   });
 
   it("omits signature header when channel has no secret", async () => {
-    const mockFetch = vi.fn(async () => new Response(null, { status: 200 }));
+    const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => new Response(null, { status: 200 }));
     const handler = createWebhookChannelHandler({ fetch: mockFetch as unknown as typeof fetch });
     await handler({ target: BASE_TARGET, event: COMPLETED_EVENT });
 
@@ -77,14 +77,14 @@ describe("createWebhookChannelHandler", () => {
   });
 
   it("throws when endpoint returns a non-2xx status", async () => {
-    const mockFetch = vi.fn(async () => new Response("Not Found", { status: 404 }));
+    const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => new Response("Not Found", { status: 404 }));
     const handler = createWebhookChannelHandler({ fetch: mockFetch as unknown as typeof fetch });
 
     await expect(handler({ target: BASE_TARGET, event: COMPLETED_EVENT })).rejects.toThrow("HTTP 404");
   });
 
   it("includes a response body snippet in the non-2xx error message", async () => {
-    const mockFetch = vi.fn(async () => new Response('{"error":"invalid_token"}', { status: 401 }));
+    const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => new Response('{"error":"invalid_token"}', { status: 401 }));
     const handler = createWebhookChannelHandler({ fetch: mockFetch as unknown as typeof fetch });
 
     await expect(handler({ target: BASE_TARGET, event: COMPLETED_EVENT })).rejects.toThrow(
@@ -94,7 +94,7 @@ describe("createWebhookChannelHandler", () => {
 
   it("truncates long response bodies to 200 characters in the error message", async () => {
     const longBody = "x".repeat(500);
-    const mockFetch = vi.fn(async () => new Response(longBody, { status: 500 }));
+    const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => new Response(longBody, { status: 500 }));
     const handler = createWebhookChannelHandler({ fetch: mockFetch as unknown as typeof fetch });
 
     await expect(handler({ target: BASE_TARGET, event: COMPLETED_EVENT })).rejects.toThrow(
@@ -103,7 +103,7 @@ describe("createWebhookChannelHandler", () => {
   });
 
   it("includes retry-pending fields for WITHDRAWAL_RETRY_PENDING events", async () => {
-    const mockFetch = vi.fn(async () => new Response(null, { status: 200 }));
+    const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => new Response(null, { status: 200 }));
     const handler = createWebhookChannelHandler({ fetch: mockFetch as unknown as typeof fetch });
 
     const event: WithdrawalRetryPendingNotificationEvent = {
@@ -129,7 +129,7 @@ describe("createWebhookChannelHandler", () => {
   });
 
   it("includes error and retryCount for WITHDRAWAL_FAILED events", async () => {
-    const mockFetch = vi.fn(async () => new Response(null, { status: 200 }));
+    const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => new Response(null, { status: 200 }));
     const handler = createWebhookChannelHandler({ fetch: mockFetch as unknown as typeof fetch });
 
     const event: WithdrawalFailedNotificationEvent = {

--- a/fiber-link-service/packages/notifications/tsconfig.json
+++ b/fiber-link-service/packages/notifications/tsconfig.json
@@ -10,9 +10,6 @@
     "src/**/*"
   ],
   "exclude": [
-    "node_modules",
-    "src/**/*.test.ts",
-    "src/**/*.e2e.test.ts",
-    "src/**/*.integration.test.ts"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
## Summary

- [x] Briefly summarize what changed and why.

Completes the strict-typecheck rollout from #485: the `src/**/*.test.ts` excludes are removed from every workspace `tsconfig.json`, so the entire tree (including tests) now checks under `strict`. This surfaced ~90 errors, all fixed. Most were mechanical mock typings — argument tuples for `vi.fn` mocks whose `.mock.calls` get inspected, `unknown`-mediated casts, and letting factory return types be inferred instead of hand-written `Mock` generics — plus a few fixes that make tests match the real contracts:

- `withdrawal-batch` dispatcher mocks now implement the full `NotificationDispatcher` (`dispatchTipSettledEvent` was missing), and the retry assertion narrows the event union before reading `error`/`retryCount`/`nextRetryAt`.
- The `liquidity-batch` sweep mock now carries its `LOCAL_CKB_SWEEP` discriminant — the previous shape (`txHash` without `recoveryStrategy`) is unrepresentable in `EnsureChainLiquidityResult` and exercised an impossible state.
- The rpc `dashboard.summary` fixture and its expected literal gained the `activityType`/`txHash`/`explorerUrl`/`destinationKind`/`destination` fields the real handler always returns.
- `hot-wallet-inventory` assertions narrow the CKB/USDI inventory union before reading `supportingCkbAmount`.
- `nonce-store`/`rate-limit` tests use the `ioredis` type for casts instead of the `ioredis-mock` value import.

## Scope

- [x] Filesystem scope is limited to this PR: `fiber-link-service/**` — 7 tsconfigs + 17 test files. No production source changes.

## Verification

- [x] Relevant local checks run
  - `tsc --noEmit`: **0 errors across all 7 workspaces** (tests included).
  - Test suites: admin 105, worker 149, db 133, fiber-adapter 68, notifications 15, client 17 — all pass; rpc 125/126 (the 1 failure is the known sandbox-only network-blocked test that passes in CI).

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (if applicable) — closes the "test-file typing cleanup" follow-up noted in #485
- [x] Required discussions or follow-ups are documented

## Notes

- Behavioral risk is minimal: assertions were strengthened (union narrowing before field reads), never weakened; the two fixture completions align mocks with what production code actually returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_