### PR TITLE
test(rpc): make the CKB-address withdrawal store test hermetic

### DIFF
--- a/fiber-link-service/apps/rpc/src/methods/withdrawal.test.ts
+++ b/fiber-link-service/apps/rpc/src/methods/withdrawal.test.ts
@@ -596,6 +596,15 @@ describe("requestWithdrawal", () => {
       idempotencyKey: "credit:t1",
     });
 
+    // Inject a stub inventory provider (like the sibling tests) so the store
+    // path stays hermetic. Without one, a CKB_ADDRESS withdrawal falls through
+    // to the default provider, which queries the live CKB indexer (testnet).
+    const hotWalletInventoryProvider = vi.fn(async () => ({
+      asset: "CKB" as const,
+      network: "AGGRON4" as const,
+      availableAmount: "1000",
+    }));
+
     const res = await requestWithdrawal(
       {
         appId: "app1",
@@ -607,7 +616,7 @@ describe("requestWithdrawal", () => {
           address: "ckt1qyqfth8m4fevfzh5hhd088s78qcdjjp8cehs7z8jhw",
         },
       },
-      { repo, ledgerRepo: ledger },
+      { repo, ledgerRepo: ledger, hotWalletInventoryProvider },
     );
 
     const saved = await repo.findByIdOrThrow(res.id);


### PR DESCRIPTION
## Summary

- [x] `withdrawal.test.ts` › "stores CKB address destination with CKB_ADDRESS kind when valid" was the **one** withdrawal test that did not inject a `hotWalletInventoryProvider`. For a `CKB_ADDRESS` destination, `requestWithdrawal` falls through to `getDefaultHotWalletInventoryProvider()`, which queries the **live CKB indexer** (`testnet.ckb.dev`).
- [x] That made the test depend on outbound network access — it passed in CI but **failed in sandboxed environments** where `testnet.ckb.dev` is unreachable. This is the recurring *"known sandbox-only failure"* caveat that has been noted on essentially every PR in this backlog.
- [x] Fix: inject a stubbed provider with ample liquidity, exactly like the **seven sibling tests** in this same file already do, so the store path stays fully offline and deterministic. The assertions (`destinationKind` / `toAddress` on the saved record) are unchanged.

## Scope

- [x] Single file, single test: `apps/rpc/src/methods/withdrawal.test.ts`. No production code, no other tests touched.

## Verification

- [x] `apps/rpc` `tsc --noEmit` passes — the stub matches the provider signature used by the sibling tests (`{ asset: "CKB", network: "AGGRON4", availableAmount }`).
- [x] `biome ci` is clean on the changed file.
- [x] The change is shape-identical to the 7 sibling tests that already pass in CI. The runtime run can't be exercised in the dev sandbox (local bun workspace-linking quirk), so the `test-service` CI job is the definitive confirmation that it now passes **without** network access.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (removes the standing "sandbox-only testnet.ckb.dev" test caveat)
- [x] Required discussions or follow-ups are documented

## Notes

- Pure test-hermeticity change; no runtime behavior impact. This closes the last known network-dependent unit test. Label: `test`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_