### PR TITLE
test(notifications,fiber-adapter): cover error paths in low-coverage modules

### DIFF
--- a/fiber-link-service/packages/fiber-adapter/src/hot-wallet-inventory.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/hot-wallet-inventory.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { getHotWalletInventory, resolveHotWalletLockScript } from "./hot-wallet-inventory";
+import {
+  createDefaultHotWalletInventoryProvider,
+  getHotWalletInventory,
+  resolveHotWalletLockScript,
+} from "./hot-wallet-inventory";
 
 function ckbToHexShannons(amount: bigint): string {
   return `0x${(amount * 100_000_000n).toString(16)}`;
@@ -147,5 +151,59 @@ describe("resolveHotWalletLockScript", () => {
     });
     expect(typeof lock.codeHash).toBe("string");
     expect(typeof lock.args).toBe("string");
+  });
+
+  it("accepts a private key supplied without a 0x prefix", () => {
+    process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY =
+      "2222222222222222222222222222222222222222222222222222222222222222";
+
+    const lock = resolveHotWalletLockScript("LINA");
+    expect(typeof lock.codeHash).toBe("string");
+    expect(typeof lock.args).toBe("string");
+  });
+});
+
+describe("hot wallet private key resolution failures", () => {
+  const originalKey = process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY;
+  const originalKeyFile = process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE;
+
+  afterEach(() => {
+    for (const [name, value] of [
+      ["FIBER_WITHDRAWAL_CKB_PRIVATE_KEY", originalKey],
+      ["FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE", originalKeyFile],
+    ] as const) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  });
+
+  it("throws when no withdrawal private key source is configured", () => {
+    delete process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY;
+    delete process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE;
+
+    expect(() => resolveHotWalletLockScript("AGGRON4")).toThrow(
+      "FIBER_WITHDRAWAL_CKB_PRIVATE_KEY (or FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE) is required",
+    );
+  });
+
+  it("throws when the private key is not a 32-byte hex string", () => {
+    process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY = "0xdeadbeef";
+    delete process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE;
+
+    expect(() => resolveHotWalletLockScript("AGGRON4")).toThrow(
+      "FIBER_WITHDRAWAL_CKB_PRIVATE_KEY must be a 32-byte hex private key",
+    );
+  });
+});
+
+describe("createDefaultHotWalletInventoryProvider", () => {
+  it("rejects non-CKB assets", async () => {
+    const provider = createDefaultHotWalletInventoryProvider();
+    await expect(provider({ asset: "USDI", network: "AGGRON4" })).rejects.toThrow(
+      "default hot wallet inventory provider currently supports only CKB",
+    );
   });
 });

--- a/fiber-link-service/packages/fiber-adapter/src/provider.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/provider.test.ts
@@ -81,6 +81,29 @@ describe("adapter provider", () => {
     expect(() => createAdapterProvider()).toThrow("FIBER_RPC_URL environment variable is not set.");
   });
 
