### PR TITLE
ci: include fiber-adapter, notifications, and client in the coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
           run_pkg apps/admin admin
           run_pkg apps/worker worker
           run_pkg packages/db db
+          run_pkg packages/fiber-adapter fiber-adapter
+          run_pkg packages/notifications notifications
+          run_pkg packages/client client
 
       - name: Collect base branch coverage
         working-directory: fiber-link-service
@@ -187,9 +190,12 @@ jobs:
           run_base_pkg apps/admin admin
           run_base_pkg apps/worker worker
           run_base_pkg packages/db db
+          run_base_pkg packages/fiber-adapter fiber-adapter
+          run_base_pkg packages/notifications notifications
+          run_base_pkg packages/client client
           mkdir -p ../base-coverage-reports
           cp -R "$base_dir/base-coverage-reports/." ../base-coverage-reports/
-          for module in rpc admin worker db; do
+          for module in rpc admin worker db fiber-adapter notifications client; do
             if [ ! -f "../base-coverage-reports/${module}/coverage-summary.json" ] && [ ! -f "../base-coverage-reports/${module}/.status" ]; then
               echo "::error title=base-coverage-layout-mismatch::Expected base coverage outputs for ${module} were not copied to ../base-coverage-reports."
               exit 1
@@ -304,6 +310,9 @@ jobs:
             ['admin','Admin'],
             ['worker','Worker'],
             ['db','DB'],
+            ['fiber-adapter','Fiber Adapter'],
+            ['notifications','Notifications'],
+            ['client','Client SDK'],
           ];
 
           let rows = [];


### PR DESCRIPTION
## Summary

- [x] Briefly summarize what changed and why.

The PR coverage comment only tracked `rpc`/`admin`/`worker`/`db`, so the three packages whose tests were recently gated in CI (#485) had no coverage visibility. This adds `packages/fiber-adapter`, `packages/notifications`, and `packages/client` to:

- the head coverage collection loop (`run_pkg`),
- the base branch collection loop (`run_base_pkg`),
- the copied-output layout check, and
- the markdown report matrix (`Fiber Adapter`, `Notifications`, `Client SDK` rows).

The existing missing/failed status handling covers the new modules unchanged (base `main` already contains all three packages, so deltas compute from the first run).

## Scope

- [x] Filesystem scope is limited to this PR: `.github/workflows/ci.yml` only.

## Verification

- [x] Relevant local checks run
  - Ran the exact CI vitest coverage invocation locally for each new package: fiber-adapter **77.89%**, notifications **70.78%**, client **88.36%** line coverage — all produce `coverage-summary.json` as the report script expects.
  - YAML parses cleanly.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (if applicable) — closes the "coverage matrix" follow-up noted in #485
- [x] Required discussions or follow-ups are documented

## Notes

- The average-line-coverage figure in the comment will drop on first merge simply because three lower-coverage modules join the denominator — that is added visibility, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_