### PR TITLE
build(deploy): add .dockerignore to slim the image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Build context excludes for all images built from the repo root
+# (docker-compose builds service.Dockerfile and fnn/Dockerfile with `context: ../..`).
+# Only non-source artifacts are excluded here; every path the Dockerfiles COPY
+# — fiber-link-service/{package.json,bun.lockb,bunfig.toml,tsconfig.base.json,
+# pnpm-workspace.yaml,apps,packages} (including packages/db/drizzle migrations)
+# and deploy/compose/fnn/{config,entrypoint.sh} — is intentionally kept.
+
+# Dependencies (bun reinstalls from the lockfile inside the image)
+**/node_modules
+
+# Build output (services run TypeScript from src via bun; no compiled dist needed)
+**/dist
+**/.next
+**/.turbo
+
+# Test and coverage output
+**/coverage
+**/coverage-reports
+**/*.lcov
+
+# VCS metadata and history
+.git
+.gitignore
+.gitattributes
+
+# Local environment and secrets (never ship these in the build context)
+**/.env
+**/.env.*
+!**/.env.example
+
+# Local scratch and tooling caches
+.worktrees
+.tmp
+.playwright-cli
+deploy/compose/evidence
+deploy/compose/backups
+
+# Editor and OS noise
+**/*.log
+**/.DS_Store
+**/Thumbs.db

--- a/.dockerignore
+++ b/.dockerignore
@@ -35,7 +35,12 @@
 deploy/compose/evidence
 deploy/compose/backups
 
-# Editor and OS noise
+# Editor/IDE config and OS noise (developer-local, may hold local settings/secrets)
 **/*.log
 **/.DS_Store
 **/Thumbs.db
+.vscode
+.idea
+**/*.swp
+**/*.swo
+**/*~


### PR DESCRIPTION
## Summary

- [x] `docker-compose` builds **both** `service.Dockerfile` and `fnn/Dockerfile` with `context: ../..` (the repo root), and there was **no `.dockerignore`** — so every image build shipped the entire repository as build context: the `.git` history, every `node_modules` tree (including the Discourse plugin's), `apps/admin/.next`, and all coverage output. That bloats the context sent to the daemon and slows every build, locally and in the `fiber-adapter-e2e` / `visual-acceptance` CI jobs.
- [x] Adds a conservative repo-root `.dockerignore` that excludes only non-source artifacts: `node_modules`, `dist`/`.next`/`.turbo` build output, coverage, `.git`, local `.env*` files (kept `.env.example`), and scratch dirs (`.worktrees`, `.tmp`, `.playwright-cli`, `deploy/compose/{evidence,backups}`).
- [x] Everything the Dockerfiles actually `COPY` is intentionally kept: `fiber-link-service/{package.json,bun.lockb,bunfig.toml,tsconfig.base.json,pnpm-workspace.yaml,apps,packages}` — including the `packages/db/drizzle` SQL migrations — and `deploy/compose/fnn/{config,entrypoint.sh}`.

## Scope

- [x] Single new file: `.dockerignore` at the repo root. **No Dockerfile or runtime behavior changes** — the in-image `bun install --frozen-lockfile` still regenerates `node_modules` from the lockfile.

## Verification

- [x] Confirmed none of the Dockerfiles' `COPY` sources match an ignore pattern (checked each path, incl. `packages/db/drizzle/*.sql` and the fnn config/entrypoint).
- [x] `deploy/compose/compose-reference.test.sh` still passes (all compose/Dockerfile assertions green).
- [x] Docker daemon isn't available in the dev sandbox, so the definitive build-time validation is the `fiber-adapter-e2e` and `visual-acceptance` CI jobs, which build the service image from the repo-root context and therefore exercise this `.dockerignore`.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (deploy hardening follow-up after the tooling backlog)
- [x] Required discussions or follow-ups are documented (see Notes)

## Notes

- Deliberately excludes only unambiguous artifacts; whole source trees (e.g. `fiber-link-discourse-plugin/`, `docs/`) are **not** excluded, so a future build that needs them won't be surprised. `NODE_ENV=production` was considered but intentionally **left out** of the image — it flips `fiber-adapter`'s simulation guardrail (`assertSimulationGuardrails`), which is per-deployment app semantics that belongs in compose env, not the shared image. Label: `enhancement`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_