### PR TITLE
ci: gate admin Next.js production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Test admin
         working-directory: fiber-link-service/apps/admin
         run: bun run test -- --run --silent
+      - name: Build admin
+        working-directory: fiber-link-service/apps/admin
+        run: bun run build
       - name: Test worker
         working-directory: fiber-link-service/apps/worker
         run: bun run test -- --run --silent


### PR DESCRIPTION
## Summary

- [x] Briefly summarize what changed and why.

The admin CI job ran only vitest and typecheck, so build-time errors — RSC boundaries, page-data collection, static generation failures — surfaced only at deploy time. This adds a `next build` step right after the admin tests in the `test-service` job.

## Scope

- [x] Filesystem scope is limited to this PR: `.github/workflows/ci.yml` only (3 lines).

## Verification

- [x] Relevant local checks run
  - Ran `bun run build` in `apps/admin` locally: compiles all 9 pages (`/`, `/apps`, `/apps/[appId]`, `/ops`, `/settlements`, `/settlements/[id]`, `/withdrawals`, `/404`, `/api/trpc/[trpc]`) with **no runtime config** — no `DATABASE_URL` or admin env needed at build time, so CI needs no extra secrets.
  - `.next/` is already gitignored; YAML parses cleanly.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (if applicable) — follows up the next-batch improvement review (missing build gate)
- [x] Required discussions or follow-ups are documented

## Notes

- The build reuses the existing bun install + cache already set up in the job, so the added CI time is just the ~10s Next compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_