### PR TITLE
feat(analytics): persist topic_id on tips for top-posts deep links (#434)

### DIFF
--- a/docs/rpc-schema.json
+++ b/docs/rpc-schema.json
@@ -64,6 +64,17 @@
                 "type": "string",
                 "minLength": 1
               },
+              "topicId": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "fromUserId": {
                 "type": "string",
                 "minLength": 1
@@ -1072,6 +1083,12 @@
                     "postId": {
                       "type": "string"
                     },
+                    "topicId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "totalAmount": {
                       "type": "string"
                     },
@@ -1081,6 +1098,7 @@
                   },
                   "required": [
                     "postId",
+                    "topicId",
                     "totalAmount",
                     "tipCount"
                   ],

--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -210,6 +210,7 @@ module ::FiberLink
         amount: params["amount"],
         asset: params["asset"],
         postId: post_id.to_s,
+        topicId: post.topic_id&.to_s,
         fromUserId: current_user.id.to_s,
         toUserId: post.user_id.to_s,
         message: params["message"].to_s.strip.presence,

--- a/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
+++ b/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
         body = JSON.parse(request.body)
         body.fetch("method") == "tip.create" &&
           body.dig("params", "postId") == post_id.to_s &&
+          body.dig("params", "topicId") == topic.id.to_s &&
           body.dig("params", "fromUserId") == user.id.to_s &&
           body.dig("params", "toUserId") == to_user_id.to_s &&
           body.dig("params", "message") == "Great post"

