### PR TITLE
test(plugin): harden the i18n parity checker (single quotes + PyYAML guard)

### DIFF
--- a/fiber-link-discourse-plugin/i18n-parity.test.sh
+++ b/fiber-link-discourse-plugin/i18n-parity.test.sh
@@ -12,7 +12,11 @@ import re
 import sys
 from pathlib import Path
 
-import yaml
+try:
+    import yaml
+except ImportError:
+    print("i18n-parity: PyYAML is required. Install it with 'pip install PyYAML'.")
+    sys.exit(1)
 
 plugin_dir = Path(sys.argv[1])
 assets_dir = plugin_dir / "assets" / "javascripts"
@@ -22,7 +26,7 @@ zh_path = plugin_dir / "config" / "locales" / "client.zh_CN.yml"
 # i18n("fiber_link....") in JS and {{i18n "fiber_link...."}} in templates.
 key_pattern = re.compile(
     r"i18n\(\s*[\"'](fiber_link\.[A-Za-z0-9_.]+)[\"']"
-    r"|{{\s*i18n\s+\"(fiber_link\.[A-Za-z0-9_.]+)\""
+    r"|{{\s*i18n\s+[\"'](fiber_link\.[A-Za-z0-9_.]+)[\"']"
 )
 
 used_keys = set()

--- a/fiber-link-discourse-plugin/i18n-parity.test.sh
+++ b/fiber-link-discourse-plugin/i18n-parity.test.sh
@@ -15,7 +15,7 @@ from pathlib import Path
 try:
     import yaml
 except ImportError:
-    print("i18n-parity: PyYAML is required. Install it with 'pip install PyYAML'.")
+    print("i18n-parity: PyYAML is required. Install it with 'pip install PyYAML'.", file=sys.stderr)
     sys.exit(1)
 
 plugin_dir = Path(sys.argv[1])


### PR DESCRIPTION
## Summary

Follow-ups from the #512 review that arrived after it merged, applied to `fiber-link-discourse-plugin/i18n-parity.test.sh`:

- [x] The template key regex now accepts **single-quoted** helpers (`{{i18n 'fiber_link.…'}}`) as well as double-quoted ones. Previously a single-quoted reference was silently skipped, so a key referenced only that way could be missing from the locale files without the guard catching it — a real (if latent) false-negative in the parity check.
- [x] A missing **PyYAML** dependency now prints an actionable `pip install PyYAML` hint and exits 1, instead of dumping a raw `ModuleNotFoundError` traceback.

## Scope

- [x] Single file: `fiber-link-discourse-plugin/i18n-parity.test.sh`. No component or locale changes.

## Verification

- [x] `./fiber-link-discourse-plugin/i18n-parity.test.sh` passes (194 referenced keys, 196/196 en/zh_CN entries) — the current tree uses double quotes throughout, so behavior is unchanged today; this just closes the single-quote gap for the future.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (follow-up to #512 review)
- [x] Required discussions or follow-ups are documented

## Notes

- Pure test-tooling robustness; no runtime or UI impact. Label: `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_