### PR TITLE
feat(db): add notification_rules.channel_id foreign key

### DIFF
--- a/fiber-link-service/packages/db/drizzle/0002_notification_rules_channel_fk.sql
+++ b/fiber-link-service/packages/db/drizzle/0002_notification_rules_channel_fk.sql
@@ -1,0 +1,15 @@
+-- Remove any notification_rules rows whose channel no longer exists before
+-- adding the FK, so the constraint can be applied to databases provisioned
+-- from the baseline (which had no FK) and may hold orphans. The FK is
+-- ON DELETE CASCADE, so deleting rules for a missing channel matches the
+-- intended semantics.
+DELETE FROM "notification_rules" nr
+WHERE NOT EXISTS (
+  SELECT 1 FROM "notification_channels" nc WHERE nc."id" = nr."channel_id"
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "notification_rules" ADD CONSTRAINT "notification_rules_channel_id_notification_channels_id_fk" FOREIGN KEY ("channel_id") REFERENCES "public"."notification_channels"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/fiber-link-service/packages/db/drizzle/meta/_journal.json
+++ b/fiber-link-service/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783742963635,
       "tag": "0001_worker_state",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783877469998,
+      "tag": "0002_notification_rules_channel_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/fiber-link-service/packages/db/migrations-archive/README.md
+++ b/fiber-link-service/packages/db/migrations-archive/README.md
@@ -65,9 +65,11 @@ of them:
   both the legacy-named FK and the drizzle-named FK after the baseline replay
   (the guard keys on constraint name). Redundant but harmless; drop the legacy one
   manually if desired.
-- **`notification_rules.channel_id` FK.** The legacy chain created this FK, but
+- **`notification_rules.channel_id` FK.** ~~The legacy chain created this FK, but
   `src/schema.ts` does not declare a `.references()` for it, so fresh databases do
-  not have it. Follow-up candidate: declare the reference in `src/schema.ts`.
+  not have it.~~ Resolved: `src/schema.ts` now declares the reference
+  (`ON DELETE CASCADE`) and migration `0002_notification_rules_channel_fk` adds it
+  to baseline databases (deleting any orphaned rules first).
 
 Note: `0000_baseline.sql` carries one hand-maintained statement — the
 `withdrawals_liquidity_pending_fields_check` check constraint — because drizzle-kit

--- a/fiber-link-service/packages/db/src/schema.ts
+++ b/fiber-link-service/packages/db/src/schema.ts
@@ -332,7 +332,9 @@ export const notificationRules = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     appId: text("app_id").notNull(),
-    channelId: uuid("channel_id").notNull(),
+    channelId: uuid("channel_id")
+      .notNull()
+      .references(() => notificationChannels.id, { onDelete: "cascade" }),
     event: notificationEventEnum("event").notNull(),
     enabled: boolean("enabled").notNull().default(true),
     createdAt: timestamp("created_at").defaultNow().notNull(),


### PR DESCRIPTION
## Summary

- [x] Briefly summarize what changed and why.

Fresh baseline databases lacked the `notification_rules → notification_channels` foreign key that legacy-upgraded databases had (drizzle-kit doesn't emit a constraint the schema never declared). This left the schema divergent between the two provisioning paths and allowed orphaned rules — a rule pointing at a deleted channel — to accumulate on baseline databases. This was the resolved follow-up recorded in the migrations-archive README.

- Declare `.references(() => notificationChannels.id, { onDelete: "cascade" })` on `channelId` in `src/schema.ts`.
- Migration `0002_notification_rules_channel_fk` **deletes orphaned rules first**, then adds the constraint. The DELETE matches the `ON DELETE CASCADE` semantics (a rule whose channel is gone is meaningless), so it applies cleanly to baseline databases that may hold orphans. The `ADD CONSTRAINT` is wrapped in a `duplicate_object` guard, so it is a no-op on legacy databases that already have the FK.

## Scope

- [x] Filesystem scope is limited to this PR: `packages/db/src/schema.ts`, the new migration, and the migrations-archive README note.

## Verification

- [x] Relevant local checks run — against **real Postgres 16**:
  - Fresh chain (`0000` + `0001` + `0002`) creates the FK.
  - Simulated dirty database (baseline + `0001`, then one valid rule + one orphaned rule injected): applying `0002` deletes only the orphan (2 → 1), adds the constraint, and cascade-deletes the remaining rule when its channel is removed (1 → 0).
  - `bun run db:validate` (drift check) clean; `packages/db` suite: 139 tests pass; typecheck clean.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (if applicable) — resolves the `notification_rules.channel_id` FK follow-up from #481's archive README
- [x] Required discussions or follow-ups are documented

## Notes

- Data-loss note: the migration deletes orphaned rules. On a correctly-maintained database there are none (the app always creates rules with a live channel); the delete only removes already-broken rows that could never fire a notification anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_