+  it("rejects an unrecognized adapter mode", () => {
+    expect(() => createAdapterProvider({ mode: "bogus" })).toThrow(
+      "Invalid FIBER_ADAPTER_MODE 'bogus'. Expected one of: rpc, simulation.",
+    );
+  });
+
+  it("builds an rpc adapter through the injected factory when an endpoint is set", () => {
+    const sentinel = { marker: "rpc-adapter" } as unknown as ReturnType<typeof createAdapterProvider>;
+    let received: { endpoint?: string } | undefined;
+
+    const adapter = createAdapterProvider({
+      mode: "rpc",
+      endpoint: "https://rpc.example.com",
+      rpcFactory: (factoryArgs) => {
+        received = factoryArgs;
+        return sentinel;
+      },
+    });
+
+    expect(adapter).toBe(sentinel);
+    expect(received?.endpoint).toBe("https://rpc.example.com");
+  });
+
   it("selects simulation mode from environment", async () => {
     process.env.FIBER_ADAPTER_MODE = "simulation";
     process.env.FIBER_SIMULATION_SCENARIO = "always-failed";

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/normalize.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/normalize.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  ckbDecimalToHexQuantity,
+  normalizeOptionalName,
+  normalizeRpcAmount,
+  normalizeRpcInteger,
+  parseBoolean,
+  parseCkbDecimalToShannons,
+  parsePositiveInteger,
+  pickRequiredAmount,
+  pickStringCandidate,
+  pickTxEvidence,
+  SHANNONS_PER_CKB,
+  toHexQuantity,
+} from "./normalize";
+
+describe("normalizeRpcAmount", () => {
+  it("stringifies finite numbers", () => {
+    expect(normalizeRpcAmount(42)).toBe("42");
+  });
+
+  it("returns '0' for non-string, non-number values", () => {
+    expect(normalizeRpcAmount(undefined)).toBe("0");
+    expect(normalizeRpcAmount(null)).toBe("0");
+    expect(normalizeRpcAmount(Number.NaN)).toBe("0");
+  });
+
+  it("returns '0' for blank strings", () => {
+    expect(normalizeRpcAmount("   ")).toBe("0");
+  });
+
+  it("converts hex strings to base-10", () => {
+    expect(normalizeRpcAmount("0xff")).toBe("255");
+  });
+
+  it("passes through trimmed decimal strings", () => {
+    expect(normalizeRpcAmount("  1000 ")).toBe("1000");
+  });
+});
+
+describe("normalizeRpcInteger", () => {
+  it("returns integer numbers unchanged", () => {
+    expect(normalizeRpcInteger(7)).toBe(7);
+  });
+
+  it("returns 0 for non-integer numbers and non-strings", () => {
+    expect(normalizeRpcInteger(1.5)).toBe(0);
+    expect(normalizeRpcInteger(null)).toBe(0);
+  });
+
+  it("returns 0 for blank strings", () => {
+    expect(normalizeRpcInteger("")).toBe(0);
+  });
+
+  it("parses hex strings", () => {
+    expect(normalizeRpcInteger("0x10")).toBe(16);
+  });
+
+  it("parses decimal strings and rejects non-integers", () => {
+    expect(normalizeRpcInteger("12")).toBe(12);
+    expect(normalizeRpcInteger("12.5")).toBe(0);
+  });
+});
+
+describe("toHexQuantity", () => {
+  it("lowercases existing hex values", () => {
+    expect(toHexQuantity("0xAB")).toBe("0xab");
+  });
+
+  it("converts decimal strings to hex", () => {
+    expect(toHexQuantity("255")).toBe("0xff");
+  });
+
+  it("throws on non-numeric input", () => {
+    expect(() => toHexQuantity("abc")).toThrow("invalid amount: abc");
+  });
+});
+
+describe("parseCkbDecimalToShannons", () => {
+  it("converts whole and fractional CKB to shannons", () => {
+    expect(parseCkbDecimalToShannons("1")).toBe(SHANNONS_PER_CKB);
+    expect(parseCkbDecimalToShannons("1.5")).toBe(150_000_000n);
+  });
+
+  it("throws on malformed amounts", () => {
+    expect(() => parseCkbDecimalToShannons("1.2.3")).toThrow("invalid CKB amount");
+  });
+
+  it("throws when more than 8 decimal places are supplied", () => {
+    expect(() => parseCkbDecimalToShannons("1.123456789")).toThrow("at most 8 decimal places");
+  });
+
+  it("throws when the amount is not greater than zero", () => {
+    expect(() => parseCkbDecimalToShannons("0")).toThrow("must be greater than 0");
+  });
+
+  it("ckbDecimalToHexQuantity emits a hex quantity", () => {
+    expect(ckbDecimalToHexQuantity("1")).toBe(`0x${SHANNONS_PER_CKB.toString(16)}`);
+  });
+});
+
+describe("pickStringCandidate", () => {
+  it("returns the trimmed value when non-empty", () => {
+    expect(pickStringCandidate("  hi ")).toBe("hi");
+  });
+
+  it("returns null for empty or non-string values", () => {
+    expect(pickStringCandidate("   ")).toBeNull();
+    expect(pickStringCandidate(123)).toBeNull();
+  });
+});
+
+describe("pickRequiredAmount", () => {
+  it("returns '0' when the key is missing", () => {
+    expect(pickRequiredAmount({}, "amount")).toBe("0");
+    expect(pickRequiredAmount(undefined, "amount")).toBe("0");
+  });
+
+  it("returns the normalized amount when present", () => {
+    expect(pickRequiredAmount({ amount: "0x0a" }, "amount")).toBe("10");
+  });
+});
+
+describe("normalizeOptionalName", () => {
+  it("lowercases and trims strings", () => {
+    expect(normalizeOptionalName("  MyChannel ")).toBe("mychannel");
+  });
+
+  it("returns an empty string for non-strings", () => {
+    expect(normalizeOptionalName(undefined)).toBe("");
+  });
+});
+
+describe("parseBoolean", () => {
+  it("returns undefined for non-strings and blanks", () => {
+    expect(parseBoolean(undefined)).toBeUndefined();
+    expect(parseBoolean("   ")).toBeUndefined();
+  });
+
+  it("recognizes truthy tokens", () => {
+    for (const token of ["1", "true", "YES", "on"]) {
+      expect(parseBoolean(token)).toBe(true);
+    }
+  });
+
+  it("recognizes falsy tokens", () => {
+    for (const token of ["0", "false", "NO", "off"]) {
+      expect(parseBoolean(token)).toBe(false);
+    }
+  });
+
+  it("returns undefined for unrecognized tokens", () => {
+    expect(parseBoolean("maybe")).toBeUndefined();
+  });
+});
+
+describe("pickTxEvidence", () => {
+  it("returns the first present hash candidate", () => {
+    expect(pickTxEvidence({ payment_hash: "0xabc" })).toBe("0xabc");
+    expect(pickTxEvidence({ tx_hash: "0x111", hash: "0x222" })).toBe("0x111");
+  });
+
+  it("returns null when no candidate is a non-empty string", () => {
+    expect(pickTxEvidence({ tx_hash: "" })).toBeNull();
+    expect(pickTxEvidence(undefined)).toBeNull();
+  });
+});
+
+describe("parsePositiveInteger", () => {
+  it("parses positive integer strings", () => {
+    expect(parsePositiveInteger("25")).toBe(25);
+  });
+
+  it("returns undefined for non-strings, non-numeric, and non-positive values", () => {
+    expect(parsePositiveInteger(undefined)).toBeUndefined();
+    expect(parsePositiveInteger("1.5")).toBeUndefined();
+    expect(parsePositiveInteger("0")).toBeUndefined();
+  });
+});

--- a/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/rpc-adapter/rebalance-ops.test.ts
@@ -325,4 +325,181 @@ describe("rebalance-ops local CKB liquidity fallback", () => {
       state: "FUNDED",
     });
   });
