### PR TITLE
refactor(worker): route long-running-path logs through the structured logger

### DIFF
--- a/fiber-link-service/apps/worker/src/entry.ts
+++ b/fiber-link-service/apps/worker/src/entry.ts
@@ -1,6 +1,7 @@
 import { createAdapterProvider, createDefaultHotWalletInventoryProvider } from "@fiber-link/fiber-adapter";
 import { createDbClient, createDbWorkerStateRepo, type TipIntentListCursor } from "@fiber-link/db";
 import { parseWorkerConfig } from "./config";
+import { createComponentLogger } from "./logger";
 import { runLiquidityBatch } from "./liquidity-batch";
 import { runSettlementDiscovery } from "./settlement-discovery";
 import { createDbSettlementCursorStore, createFileSettlementCursorStore } from "./settlement-cursor-store";
@@ -11,6 +12,8 @@ import {
 import { runWithdrawalBatch } from "./withdrawal-batch";
 import { createSettlementPublisher } from "./settlement-publisher";
 import { createWorkerRuntime } from "./worker-runtime";
+
+const logger = createComponentLogger("worker");
 
 async function main() {
   const config = parseWorkerConfig(process.env);
@@ -124,9 +127,7 @@ async function main() {
 
   if (config.settlementStrategy === "subscription") {
     if (!hasSettlementSubscriptionUrl) {
-      console.warn(
-        "[worker] settlement subscription strategy requested but FIBER_SETTLEMENT_SUBSCRIPTION_URL is not set; using polling fallback only",
-      );
+      logger.warn("worker.settlement_subscription_url_missing", { fallback: "polling" });
     }
 
     try {
@@ -139,7 +140,7 @@ async function main() {
           publisher: settlementPublisher,
         });
       }
-      console.info("[worker] settlement strategy enabled", {
+      logger.info("worker.settlement_strategy_enabled", {
         strategy: "subscription",
         pollingFallback: true,
         subscriptionUrlConfigured: hasSettlementSubscriptionUrl,
@@ -149,10 +150,10 @@ async function main() {
         liquidityFallback,
       });
     } catch (error) {
-      console.error("[worker] settlement subscription startup failed; continuing with polling fallback", error);
+      logger.error("worker.settlement_subscription_startup_failed", { error, fallback: "polling" });
     }
   } else {
-    console.info("[worker] settlement strategy enabled", {
+    logger.info("worker.settlement_strategy_enabled", {
       strategy: "polling",
       pollingFallback: false,
       liquidityFallback,
@@ -162,7 +163,7 @@ async function main() {
   async function shutdown(signal: NodeJS.Signals) {
     await subscriptionRunner?.close();
     await settlementPublisher.close().catch((error) => {
-      console.warn("[worker] settlement publisher close failed", error);
+      logger.warn("worker.settlement_publisher_close_failed", { error });
     });
     await runtime.shutdown(signal);
   }
@@ -178,6 +179,6 @@ async function main() {
 }
 
 void main().catch((error) => {
-  console.error("[worker] startup failed", error);
+  logger.error("worker.startup_failed", { error });
   process.exit(1);
 });

--- a/fiber-link-service/apps/worker/src/entry.ts
+++ b/fiber-link-service/apps/worker/src/entry.ts
@@ -15,6 +15,21 @@ import { createWorkerRuntime } from "./worker-runtime";
 
 const logger = createComponentLogger("worker");
 
+// RPC URLs may carry userinfo (user:pass@host); strip credentials before logging.
+function redactUrlForLog(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.username || u.password) {
+      u.username = "";
+      u.password = "";
+      return `${u.origin}${u.pathname}`;
+    }
+    return url;
+  } catch {
+    return url;
+  }
+}
+
 async function main() {
   const config = parseWorkerConfig(process.env);
   const settlementSubscriptionUrl = (process.env.FIBER_SETTLEMENT_SUBSCRIPTION_URL ?? "").trim();
@@ -56,6 +71,10 @@ async function main() {
     channelRotationBootstrapReserve: config.channelRotationBootstrapReserve,
     channelRotationMinRecoverableAmount: config.channelRotationMinRecoverableAmount,
     channelRotationMaxConcurrent: config.channelRotationMaxConcurrent,
+  };
+  const liquidityFallbackForLog = {
+    ...liquidityFallback,
+    channelAcceptRpcUrl: redactUrlForLog(liquidityFallback.channelAcceptRpcUrl),
   };
 
   const runtime = createWorkerRuntime({
@@ -147,7 +166,7 @@ async function main() {
         subscriptionConcurrency: config.subscriptionConcurrency,
         maxPendingEvents: config.subscriptionMaxPendingEvents,
         recentInvoiceDedupeSize: config.subscriptionRecentInvoiceDedupeSize,
-        liquidityFallback,
+        liquidityFallback: liquidityFallbackForLog,
       });
     } catch (error) {
       logger.error("worker.settlement_subscription_startup_failed", { error, fallback: "polling" });
@@ -156,7 +175,7 @@ async function main() {
     logger.info("worker.settlement_strategy_enabled", {
       strategy: "polling",
       pollingFallback: false,
-      liquidityFallback,
+      liquidityFallback: liquidityFallbackForLog,
     });
   }
 

--- a/fiber-link-service/apps/worker/src/settlement-discovery.ts
+++ b/fiber-link-service/apps/worker/src/settlement-discovery.ts
@@ -122,7 +122,7 @@ function getDefaultTipIntentEventRepo(): TipIntentEventRepo | null {
   try {
     defaultTipIntentEventRepo = createDbTipIntentEventRepo(getDefaultDb());
   } catch (error) {
-    console.error("Failed to initialize default TipIntentEventRepo.", error);
+    defaultLogger.error("settlement.discovery.event_repo_init_failed", { error });
     defaultTipIntentEventRepo = null;
   }
 

--- a/fiber-link-service/apps/worker/src/settlement.ts
+++ b/fiber-link-service/apps/worker/src/settlement.ts
@@ -9,6 +9,9 @@ import {
 } from "@fiber-link/db";
 import type { NotificationDispatcher } from "@fiber-link/notifications";
 import { type SettlementPublisher } from "./settlement-publisher";
+import { createComponentLogger } from "./logger";
+
+const logger = createComponentLogger("settlement");
 
 let defaultDb: DbClient | null = null;
 let defaultTipIntentRepo: TipIntentRepo | null = null;
@@ -79,13 +82,13 @@ export async function markSettled(
         asset: tipIntent.asset,
         amount: String(tipIntent.amount),
       })
-      .catch((e) => console.warn("TIP_SETTLED notification dispatch failed:", e));
+      .catch((e) => logger.warn("settlement.tip_settled_notification_failed", { invoice, error: e }));
   }
 
   // Publish settlement event for real-time SSE subscribers. Failure is non-blocking.
   if (options.publisher) {
     await options.publisher.publish(invoice, { settledAt }).catch((err) => {
-      console.warn("settlement-publisher: publish failed", err);
+      logger.warn("settlement.publisher_publish_failed", { invoice, error: err });
     });
   }
 


### PR DESCRIPTION
## Summary

- [x] Briefly summarize what changed and why.

The worker's long-running paths mixed bare `console.*` calls with the existing `createComponentLogger` structured output, so those lines lacked the `component`/`event`/`severity` envelope (and bigint/Error-safe serialization) the rest of the worker emits — making them hard to filter/alert on in production.

- **`settlement.ts`**: route the `TIP_SETTLED` notification-dispatch and settlement-publisher failure warnings through a `"settlement"` component logger with `invoice`/`error` context.
- **`settlement-discovery.ts`**: use the existing `defaultLogger` for the event-repo init failure instead of `console.error`.
- **`entry.ts`**: route startup/shutdown logs (subscription URL missing, strategy enabled, subscription-startup failure, publisher-close failure, startup failure) through a `"worker"` component logger.

## Scope

- [x] Filesystem scope is limited to this PR: `apps/worker/src/{settlement,settlement-discovery,entry}.ts`.

**Deliberate exclusions:**
- Worker **CLI scripts** (`ops-summary`, `reconcile-*`, `w5-demo`, `backfill-settlements`, `healthcheck`, `seed-*`) keep `console` output — that is their intended operator stdout, not service logging.
- The **rpc app's 5 module-init/startup `console.error` calls** are left as-is: they run at process boundaries where no structured logger is available (before/around fastify's pino), and adding a second copy of the component logger to rpc would just duplicate the worker's. If a shared logger package is introduced later, both can adopt it together.

## Verification

- [x] Relevant local checks run
  - `apps/worker` typecheck clean; suite: **154 tests pass** (including `logger-contract.test.ts`, which pins the structured-log envelope).
  - Confirmed 0 bare `console.*` remain in the three long-running files.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (if applicable) — follows up the next-batch review (log consistency)
- [x] Required discussions or follow-ups are documented (rpc module-init logging, shared logger package)

## Notes

- Behavioral change is limited to log *shape* (structured payload vs free string); no control-flow changes. All converted sites were non-fatal `.catch` handlers or startup notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_