### PR TITLE
feat(compose): run rpc, worker, and migrate containers as non-root

### DIFF
--- a/deploy/compose/service.Dockerfile
+++ b/deploy/compose/service.Dockerfile
@@ -1,6 +1,9 @@
 FROM public.ecr.aws/docker/library/node:22-bookworm-slim AS base
 
-ENV BUN_INSTALL=/root/.bun
+# Install bun under /opt (not /root/.bun) so the runtime stages can drop to the
+# non-root `node` user (uid/gid 1000, built into the node base image) and still
+# traverse into the install directory to execute it.
+ENV BUN_INSTALL=/opt/bun
 ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 
 WORKDIR /app
@@ -9,8 +12,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl unzip \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.11 \
-  && ln -sf /root/.bun/bin/bun /usr/local/bin/bun \
-  && ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
+  && ln -sf /opt/bun/bin/bun /usr/local/bin/bun \
+  && ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
 
 COPY fiber-link-service/package.json ./package.json
 COPY fiber-link-service/bun.lockb ./bun.lockb
@@ -22,12 +25,20 @@ COPY fiber-link-service/packages ./packages
 RUN bun install --frozen-lockfile
 
 FROM base AS migrate
+USER node
 WORKDIR /app/packages/db
 CMD ["bun", "run", "drizzle-kit", "migrate", "--config=drizzle.config.ts"]
 
 FROM base AS rpc
+USER node
 EXPOSE 3000
 CMD ["bun", "run", "apps/rpc/src/entry.ts"]
 
 FROM base AS worker
+# Pre-create the legacy cursor volume mount point owned by `node` so a fresh
+# `worker-data` named volume inherits node-writable ownership. Volumes created
+# by an older (root-running) image stay root-owned; see the compose runbook for
+# the one-time chown when upgrading.
+RUN mkdir -p /var/lib/fiber-link && chown node:node /var/lib/fiber-link
+USER node
 CMD ["bun", "run", "apps/worker/src/entry.ts"]

--- a/docs/runbooks/compose-reference.md
+++ b/docs/runbooks/compose-reference.md
@@ -78,6 +78,10 @@ Edit `.env` minimally:
 - `FIBER_RPC_URL` is the compose-network endpoint used by `rpc` and `worker`; default is `http://fnn:8227`.
 - `FIBER_LINK_RATE_LIMIT_REDIS_URL` defaults to a dedicated Redis DB (`redis://redis:6379/1`) so rate limiting stays shared across RPC instances instead of falling back to in-process memory.
 - Worker cursor persistence uses `worker-data` volume mounted at `/var/lib/fiber-link`.
+- The service containers (`rpc`, `worker`, `migrate`) run as the non-root `node` user (uid/gid 1000). A `worker-data` volume created by an image from before this change is owned by root; if the worker needs the legacy file cursor (`WORKER_SETTLEMENT_CURSOR_STORE=file`), run a one-time
+  `docker compose run --rm --user root worker chown -R node:node /var/lib/fiber-link`
+  after upgrading. Fresh volumes inherit `node` ownership automatically. The default `db` cursor store is unaffected.
+- Likewise, any file mounted into the containers (e.g. a withdrawal key supplied via `FIBER_WITHDRAWAL_CKB_PRIVATE_KEY_FILE`) must be readable by uid 1000 — a root-owned `600` host file will fail with `EACCES` now that the services no longer run as root.
 - Compose startup order is `postgres/redis/fnn` -> `rpc` -> `worker` (current dependency wiring in `docker-compose.yml`).
 
 Start:


### PR DESCRIPTION
## Summary

- [x] All three `service.Dockerfile` stages (`rpc`, `worker`, `migrate`) previously ran as **root**. They now drop to the non-root `node` user (uid/gid 1000, built into the node base image), shrinking the blast radius of any container compromise — particularly relevant for the rpc container, which holds the hot-wallet withdrawal key.
- [x] The bun install moved from `/root/.bun` to `/opt/bun`: `/root` is mode 700, so a non-root user could not traverse into the old install directory to execute the interpreter.
- [x] The worker stage pre-creates `/var/lib/fiber-link` owned by `node`, so a **fresh** `worker-data` named volume inherits node-writable ownership automatically.
- [x] Runbook documents the two upgrade caveats: a one-time `chown` for pre-existing root-owned `worker-data` volumes (only relevant to the legacy `file` cursor store; the default `db` store is unaffected), and that mounted key files must be readable by uid 1000.

## Scope

- [x] Filesystem scope limited to `deploy/compose/service.Dockerfile` and `docs/runbooks/compose-reference.md`. No application code changed.

## Verification

- [x] Container test on the same node:22-bookworm-slim base: bun 1.3.11 under `/opt/bun` executes as uid 1000 (`bun --version`, `bun run` of a root-owned `/app` source file both succeed).
- [x] Volume-inheritance test: image layer with `mkdir -p /var/lib/fiber-link && chown node:node` + `USER node` → fresh named volume mounts as `node:node`, write succeeds.
- [x] `./deploy/compose/compose-reference.test.sh` passes.
- [x] Full image build is exercised by the `fiber-adapter-e2e` CI job, which builds this Dockerfile and boots the whole compose stack (migrate + rpc + worker healthchecks) — that's the end-to-end proof in CI. (The sandbox proxy blocks `bun.sh`/`deb.debian.org`, so the full build could not run locally.)

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (container-hardening backlog item U1)
- [x] Required discussions or follow-ups are documented

## Notes

- The `fnn` image still runs as root; it is an upstream binary with its own `/data` volume layout and is left out of scope here. Ports are unaffected (3000 is unprivileged). Label: `enhancement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_