+
+  it("recognizes a FiberRpcError instance with code -32601 as unsupported", async () => {
+    process.env.FIBER_LIQUIDITY_CKB_SOURCE_PRIVATE_KEY =
+      "0x2222222222222222222222222222222222222222222222222222222222222222";
+    process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY =
+      "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+    rpcCallMock.mockRejectedValueOnce(new MockFiberRpcError(-32601, "rpc method missing"));
+    resolveHotWalletAddressMock.mockReturnValue("ckt1qhotwallet");
+    executeTransferMock.mockResolvedValue({ txHash: "0xsweep" });
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    const result = await ensureChainLiquidity("http://fnn:8227", {
+      requestId: "liq-rpc-error-instance",
+      asset: "CKB",
+      network: "AGGRON4",
+      requiredAmount: "62",
+      sourceKind: "FIBER_TO_CKB_CHAIN",
+    });
+
+    expect(result).toMatchObject({ recoveryStrategy: "LOCAL_CKB_SWEEP", txHash: "0xsweep" });
+  });
+
+  it("recognizes an unsupported rpc from a message-only error object", async () => {
+    process.env.FIBER_LIQUIDITY_CKB_SOURCE_PRIVATE_KEY =
+      "0x2222222222222222222222222222222222222222222222222222222222222222";
+    process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY =
+      "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+    // Plain object without a `code`, exercising the message-extraction branch.
+    rpcCallMock.mockRejectedValueOnce({ message: "unknown method: rebalance_to_ckb_chain" });
+    resolveHotWalletAddressMock.mockReturnValue("ckt1qhotwallet");
+    executeTransferMock.mockResolvedValue({ txHash: "0xsweep" });
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    const result = await ensureChainLiquidity("http://fnn:8227", {
+      requestId: "liq-msg-only",
+      asset: "CKB",
+      network: "AGGRON4",
+      requiredAmount: "62",
+      sourceKind: "FIBER_TO_CKB_CHAIN",
+    });
+
+    expect(result).toMatchObject({ recoveryStrategy: "LOCAL_CKB_SWEEP" });
+  });
+
+  it("maps a failed rebalance status from the Fiber RPC result", async () => {
+    rpcCallMock.mockResolvedValueOnce({ status: "failed", error: "insufficient inbound", started: true });
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    await expect(
+      ensureChainLiquidity("http://fnn:8227", {
+        requestId: "liq-failed-status",
+        asset: "CKB",
+        network: "AGGRON4",
+        requiredAmount: "62",
+        sourceKind: "FIBER_TO_CKB_CHAIN",
+      }),
+    ).resolves.toEqual({ state: "FAILED", started: true, error: "insufficient inbound" });
+  });
+
+  it("treats an unrecognized rebalance status as pending", async () => {
+    rpcCallMock.mockResolvedValueOnce({ status: "who-knows" });
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    await expect(
+      ensureChainLiquidity("http://fnn:8227", {
+        requestId: "liq-idle-status",
+        asset: "CKB",
+        network: "AGGRON4",
+        requiredAmount: "62",
+        sourceKind: "FIBER_TO_CKB_CHAIN",
+      }),
+    ).resolves.toEqual({ state: "PENDING", started: false });
+  });
+
+  it("treats a result with no status field as pending", async () => {
+    rpcCallMock.mockResolvedValueOnce({});
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    await expect(
+      ensureChainLiquidity("http://fnn:8227", {
+        requestId: "liq-no-status",
+        asset: "CKB",
+        network: "AGGRON4",
+        requiredAmount: "62",
+        sourceKind: "FIBER_TO_CKB_CHAIN",
+      }),
+    ).resolves.toEqual({ state: "PENDING", started: false });
+  });
+
+  it("rethrows a non-Error, non-object rpc rejection unchanged", async () => {
+    process.env.FIBER_LIQUIDITY_CKB_SOURCE_PRIVATE_KEY =
+      "0x2222222222222222222222222222222222222222222222222222222222222222";
+    process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY =
+      "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+    // A primitive rejection exercises the String(error) normalization fallback.
+    rpcCallMock.mockRejectedValueOnce("boom");
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    await expect(
+      ensureChainLiquidity("http://fnn:8227", {
+        requestId: "liq-primitive-error",
+        asset: "CKB",
+        network: "AGGRON4",
+        requiredAmount: "62",
+        sourceKind: "FIBER_TO_CKB_CHAIN",
+      }),
+    ).rejects.toBe("boom");
+    expect(executeTransferMock).not.toHaveBeenCalled();
+  });
+
+  it("encodes non-CKB rebalance amounts as plain hex and rethrows rpc failures without local fallback", async () => {
+    delete process.env.FIBER_LIQUIDITY_CKB_SOURCE_PRIVATE_KEY;
+    delete process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY;
+
+    rpcCallMock.mockRejectedValueOnce({ code: -32601, message: "Method not found" });
+
+    const { ensureChainLiquidity } = await import("./rebalance-ops");
+    await expect(
+      ensureChainLiquidity("http://fnn:8227", {
+        requestId: "liq-usdi",
+        asset: "USDI",
+        network: "AGGRON4",
+        requiredAmount: "100",
+        sourceKind: "FIBER_TO_CKB_CHAIN",
+      }),
+    ).rejects.toMatchObject({ code: -32601 });
+
+    expect(rpcCallMock).toHaveBeenCalledWith(
+      "http://fnn:8227",
+      "rebalance_to_ckb_chain",
+      expect.objectContaining({ required_amount: "0x64" }),
+    );
+    expect(executeTransferMock).not.toHaveBeenCalled();
+  });
+
+  it("reports IDLE from get_rebalance_status when the rpc is unsupported and local sweep is available", async () => {
+    process.env.FIBER_LIQUIDITY_CKB_SOURCE_PRIVATE_KEY =
+      "0x2222222222222222222222222222222222222222222222222222222222222222";
+    process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY =
+      "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+    rpcCallMock.mockRejectedValueOnce({ code: -32601, message: "Method not found" });
+
+    const { getRebalanceStatus } = await import("./rebalance-ops");
+    await expect(
+      getRebalanceStatus("http://fnn:8227", { requestId: "liq-no-local-tracking" }),
+    ).resolves.toEqual({ state: "IDLE" });
+  });
+
+  it("marks a local sweep failed when its transaction is rejected on chain", async () => {
+    process.env.FIBER_LIQUIDITY_CKB_SOURCE_PRIVATE_KEY =
+      "0x2222222222222222222222222222222222222222222222222222222222222222";
+    process.env.FIBER_WITHDRAWAL_CKB_PRIVATE_KEY =
+      "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+    rpcCallMock.mockRejectedValueOnce({ code: -32601, message: "Method not found" });
+    resolveHotWalletAddressMock.mockReturnValue("ckt1qhotwallet");
+    executeTransferMock.mockResolvedValue({ txHash: "0xsweep" });
+    getTransactionStatusMock.mockResolvedValueOnce("REJECTED");
+
+    const { ensureChainLiquidity, getRebalanceStatus } = await import("./rebalance-ops");
+    await ensureChainLiquidity("http://fnn:8227", {
+      requestId: "liq-rejected",
+      asset: "CKB",
+      network: "AGGRON4",
+      requiredAmount: "62",
+      sourceKind: "FIBER_TO_CKB_CHAIN",
+    });
+
+    await expect(getRebalanceStatus("http://fnn:8227", { requestId: "liq-rejected" })).resolves.toEqual({
+      state: "FAILED",
+      error: "local liquidity sweep transaction 0xsweep was rejected",
+    });
+  });
 });