--- a/fiber-link-service/apps/rpc/src/contracts.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.ts
@@ -19,6 +19,7 @@ const PositiveAmountStringSchema = z
 
 export const TipCreateParamsSchema = z.object({
   postId: z.string().min(1),
+  topicId: z.string().min(1).optional().nullable(),
   fromUserId: z.string().min(1),
   toUserId: z.string().min(1),
   asset: z.enum(["CKB", "USDI"]),
@@ -328,6 +329,7 @@ const AnalyticsTimeSeriesItemSchema = z.object({
 
 const AnalyticsTopPostSchema = z.object({
   postId: z.string(),
+  topicId: z.string().nullable(),
   totalAmount: z.string(),
   tipCount: z.number().int(),
 });

--- a/fiber-link-service/apps/rpc/src/methods/dashboard.test.ts
+++ b/fiber-link-service/apps/rpc/src/methods/dashboard.test.ts
@@ -283,7 +283,7 @@ describe("handleDashboardAnalytics", () => {
 
     const analyticsResult = {
       timeSeries: [{ date: "2026-05-01", amount: "100" }],
-      topPosts: [{ postId: "post-1", totalAmount: "50", tipCount: 3 }],
+      topPosts: [{ postId: "post-1", topicId: "topic-1", totalAmount: "50", tipCount: 3 }],
       topTippers: [{ userId: "u-alice", totalAmount: "75", tipCount: 5 }],
       withdrawalHistory: [],
     };

--- a/fiber-link-service/apps/rpc/src/methods/tip.ts
+++ b/fiber-link-service/apps/rpc/src/methods/tip.ts
@@ -98,6 +98,7 @@ export function getDefaultAdapterForStream(): ReturnType<typeof createAdapterPro
 export type HandleTipCreateInput = {
   appId: string;
   postId: string;
+  topicId?: string | null;
   fromUserId: string;
   toUserId: string;
   asset: "CKB" | "USDI";
@@ -183,6 +184,7 @@ export async function handleTipCreate(input: HandleTipCreateInput, options: Hand
   const tipIntent = await repo.create({
     appId: input.appId,
     postId: input.postId,
+    topicId: input.topicId ?? null,
     fromUserId: input.fromUserId,
     toUserId: input.toUserId,
     asset: input.asset,

--- a/fiber-link-service/packages/db/drizzle/0003_tip_intents_topic_id.sql
+++ b/fiber-link-service/packages/db/drizzle/0003_tip_intents_topic_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tip_intents" ADD COLUMN "topic_id" text;

--- a/fiber-link-service/packages/db/drizzle/0003_tip_intents_topic_id.sql
+++ b/fiber-link-service/packages/db/drizzle/0003_tip_intents_topic_id.sql
@@ -1,1 +1,4 @@
-ALTER TABLE "tip_intents" ADD COLUMN "topic_id" text;
+-- Idempotent ADD COLUMN: the e2e harness replays every migration file via psql
+-- on top of an already-migrated database (see scripts/e2e-invoice-payment-
+-- accounting.sh), so this must tolerate the column already existing.
+ALTER TABLE "tip_intents" ADD COLUMN IF NOT EXISTS "topic_id" text;

--- a/fiber-link-service/packages/db/drizzle/meta/_journal.json
+++ b/fiber-link-service/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783877469998,
       "tag": "0002_notification_rules_channel_fk",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784137931891,
+      "tag": "0003_tip_intents_topic_id",
+      "breakpoints": true
     }
   ]
 }

--- a/fiber-link-service/packages/db/src/analytics-repo.ts
+++ b/fiber-link-service/packages/db/src/analytics-repo.ts
@@ -11,6 +11,7 @@ export type AnalyticsTimeSeries = {
 
 export type AnalyticsTopPost = {
   postId: string;
+  topicId: string | null;
   totalAmount: string;
   tipCount: number;
 };
@@ -76,6 +77,10 @@ export async function getCreatorAnalytics(
     db
       .select({
         postId: tipIntents.postId,
+        // A post_id maps to exactly one topic, but topic_id is nullable for
+        // rows created before it was tracked; MAX ignores NULLs so a post that
+        // ever recorded a topic keeps its deep link.
+        topicId: sql<string | null>`max(${tipIntents.topicId})`,
         totalAmount: sql<string>`COALESCE(SUM(${tipIntents.amount}), 0)::text`,
         tipCount: sql<number>`count(*)::int`,
       })
@@ -121,6 +126,7 @@ export async function getCreatorAnalytics(
     timeSeries: timeSeriesRows.map((r) => ({ date: r.date, amount: r.amount })),
     topPosts: topPostRows.map((r) => ({
       postId: r.postId,
+      topicId: r.topicId ?? null,
       totalAmount: r.totalAmount,
       tipCount: Number(r.tipCount),
     })),

--- a/fiber-link-service/packages/db/src/schema.ts
+++ b/fiber-link-service/packages/db/src/schema.ts
@@ -168,6 +168,10 @@ export const tipIntents = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     appId: text("app_id").notNull(),
     postId: text("post_id").notNull(),
+    // Nullable: older rows predate this column and analytics simply omits the
+    // post deep link for them. New tips persist the Discourse topic id so the
+    // analytics top-posts list can link to /t/:topic_id.
+    topicId: text("topic_id"),
     fromUserId: text("from_user_id").notNull(),
     toUserId: text("to_user_id").notNull(),
     asset: assetEnum("asset").notNull(),

--- a/fiber-link-service/packages/db/src/tip-intent-repo.ts
+++ b/fiber-link-service/packages/db/src/tip-intent-repo.ts
@@ -16,6 +16,7 @@ export type SettlementFailureReason =
 export type CreateTipIntentInput = {
   appId: string;
   postId: string;
+  topicId?: string | null;
   fromUserId: string;
   toUserId: string;
   asset: TipAsset;
@@ -117,6 +118,7 @@ function toRecord(row: TipIntentRow): TipIntentRecord {
     id: row.id,
     appId: row.appId,
     postId: row.postId,
+    topicId: row.topicId ?? null,
     fromUserId: row.fromUserId,
     toUserId: row.toUserId,
     asset: row.asset as TipAsset,
@@ -186,6 +188,7 @@ export function createDbTipIntentRepo(db: DbClient): TipIntentRepo {
           .values({
             appId: input.appId,
             postId: input.postId,
+            topicId: input.topicId ?? null,
             fromUserId: input.fromUserId,
             toUserId: input.toUserId,
             asset: input.asset,
@@ -396,6 +399,7 @@ export function createInMemoryTipIntentRepo(): TipIntentRepo {
       const now = new Date();
       const record: TipIntentRecord = {
         ...input,
+        topicId: input.topicId ?? null,
         message: input.message ?? null,
         id: randomUUID(),
         invoiceState: "UNPAID",


### PR DESCRIPTION
## Summary

Implements **#434** (parent plan #421, milestone **#416 Creator Analytics Dashboard**). Analytics top-posts links need both `post_id` and `topic_id`, but `tip_intents` only stored `post_id`. This threads `topic_id` end-to-end so the analytics panel can link a top post to `/t/:topic_id`.

- [x] **DB**: add a nullable `topic_id` column to `tip_intents` (migration `0003_tip_intents_topic_id`) plus the Drizzle model and repo types. Nullable by design — older rows predate the column and analytics simply omits the link for them (**no backfill**, per the acceptance criteria).
- [x] **RPC**: `tip.create` accepts an optional `topicId` and persists it alongside `postId`; `dashboard.analytics` → `topPosts` rows now return `topicId` (aggregated with `MAX` over the post group, so a post that ever recorded a topic keeps its deep link even if some rows are NULL).
- [x] **Contracts**: `TipCreateParamsSchema` + the analytics `topPosts` schema updated; `docs/rpc-schema.json` regenerated (the committed schema is drift-checked by `rpc-schema.test.ts`).
- [x] **Discourse**: the RPC proxy derives `topic_id` from the post **server-side** (same trust model as `post_id`/`toUserId` — never trusts the browser) and forwards it in the `tip.create` payload.

## Scope

- [x] `packages/db` (schema + migration + tip-intent repo + analytics repo), `apps/rpc` (contracts + tip handler), `docs/rpc-schema.json`, and the Discourse `rpc_controller.rb` + its request spec. No UI or worker changes.

## Verification

- [x] `packages/db` and `apps/rpc` `tsc --noEmit` pass.
- [x] `biome ci` clean.
- [x] Vitest: `tip.test.ts` (11), `dashboard.test.ts` analytics (3), `rpc-schema.test.ts` drift (5), `tip-intent-repo.test.ts` (25) all pass.
- [x] `drizzle-kit check` (`db:validate`) is clean — run the way CI runs it, without the gitignored `drizzle/meta` snapshots.
- [x] Migration is additive and safe on live data (`ADD COLUMN "topic_id" text`, nullable, no default rewrite).

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (closes #434; unblocks #433 analytics UI and #435 tests)
- [x] Required discussions or follow-ups are documented (see Notes)

## Notes

- First PR of the #416 analytics milestone. Follow-ups: **#435** (analytics test coverage) and **#433** (Discourse analytics UI panel, which consumes the new `topicId` for post links). Label: `enhancement`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_