### PR TITLE
i18n(plugin): add server locale and Simplified Chinese translations

### DIFF
--- a/fiber-link-discourse-plugin/config/locales/client.zh_CN.yml
+++ b/fiber-link-discourse-plugin/config/locales/client.zh_CN.yml
@@ -1,0 +1,13 @@
+zh_CN:
+  js:
+    notifications:
+      alt:
+        fiber_link:
+          tip_received_notification: "收到打赏"
+    fiber_link:
+      dashboard:
+        user_menu_link: "Fiber Link 面板"
+      tip_received_notification: "<p><span>%{username}</span> 打赏了你 <span>%{amount} %{asset}</span>。</p>"
+      tip_nudge_text: "发个小额打赏"
+      notification:
+        title: "你收到了一笔打赏"

--- a/fiber-link-discourse-plugin/config/locales/server.en.yml
+++ b/fiber-link-discourse-plugin/config/locales/server.en.yml
@@ -1,0 +1,6 @@
+en:
+  site_settings:
+    fiber_link_enabled: "Enable the Fiber Link tipping plugin."
+    fiber_link_service_url: "Base URL of the Fiber Link backend service the plugin proxies RPC calls to (e.g. https://fiber-link.example.com)."
+    fiber_link_app_id: "App ID registered with the Fiber Link service for this forum."
+    fiber_link_app_secret: "HMAC secret used to sign RPC requests to the Fiber Link service. Keep this confidential."

--- a/fiber-link-discourse-plugin/config/locales/server.zh_CN.yml
+++ b/fiber-link-discourse-plugin/config/locales/server.zh_CN.yml
@@ -1,0 +1,6 @@
+zh_CN:
+  site_settings:
+    fiber_link_enabled: "启用 Fiber Link 打赏插件。"
+    fiber_link_service_url: "插件代理 RPC 请求的 Fiber Link 后端服务地址(例如 https://fiber-link.example.com)。"
+    fiber_link_app_id: "本论坛在 Fiber Link 服务中注册的 App ID。"
+    fiber_link_app_secret: "用于对发往 Fiber Link 服务的 RPC 请求进行 HMAC 签名的密钥,请妥善保密。"

--- a/fiber-link-discourse-plugin/config/locales/server.zh_CN.yml
+++ b/fiber-link-discourse-plugin/config/locales/server.zh_CN.yml
@@ -1,6 +1,6 @@
 zh_CN:
   site_settings:
     fiber_link_enabled: "启用 Fiber Link 打赏插件。"
-    fiber_link_service_url: "插件代理 RPC 请求的 Fiber Link 后端服务地址(例如 https://fiber-link.example.com)。"
+    fiber_link_service_url: "插件代理 RPC 请求的 Fiber Link 后端服务地址（例如 https://fiber-link.example.com）。"
     fiber_link_app_id: "本论坛在 Fiber Link 服务中注册的 App ID。"
-    fiber_link_app_secret: "用于对发往 Fiber Link 服务的 RPC 请求进行 HMAC 签名的密钥,请妥善保密。"
+    fiber_link_app_secret: "用于对发往 Fiber Link 服务的 RPC 请求进行 HMAC 签名的密钥，请妥善保密。"


### PR DESCRIPTION
## Summary

- [x] Briefly summarize what changed and why.

The Discourse plugin shipped only `client.en.yml`: the four site settings (`fiber_link_enabled`, `fiber_link_service_url`, `fiber_link_app_id`, `fiber_link_app_secret`) had no `server.en.yml` descriptions, so the admin settings UI displays raw translation keys; and no non-English locale existed despite the CKB community's large Chinese-speaking user base.

- **`server.en.yml`**: descriptions for all four site settings (including a confidentiality note on the HMAC secret).
- **`client.zh_CN.yml` / `server.zh_CN.yml`**: Simplified Chinese translations of every existing key.

## Scope

- [x] Filesystem scope is limited to this PR: `fiber-link-discourse-plugin/config/locales/` — three new YAML files, nothing else.

## Verification

- [x] Relevant local checks run — all four locale files parse as valid YAML; key structure mirrors `client.en.yml` exactly. The CI `plugin-smoke` job boots Discourse with the plugin (locale files load at boot).

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (if applicable) — follows up the project improvement review (plugin i18n finding)
- [x] Required discussions or follow-ups are documented

## Notes

- Follow-up (not in this PR): the Ember `.gjs` components and the inline boot-fallback script in `plugin.rb` still hardcode English strings; moving those to I18n keys is a larger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_