--- a/fiber-link-service/packages/fiber-adapter/src/withdrawal-key.test.ts
+++ b/fiber-link-service/packages/fiber-adapter/src/withdrawal-key.test.ts
@@ -47,6 +47,16 @@ describe("readWithdrawalPrivateKeyRaw", () => {
       readWithdrawalPrivateKeyRaw({ FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE: "/nonexistent/key" }),
     ).toThrow(/FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE/);
   });
+
+  it("caches the file read by path and does not re-read after the file changes", () => {
+    const file = keyFileWith(`${KEY}\n`);
+    expect(readWithdrawalPrivateKeyRaw({ FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE: file })).toBe(KEY);
+
+    // Mutating the on-disk secret must not be observed: the file variant is a
+    // static mount and the first read is cached by path.
+    writeFileSync(file, "0x".padEnd(66, "c"));
+    expect(readWithdrawalPrivateKeyRaw({ FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE: file })).toBe(KEY);
+  });
 });
 
 describe("hasWithdrawalPrivateKey", () => {

--- a/fiber-link-service/packages/notifications/src/dispatcher.test.ts
+++ b/fiber-link-service/packages/notifications/src/dispatcher.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createNotificationDispatcher } from "./dispatcher";
+import { createNoopNotificationDispatcher, createNotificationDispatcher } from "./dispatcher";
 import { createInMemoryNotificationRepo } from "./notification-repo";
 
 describe("createNotificationDispatcher", () => {
@@ -121,5 +121,103 @@ describe("createNotificationDispatcher", () => {
 
     expect(summary).toEqual({ matched: 0, attempted: 0, delivered: 0, failed: 0 });
     expect(webhookHandler).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors thrown by the onDispatchError observer", async () => {
+    const channel = await repo.createChannel({
+      appId: "app-1",
+      name: "observer-throws",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/observer",
+    });
+    await repo.createRule({ appId: "app-1", channelId: channel.id, event: "WITHDRAWAL_FAILED" });
+
+    const onDispatchError = vi.fn(() => {
+      throw new Error("observer blew up");
+    });
+    const dispatcher = createNotificationDispatcher({
+      repo,
+      handlers: {
+        WEBHOOK: vi.fn(async () => {
+          throw new Error("delivery failed");
+        }),
+      },
+      onDispatchError,
+    });
+
+    // A throwing observer must not propagate out of dispatch (best-effort).
+    const summary = await dispatcher.dispatchWithdrawalEvent({
+      type: "WITHDRAWAL_FAILED",
+      occurredAt: new Date("2026-02-07T13:30:00.000Z"),
+      appId: "app-1",
+      userId: "user-1",
+      withdrawalId: "wd-observer",
+      asset: "CKB",
+      amount: "1",
+      retryCount: 3,
+      error: "exhausted",
+    });
+
+    expect(summary).toEqual({ matched: 1, attempted: 1, delivered: 0, failed: 1 });
+    expect(onDispatchError).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches TIP_SETTLED events to matched channels", async () => {
+    const channel = await repo.createChannel({
+      appId: "app-1",
+      name: "tip-hook",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/tip",
+    });
+    await repo.createRule({ appId: "app-1", channelId: channel.id, event: "TIP_SETTLED" });
+
+    const webhookHandler = vi.fn(async () => {});
+    const dispatcher = createNotificationDispatcher({ repo, handlers: { WEBHOOK: webhookHandler } });
+
+    const summary = await dispatcher.dispatchTipSettledEvent({
+      type: "TIP_SETTLED",
+      occurredAt: new Date("2026-02-07T15:30:00.000Z"),
+      appId: "app-1",
+      toUserId: "author-1",
+      fromUserId: "tipper-1",
+      postId: "post-1",
+      invoice: "fibt1qtip",
+      asset: "CKB",
+      amount: "3",
+    });
+
+    expect(summary).toEqual({ matched: 1, attempted: 1, delivered: 1, failed: 0 });
+    expect(webhookHandler).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createNoopNotificationDispatcher", () => {
+  it("returns empty summaries without dispatching", async () => {
+    const dispatcher = createNoopNotificationDispatcher();
+
+    const withdrawalSummary = await dispatcher.dispatchWithdrawalEvent({
+      type: "WITHDRAWAL_COMPLETED",
+      occurredAt: new Date("2026-02-07T16:00:00.000Z"),
+      appId: "app-1",
+      userId: "user-1",
+      withdrawalId: "wd-noop",
+      asset: "CKB",
+      amount: "1",
+      txHash: "0xnoop",
+    });
+    const tipSummary = await dispatcher.dispatchTipSettledEvent({
+      type: "TIP_SETTLED",
+      occurredAt: new Date("2026-02-07T16:05:00.000Z"),
+      appId: "app-1",
+      toUserId: "author-1",
+      fromUserId: "tipper-1",
+      postId: "post-1",
+      invoice: "fibt1qnoop",
+      asset: "CKB",
+      amount: "1",
+    });
+
+    expect(withdrawalSummary).toEqual({ matched: 0, attempted: 0, delivered: 0, failed: 0 });
+    expect(tipSummary).toEqual({ matched: 0, attempted: 0, delivered: 0, failed: 0 });
   });
 });

--- a/fiber-link-service/packages/notifications/src/index.test.ts
+++ b/fiber-link-service/packages/notifications/src/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import * as notifications from "./index";
+
+describe("package entry point", () => {
+  it("re-exports the public notification surface", () => {
+    expect(typeof notifications.createDbNotificationRepo).toBe("function");
+    expect(typeof notifications.createInMemoryNotificationRepo).toBe("function");
+    expect(typeof notifications.createNotificationDispatcher).toBe("function");
+    expect(typeof notifications.createNoopNotificationDispatcher).toBe("function");
+    expect(typeof notifications.createWebhookChannelHandler).toBe("function");
+  });
+});

--- a/fiber-link-service/packages/notifications/src/notification-repo.test.ts
+++ b/fiber-link-service/packages/notifications/src/notification-repo.test.ts
@@ -1,5 +1,57 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { createInMemoryNotificationRepo } from "./notification-repo";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DbClient } from "@fiber-link/db";
+import { createDbNotificationRepo, createInMemoryNotificationRepo } from "./notification-repo";
+
+// Minimal chainable stand-in for the drizzle query builder. Every builder method
+// used by the repo returns the same object, and awaiting it resolves to a
+// pre-queued result, so we can unit-test the repo's control flow and row→record
+// mapping without a live Postgres.
+function makeDbMock() {
+  const selectResults: unknown[] = [];
+  const insertResults: unknown[] = [];
+  function chain(result: unknown) {
+    const c = {
+      from: () => c,
+      where: () => c,
+      limit: () => c,
+      innerJoin: () => c,
+      orderBy: () => c,
+      values: () => c,
+      returning: () => c,
+      then: (resolve: (value: unknown) => void) => resolve(result),
+    };
+    return c;
+  }
+  const db = {
+    select: () => chain(selectResults.shift()),
+    insert: () => chain(insertResults.shift()),
+  } as unknown as DbClient;
+  return {
+    db,
+    queueSelect(result: unknown) {
+      selectResults.push(result);
+    },
+    queueInsert(result: unknown) {
+      insertResults.push(result);
+    },
+  };
+}
+
+function channelRow(overrides: Record<string, unknown> = {}) {
+  const now = new Date("2026-03-01T00:00:00.000Z");
+  return {
+    id: "ch-db-1",
+    appId: "app-1",
+    name: "db-webhook",
+    kind: "WEBHOOK",
+    target: "https://example.com/hooks/db",
+    secret: null,
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
 
 describe("createInMemoryNotificationRepo", () => {
   const repo = createInMemoryNotificationRepo();
@@ -82,5 +134,180 @@ describe("createInMemoryNotificationRepo", () => {
         event: "WITHDRAWAL_RETRY_PENDING",
       }),
     ).rejects.toThrow("notification channel not found");
+  });
+
+  it("rejects a duplicate channel name within the same app", async () => {
+    await repo.createChannel({
+      appId: "app-1",
+      name: "dupe",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/a",
+    });
+
+    await expect(
+      repo.createChannel({
+        appId: "app-1",
+        name: "dupe",
+        kind: "WEBHOOK",
+        target: "https://example.com/hooks/b",
+      }),
+    ).rejects.toThrow("duplicate notification channel name");
+  });
+
+  it("rejects a duplicate rule for the same channel and event", async () => {
+    const channel = await repo.createChannel({
+      appId: "app-1",
+      name: "rule-dupe",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/rule-dupe",
+    });
+    await repo.createRule({ appId: "app-1", channelId: channel.id, event: "WITHDRAWAL_FAILED" });
+
+    await expect(
+      repo.createRule({ appId: "app-1", channelId: channel.id, event: "WITHDRAWAL_FAILED" }),
+    ).rejects.toThrow("duplicate notification rule");
+  });
+
+  it("orders dispatch targets by rule creation time", async () => {
+    vi.useFakeTimers();
+    try {
+      const older = await repo.createChannel({
+        appId: "app-1",
+        name: "older",
+        kind: "WEBHOOK",
+        target: "https://example.com/hooks/older",
+      });
+      const newer = await repo.createChannel({
+        appId: "app-1",
+        name: "newer",
+        kind: "WEBHOOK",
+        target: "https://example.com/hooks/newer",
+      });
+
+      // Create the rules out of chronological order but with distinct
+      // createdAt timestamps, so the comparator's non-zero branch decides
+      // ordering (not insertion order).
+      vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
+      await repo.createRule({ appId: "app-1", channelId: newer.id, event: "WITHDRAWAL_COMPLETED" });
+      vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+      await repo.createRule({ appId: "app-1", channelId: older.id, event: "WITHDRAWAL_COMPLETED" });
+
+      const targets = await repo.listDispatchTargets("app-1", "WITHDRAWAL_COMPLETED");
+      expect(targets.map((t) => t.channelName)).toEqual(["older", "newer"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("createDbNotificationRepo", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps an inserted channel row to a channel record", async () => {
+    const { db, queueInsert } = makeDbMock();
+    queueInsert([channelRow({ secret: "s3cr3t" })]);
+    const repo = createDbNotificationRepo(db);
+
+    const record = await repo.createChannel({
+      appId: "app-1",
+      name: "db-webhook",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/db",
+      secret: "s3cr3t",
+    });
+
+    expect(record).toMatchObject({
+      id: "ch-db-1",
+      appId: "app-1",
+      name: "db-webhook",
+      kind: "WEBHOOK",
+      target: "https://example.com/hooks/db",
+      secret: "s3cr3t",
+      enabled: true,
+    });
+  });
+
+  it("creates a rule after verifying the channel belongs to the app", async () => {
+    const { db, queueSelect, queueInsert } = makeDbMock();
+    queueSelect([{ id: "ch-db-1", appId: "app-1" }]);
+    queueInsert([
+      {
+        id: "rule-db-1",
+        appId: "app-1",
+        channelId: "ch-db-1",
+        event: "WITHDRAWAL_COMPLETED",
+        enabled: true,
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    const repo = createDbNotificationRepo(db);
+
+    const record = await repo.createRule({
+      appId: "app-1",
+      channelId: "ch-db-1",
+      event: "WITHDRAWAL_COMPLETED",
+    });
+
+    expect(record).toMatchObject({
+      id: "rule-db-1",
+      appId: "app-1",
+      channelId: "ch-db-1",
+      event: "WITHDRAWAL_COMPLETED",
+      enabled: true,
+    });
+  });
+
+  it("throws when the channel row is missing", async () => {
+    const { db, queueSelect } = makeDbMock();
+    queueSelect([]);
+    const repo = createDbNotificationRepo(db);
+
+    await expect(
+      repo.createRule({ appId: "app-1", channelId: "missing", event: "WITHDRAWAL_FAILED" }),
+    ).rejects.toThrow("notification channel not found");
+  });
+
+  it("throws when the channel belongs to a different app", async () => {
+    const { db, queueSelect } = makeDbMock();
+    queueSelect([{ id: "ch-db-1", appId: "other-app" }]);
+    const repo = createDbNotificationRepo(db);
+
+    await expect(
+      repo.createRule({ appId: "app-1", channelId: "ch-db-1", event: "WITHDRAWAL_FAILED" }),
+    ).rejects.toThrow("notification channel not found");
+  });
+
+  it("maps joined rule+channel rows to dispatch targets", async () => {
+    const { db, queueSelect } = makeDbMock();
+    queueSelect([
+      {
+        ruleId: "rule-db-1",
+        channelId: "ch-db-1",
+        appId: "app-1",
+        event: "WITHDRAWAL_COMPLETED",
+        channelName: "db-webhook",
+        kind: "WEBHOOK",
+        target: "https://example.com/hooks/db",
+        secret: "s3cr3t",
+      },
+    ]);
+    const repo = createDbNotificationRepo(db);
+
+    const targets = await repo.listDispatchTargets("app-1", "WITHDRAWAL_COMPLETED");
+    expect(targets).toEqual([
+      {
+        ruleId: "rule-db-1",
+        channelId: "ch-db-1",
+        appId: "app-1",
+        event: "WITHDRAWAL_COMPLETED",
+        channelName: "db-webhook",
+        kind: "WEBHOOK",
+        target: "https://example.com/hooks/db",
+        secret: "s3cr3t",
+      },
+    ]);
   });
 });

--- a/fiber-link-service/packages/notifications/src/webhook-handler.test.ts
+++ b/fiber-link-service/packages/notifications/src/webhook-handler.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import crypto from "node:crypto";
 import { createWebhookChannelHandler } from "./webhook-handler";
 import type { NotificationDispatchTarget } from "./notification-repo";
-import type { WithdrawalCompletedNotificationEvent, WithdrawalFailedNotificationEvent, WithdrawalRetryPendingNotificationEvent } from "./notification-events";
+import type { TipSettledNotificationEvent, WithdrawalCompletedNotificationEvent, WithdrawalFailedNotificationEvent, WithdrawalRetryPendingNotificationEvent } from "./notification-events";
 
 const BASE_TARGET: NotificationDispatchTarget = {
   ruleId: "rule-1",
@@ -150,6 +150,44 @@ describe("createWebhookChannelHandler", () => {
     const body = JSON.parse(init.body as string);
     expect(body.retryCount).toBe(5);
     expect(body.error).toBe("max retries exceeded");
+    expect(body.txHash).toBeUndefined();
+  });
+
+  it("serializes TIP_SETTLED events with tip fields and omits withdrawal fields", async () => {
+    const mockFetch = vi.fn(async (_url: string, _init?: RequestInit) => new Response(null, { status: 200 }));
+    const handler = createWebhookChannelHandler({ fetch: mockFetch as unknown as typeof fetch });
+
+    const event: TipSettledNotificationEvent = {
+      type: "TIP_SETTLED",
+      occurredAt: new Date("2026-02-07T15:00:00.000Z"),
+      appId: "app-1",
+      toUserId: "author-1",
+      fromUserId: "tipper-1",
+      postId: "post-42",
+      invoice: "fibt1qxyz",
+      asset: "CKB",
+      amount: "7",
+    };
+
+    await handler({ target: { ...BASE_TARGET, event: "TIP_SETTLED" }, event });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["x-fiber-link-event"]).toBe("TIP_SETTLED");
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      event: "TIP_SETTLED",
+      occurredAt: "2026-02-07T15:00:00.000Z",
+      appId: "app-1",
+      toUserId: "author-1",
+      fromUserId: "tipper-1",
+      postId: "post-42",
+      invoice: "fibt1qxyz",
+      asset: "CKB",
+      amount: "7",
+    });
+    // Withdrawal-only fields must not leak into a tip payload.
+    expect(body.withdrawalId).toBeUndefined();
+    expect(body.userId).toBeUndefined();
     expect(body.txHash).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Raises coverage on the two lowest-covered packages by testing previously-unexercised error and branch paths. **Tests only — no runtime code changed.**

**Notifications: 70.78% → 100% lines**
- [x] Exercise the DB-backed repo (`createDbNotificationRepo`) via a small chainable drizzle stand-in: row→record mapping, the channel-ownership check on rule creation (missing / wrong-app), and dispatch-target join mapping — this whole path was untested.
- [x] Cover the in-memory repo's duplicate-channel-name and duplicate-rule guards and the `createdAt` ordering comparator.
- [x] Add the `TIP_SETTLED` webhook payload branch (and assert withdrawal-only fields don't leak), the noop dispatcher, the best-effort `onDispatchError` swallow, and a package entry-point (`index.ts`) smoke test.

**Fiber adapter: 77.89% → 81.37% lines**
- [x] Full unit coverage for the pure RPC `normalize.ts` helpers (0 dedicated tests before → 100%).
- [x] `rebalance-ops.ts` error/branch paths (88% → 99%): `FiberRpcError`-instance and message-only unsupported-RPC detection, failed/idle/absent status mapping, non-CKB amount encoding + rethrow, on-chain `REJECTED` sweep, and the `IDLE` `get_rebalance_status` fallback.
- [x] `provider.ts` invalid-mode and injected rpc-factory paths (→ 100%).
- [x] Hot-wallet private-key resolution failures (missing / malformed / no-`0x`-prefix) and the non-CKB default provider guard.
- [x] `withdrawal-key.ts` path-keyed file-read cache behavior (a mutated file is not re-read).

## Scope

- [x] Filesystem scope limited to `*.test.ts` files under `packages/notifications/src` and `packages/fiber-adapter/src`, plus two new test files. No non-test files touched.

## Verification

- [x] `vitest run` — notifications 28/28 pass (100% lines, 95.58% branch); fiber-adapter 116/116 pass.
- [x] `bun run typecheck` passes in both packages.
- [x] The remaining fiber-adapter gaps (`ckb-onchain-withdrawal`, `channel-ops`, `settlement-stream`, `simulation-adapter`) are on-chain/`@ckb-lumos`-heavy paths that need a live chain or much heavier mocking — deliberately out of scope here.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (low-coverage-module backlog item)
- [x] Required discussions or follow-ups are documented

## Notes

- One rebalance defensive branch (`resolveLocalChainLiquiditySourcePrivateKey` missing-key throw) is intentionally left uncovered: it's guarded unreachable via the public API (the caller checks `hasLocalChainLiquiditySweepSupport()` first). Label: `test`/`enhancement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_