### PR TITLE
docs(db): document and enforce the migration idempotency convention

### DIFF
--- a/fiber-link-service/packages/db/README.md
+++ b/fiber-link-service/packages/db/README.md
@@ -18,6 +18,35 @@ From this package directory:
 - Apply migrations to local Postgres in idempotent mode (runs twice; second pass should be no-op):
   - `bun run db:migrate:local`
 
+### Idempotency requirement
+
+Every migration file must be safe to apply **twice**. The visual-acceptance
+e2e harness (`scripts/e2e-invoice-payment-accounting.sh`) replays every
+`drizzle/*.sql` file with `psql -v ON_ERROR_STOP=1` on top of a database the
+compose `migrate` service has already migrated, so a bare `CREATE TABLE` /
+`ADD COLUMN` / `ADD CONSTRAINT` / `CREATE TYPE` aborts the whole run with a
+duplicate-object error.
+
+Conventions (drizzle-kit generates the first two by default; hand-adjust the
+rest after `db:generate`):
+
+- `CREATE TABLE IF NOT EXISTS ...`
+- `CREATE [UNIQUE] INDEX IF NOT EXISTS ...`
+- `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...`
+- `CREATE TYPE` and `ADD CONSTRAINT` wrapped in
+  `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN null; END $$;`
+- Data statements (`DELETE`/`UPDATE`/`INSERT`) written to be re-runnable
+  (see `0002_notification_rules_channel_fk.sql` for an example).
+
+`src/migration-idempotency.test.ts` enforces the DDL rules in the regular
+test suite, and `db:migrate:local` (apply twice; second pass must be a no-op)
+exercises the same property against a live database.
+
+Also note: `drizzle/meta/` snapshots are gitignored — only `_journal.json` is
+tracked. After `db:generate`, rename the generated SQL file to a descriptive
+`NNNN_snake_case_name.sql` and update the matching `tag` in
+`drizzle/meta/_journal.json`.
+
 Set `DATABASE_URL` for non-local migration commands:
 
 ```bash

--- a/fiber-link-service/packages/db/src/migration-idempotency.test.ts
+++ b/fiber-link-service/packages/db/src/migration-idempotency.test.ts
@@ -34,9 +34,9 @@ function stripGuardedBlocks(sql: string): string {
   return sql.replace(/DO\s+\$\$[\s\S]*?\$\$\s*;?/gi, "");
 }
 
-/** Remove SQL comments so commented-out DDL doesn't trip the checks. */
+/** Remove line and block comments so commented-out DDL doesn't trip the checks. */
 function stripComments(sql: string): string {
-  return sql.replace(/--[^\n]*/g, "");
+  return sql.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
 describe("migration idempotency (drizzle/*.sql replay safety)", () => {
@@ -50,18 +50,27 @@ describe("migration idempotency (drizzle/*.sql replay safety)", () => {
   for (const file of files) {
     describe(file, () => {
       const raw = readFileSync(join(MIGRATIONS_DIR, file), "utf8");
-      const unguarded = stripComments(stripGuardedBlocks(raw));
+      // Comments first, then guards: a comment containing `$$` must not
+      // corrupt the guarded-block stripping.
+      const unguarded = stripGuardedBlocks(stripComments(raw));
 
       it("uses CREATE TABLE IF NOT EXISTS", () => {
         expect(unguarded).not.toMatch(/CREATE\s+TABLE\s+(?!IF\s+NOT\s+EXISTS)/i);
       });
 
-      it("uses CREATE [UNIQUE] INDEX IF NOT EXISTS", () => {
-        expect(unguarded).not.toMatch(/CREATE\s+(UNIQUE\s+)?INDEX\s+(?!IF\s+NOT\s+EXISTS)/i);
+      it("uses CREATE [UNIQUE] INDEX [CONCURRENTLY] IF NOT EXISTS", () => {
+        // The optional CONCURRENTLY lives inside the lookahead: an optional
+        // group *before* a negative lookahead can backtrack and false-flag
+        // the compliant `CONCURRENTLY IF NOT EXISTS` form.
+        expect(unguarded).not.toMatch(/CREATE\s+(UNIQUE\s+)?INDEX\s+(?!(CONCURRENTLY\s+)?IF\s+NOT\s+EXISTS)/i);
       });
 
-      it("uses ADD COLUMN IF NOT EXISTS", () => {
-        expect(unguarded).not.toMatch(/ADD\s+COLUMN\s+(?!IF\s+NOT\s+EXISTS)/i);
+      it("uses ADD [COLUMN] IF NOT EXISTS", () => {
+        // Postgres allows omitting the COLUMN keyword, so catch both forms.
+        // Two alternations (instead of one optional group) avoid lookahead
+        // backtracking false-positives on `ADD COLUMN IF NOT EXISTS`.
+        expect(unguarded).not.toMatch(/\bADD\s+COLUMN\s+(?!IF\s+NOT\s+EXISTS)/i);
+        expect(unguarded).not.toMatch(/\bADD\s+(?!COLUMN\b|CONSTRAINT\b|IF\s+NOT\s+EXISTS)/i);
       });
 
       it("wraps CREATE TYPE in a duplicate_object guard", () => {

--- a/fiber-link-service/packages/db/src/migration-idempotency.test.ts
+++ b/fiber-link-service/packages/db/src/migration-idempotency.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every migration file must be idempotent (safe to apply twice).
+ *
+ * The visual-acceptance e2e harness (scripts/e2e-invoice-payment-accounting.sh)
+ * replays every drizzle/*.sql file with `psql -v ON_ERROR_STOP=1` on top of a
+ * database the compose `migrate` service has already migrated, so a bare
+ * `CREATE TABLE` / `ADD COLUMN` / `ADD CONSTRAINT` / `CREATE TYPE` aborts the
+ * whole run with a duplicate-object error. The repo convention is:
+ *
+ * - `CREATE TABLE IF NOT EXISTS` / `CREATE [UNIQUE] INDEX IF NOT EXISTS`
+ * - `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`
+ * - `CREATE TYPE` and `ADD CONSTRAINT` wrapped in
+ *   `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN null; END $$;`
+ * - data statements (DELETE/UPDATE/INSERT) written to be re-runnable
+ *
+ * This test guards the DDL rules; see packages/db/README.md for the full
+ * convention.
+ */
+
+const MIGRATIONS_DIR = resolve(__dirname, "..", "drizzle");
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+}
+
+/** Remove DO $$ ... $$ blocks — statements inside them are exception-guarded. */
+function stripGuardedBlocks(sql: string): string {
+  return sql.replace(/DO\s+\$\$[\s\S]*?\$\$\s*;?/gi, "");
+}
+
+/** Remove SQL comments so commented-out DDL doesn't trip the checks. */
+function stripComments(sql: string): string {
+  return sql.replace(/--[^\n]*/g, "");
+}
+
+describe("migration idempotency (drizzle/*.sql replay safety)", () => {
+  const files = migrationFiles();
+
+  it("finds at least the baseline migration", () => {
+    expect(files.length).toBeGreaterThan(0);
+    expect(files[0]).toMatch(/^0000_/);
+  });
+
+  for (const file of files) {
+    describe(file, () => {
+      const raw = readFileSync(join(MIGRATIONS_DIR, file), "utf8");
+      const unguarded = stripComments(stripGuardedBlocks(raw));
+
+      it("uses CREATE TABLE IF NOT EXISTS", () => {
+        expect(unguarded).not.toMatch(/CREATE\s+TABLE\s+(?!IF\s+NOT\s+EXISTS)/i);
+      });
+
+      it("uses CREATE [UNIQUE] INDEX IF NOT EXISTS", () => {
+        expect(unguarded).not.toMatch(/CREATE\s+(UNIQUE\s+)?INDEX\s+(?!IF\s+NOT\s+EXISTS)/i);
+      });
+
+      it("uses ADD COLUMN IF NOT EXISTS", () => {
+        expect(unguarded).not.toMatch(/ADD\s+COLUMN\s+(?!IF\s+NOT\s+EXISTS)/i);
+      });
+
+      it("wraps CREATE TYPE in a duplicate_object guard", () => {
+        expect(unguarded).not.toMatch(/CREATE\s+TYPE/i);
+      });
+
+      it("wraps ADD CONSTRAINT in a duplicate_object guard", () => {
+        expect(unguarded).not.toMatch(/ADD\s+CONSTRAINT/i);
+      });
+
+      it("guarded blocks swallow duplicate_object", () => {
+        const guards = raw.match(/DO\s+\$\$[\s\S]*?\$\$\s*;?/gi) ?? [];
+        for (const guard of guards) {
+          expect(guard).toMatch(/EXCEPTION[\s\S]*WHEN\s+duplicate_object\s+THEN/i);
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

The e2e harness (`scripts/e2e-invoice-payment-accounting.sh`) replays **every** `drizzle/*.sql` file with `psql -v ON_ERROR_STOP=1` on top of a database the compose `migrate` service has already migrated — so every migration must be safe to apply twice. The convention existed implicitly (baseline uses `IF NOT EXISTS` + guarded `CREATE TYPE`; `0002` guards its `ADD CONSTRAINT`) but was **undocumented**, and #517 tripped over it with a bare `ADD COLUMN` that aborted the visual-acceptance bootstrap.

- [x] **`packages/db/README.md`**: documents the replay behavior, the required DDL forms (`IF NOT EXISTS` for tables/indexes/columns; `DO $$ … EXCEPTION WHEN duplicate_object` guards for `CREATE TYPE` / `ADD CONSTRAINT`; re-runnable data statements), the `drizzle/meta` gitignore convention, and the rename-after-generate step.
- [x] **`src/migration-idempotency.test.ts`** (new): enforces the DDL rules inside the regular vitest suite — no CI wiring needed. Strips comments and guarded `DO $$` blocks, then flags any bare `CREATE TABLE` / `CREATE [UNIQUE] INDEX` / `ADD COLUMN` / `CREATE TYPE` / `ADD CONSTRAINT`, and verifies each guard actually swallows `duplicate_object`.

## Scope

- [x] Two files in `packages/db`: README + one new test. No schema, migration, or runtime changes.

## Verification

- [x] The new test passes on the four existing migrations (25 assertions).
- [x] Negative-tested: a synthetic migration with bare `ADD COLUMN` + `CREATE TABLE` is correctly rejected (2 failures), then removed.
- [x] `biome ci` clean.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (follow-up to the #517 migration failure; also protects the upcoming multi-asset migrations, #440/#444)
- [x] Required discussions or follow-ups are documented

## Notes

- Pure docs + test guard; prevents a whole class of e2e bootstrap failures. Label: `docs`, `test`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_