### PR TITLE
ci(e2e): retry transient CKB testnet failures in faucet and inventory steps

### DIFF
--- a/scripts/e2e-discourse-four-flows-common.test.sh
+++ b/scripts/e2e-discourse-four-flows-common.test.sh
@@ -77,3 +77,118 @@ trap 'rm -rf "${TEST_TMPDIR}" "${NORMALIZE_TMPDIR}" "${COPY_TMPDIR}"' EXIT
   diff -u "${src}" "${dest_one}" >/dev/null
   diff -u "${src}" "${dest_two}" >/dev/null
 )
+
+FAUCET_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TEST_TMPDIR}" "${NORMALIZE_TMPDIR}" "${COPY_TMPDIR}" "${FAUCET_TMPDIR}"' EXIT
+
+# Faucet retry: two transient 504s then success must be accepted, with two
+# retry log lines and no fatal.
+(
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/scripts/lib/e2e-discourse-four-flows-common.sh"
+
+  ARTIFACTS_DIR="${FAUCET_TMPDIR}"
+  CKB_FAUCET_ENABLE_FALLBACK=0
+  CKB_FAUCET_WAIT_SECONDS=0
+  CKB_FAUCET_RETRY_INTERVAL_SECONDS=0
+  CURL_COUNT_FILE="${FAUCET_TMPDIR}/curl.count"
+  printf '0' > "${CURL_COUNT_FILE}"
+
+  log() { printf '%s\n' "$*" >> "${FAUCET_TMPDIR}/faucet.log"; }
+  sleep() { :; }
+  fatal() { printf 'fatal:%s\n' "$*" >> "${FAUCET_TMPDIR}/faucet.log"; exit 90; }
+
+  curl() {
+    local out=""
+    while [[ $# -gt 0 ]]; do
+      if [[ "$1" == "-o" ]]; then out="$2"; shift 2; else shift; fi
+    done
+    local n
+    n=$(( $(cat "${CURL_COUNT_FILE}") + 1 ))
+    printf '%s' "${n}" > "${CURL_COUNT_FILE}"
+    if [[ "${n}" -lt 3 ]]; then
+      printf '' > "${out}"
+      printf '504'
+    else
+      printf '{}' > "${out}"
+      printf '200'
+    fi
+    return 0
+  }
+
+  request_ckb_faucet_for_address "ckt1qtestaddress" "retry-case"
+
+  [[ "$(cat "${CURL_COUNT_FILE}")" == "3" ]]
+  [[ "$(grep -c 'transient failure (http=504)' "${FAUCET_TMPDIR}/faucet.log")" == "2" ]]
+  grep -q 'ckb faucet(retry-case) accepted' "${FAUCET_TMPDIR}/faucet.log"
+  ! grep -q '^fatal:' "${FAUCET_TMPDIR}/faucet.log"
+)
+
+# Faucet retry: a hard 4xx (403) must fail fast without retries.
+(
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/scripts/lib/e2e-discourse-four-flows-common.sh"
+
+  ARTIFACTS_DIR="${FAUCET_TMPDIR}"
+  CKB_FAUCET_ENABLE_FALLBACK=0
+  CKB_FAUCET_RETRY_INTERVAL_SECONDS=0
+  CURL_COUNT_FILE="${FAUCET_TMPDIR}/curl-hard.count"
+  printf '0' > "${CURL_COUNT_FILE}"
+
+  log() { printf '%s\n' "$*" >> "${FAUCET_TMPDIR}/faucet-hard.log"; }
+  sleep() { :; }
+  fatal() { printf 'fatal:%s\n' "$*" >> "${FAUCET_TMPDIR}/faucet-hard.log"; exit 90; }
+
+  curl() {
+    local out=""
+    while [[ $# -gt 0 ]]; do
+      if [[ "$1" == "-o" ]]; then out="$2"; shift 2; else shift; fi
+    done
+    local n
+    n=$(( $(cat "${CURL_COUNT_FILE}") + 1 ))
+    printf '%s' "${n}" > "${CURL_COUNT_FILE}"
+    printf '' > "${out}"
+    printf '403'
+    return 0
+  }
+
+  rc=0
+  ( request_ckb_faucet_for_address "ckt1qtestaddress" "hard-case" ) || rc=$?
+  [[ "${rc}" == "90" ]]
+  [[ "$(cat "${CURL_COUNT_FILE}")" == "1" ]]
+  grep -q 'fatal:.*http=403' "${FAUCET_TMPDIR}/faucet-hard.log"
+)
+
+# Hot-wallet inventory retry: two docker failures then success.
+(
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/scripts/lib/e2e-discourse-four-flows-common.sh"
+
+  HOT_WALLET_INVENTORY_RETRY_INTERVAL_SECONDS=0
+  DOCKER_COUNT_FILE="${FAUCET_TMPDIR}/docker.count"
+  printf '0' > "${DOCKER_COUNT_FILE}"
+
+  log() { printf '%s\n' "$*" >> "${FAUCET_TMPDIR}/inventory.log"; }
+  sleep() { :; }
+  fatal() { printf 'fatal:%s\n' "$*" >> "${FAUCET_TMPDIR}/inventory.log"; exit 90; }
+
+  docker() {
+    local n
+    n=$(( $(cat "${DOCKER_COUNT_FILE}") + 1 ))
+    printf '%s' "${n}" > "${DOCKER_COUNT_FILE}"
+    if [[ "${n}" -lt 3 ]]; then
+      return 1
+    fi
+    printf '{"asset":"CKB","availableAmount":"1"}\n'
+    return 0
+  }
+
+  capture_hot_wallet_inventory "${FAUCET_TMPDIR}/inventory.json" "CKB" "AGGRON4"
+
+  [[ "$(cat "${DOCKER_COUNT_FILE}")" == "3" ]]
+  grep -q '"availableAmount":"1"' "${FAUCET_TMPDIR}/inventory.json"
+  [[ "$(grep -c 'inventory capture failed; retry' "${FAUCET_TMPDIR}/inventory.log")" == "2" ]]
+  ! grep -q '^fatal:' "${FAUCET_TMPDIR}/inventory.log"
+)
+
+printf 'e2e-discourse-four-flows-common checks passed\n'

--- a/scripts/e2e-discourse-four-flows-common.test.sh
+++ b/scripts/e2e-discourse-four-flows-common.test.sh
@@ -191,4 +191,41 @@ trap 'rm -rf "${TEST_TMPDIR}" "${NORMALIZE_TMPDIR}" "${COPY_TMPDIR}" "${FAUCET_T
   ! grep -q '^fatal:' "${FAUCET_TMPDIR}/inventory.log"
 )
 
+
+# Faucet retry: a 2xx response carrying a logical error body is permanent —
+# must fail fast without retries.
+(
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/scripts/lib/e2e-discourse-four-flows-common.sh"
+
+  ARTIFACTS_DIR="${FAUCET_TMPDIR}"
+  CKB_FAUCET_ENABLE_FALLBACK=0
+  CKB_FAUCET_RETRY_INTERVAL_SECONDS=0
+  CURL_COUNT_FILE="${FAUCET_TMPDIR}/curl-logical.count"
+  printf '0' > "${CURL_COUNT_FILE}"
+
+  log() { printf '%s\n' "$*" >> "${FAUCET_TMPDIR}/faucet-logical.log"; }
+  sleep() { :; }
+  fatal() { printf 'fatal:%s\n' "$*" >> "${FAUCET_TMPDIR}/faucet-logical.log"; exit 90; }
+
+  curl() {
+    local out=""
+    while [[ $# -gt 0 ]]; do
+      if [[ "$1" == "-o" ]]; then out="$2"; shift 2; else shift; fi
+    done
+    local n
+    n=$(( $(cat "${CURL_COUNT_FILE}") + 1 ))
+    printf '%s' "${n}" > "${CURL_COUNT_FILE}"
+    printf '{"error":"address already claimed"}' > "${out}"
+    printf '200'
+    return 0
+  }
+
+  rc=0
+  ( request_ckb_faucet_for_address "ckt1qtestaddress" "logical-case" ) || rc=$?
+  [[ "${rc}" == "90" ]]
+  [[ "$(cat "${CURL_COUNT_FILE}")" == "1" ]]
+  grep -q 'fatal:.*http=200' "${FAUCET_TMPDIR}/faucet-logical.log"
+)
+
 printf 'e2e-discourse-four-flows-common checks passed\n'

--- a/scripts/e2e-invoice-payment-accounting.sh
+++ b/scripts/e2e-invoice-payment-accounting.sh
@@ -879,17 +879,33 @@ request_ckb_faucet() {
   printf '%s\n' "${payload}" > "${target_dir}/ckb-faucet-${label}.request.json"
 
   local response_file="${target_dir}/ckb-faucet-${label}.response.json"
-  local http_code
-  set +e
-  http_code="$(curl -sS -o "${response_file}" -w "%{http_code}" \
-    -H "content-type: application/json" \
-    -d "${payload}" \
-    "${CKB_FAUCET_API_BASE%/}/claim_events")"
-  local rc=$?
-  set -e
-  if [[ "${rc}" -ne 0 ]]; then
-    http_code="000"
-  fi
+  local http_code rc attempt
+  local attempts="${CKB_FAUCET_ATTEMPTS:-3}"
+  local retry_interval="${CKB_FAUCET_RETRY_INTERVAL_SECONDS:-20}"
+  for (( attempt=1; attempt<=attempts; attempt++ )); do
+    set +e
+    http_code="$(curl -sS -o "${response_file}" -w "%{http_code}" \
+      -H "content-type: application/json" \
+      -d "${payload}" \
+      "${CKB_FAUCET_API_BASE%/}/claim_events")"
+    rc=$?
+    set -e
+    if [[ "${rc}" -ne 0 ]]; then
+      http_code="000"
+    fi
+    # Success, or a non-transient status: stop retrying. Only network
+    # failures (000), timeouts (408), rate limits (429), and 5xx heal.
+    if [[ "${http_code}" -ge 200 && "${http_code}" -lt 300 ]]; then
+      break
+    fi
+    if [[ "${http_code}" =~ ^4 && "${http_code}" != "408" && "${http_code}" != "429" ]]; then
+      break
+    fi
+    if (( attempt < attempts )); then
+      log "CKB faucet(${label}) transient failure (HTTP ${http_code}); retry ${attempt}/${attempts} in $((retry_interval * attempt))s"
+      sleep $((retry_interval * attempt))
+    fi
+  done
 
   if [[ "${http_code}" -lt 200 || "${http_code}" -ge 300 ]]; then
     if [[ "${CKB_FAUCET_ENABLE_FALLBACK}" == "1" ]]; then

--- a/scripts/e2e-invoice-payment-accounting.sh
+++ b/scripts/e2e-invoice-payment-accounting.sh
@@ -876,13 +876,16 @@ request_ckb_faucet() {
 
   local payload
   payload="$(jq -cn --arg address "${address}" --arg amount "${CKB_FAUCET_AMOUNT}" '{claim_event:{address_hash:$address,amount:$amount}}')"
-  printf '%s\n' "${payload}" > "${target_dir}/ckb-faucet-${label}.request.json"
 
-  local response_file="${target_dir}/ckb-faucet-${label}.response.json"
+  local response_file
   local http_code rc attempt
   local attempts="${CKB_FAUCET_ATTEMPTS:-3}"
   local retry_interval="${CKB_FAUCET_RETRY_INTERVAL_SECONDS:-20}"
   for (( attempt=1; attempt<=attempts; attempt++ )); do
+    # Per-attempt request/response artifacts keep the debugging trail intact
+    # (matches the four-flows common lib).
+    printf '%s\n' "${payload}" > "${target_dir}/ckb-faucet-${label}-a${attempt}.request.json"
+    response_file="${target_dir}/ckb-faucet-${label}-a${attempt}.response.json"
     set +e
     http_code="$(curl -sS -o "${response_file}" -w "%{http_code}" \
       -H "content-type: application/json" \

--- a/scripts/lib/e2e-discourse-four-flows-common.sh
+++ b/scripts/lib/e2e-discourse-four-flows-common.sh
@@ -32,6 +32,13 @@ CKB_FAUCET_FALLBACK_API_BASE="${CKB_FAUCET_FALLBACK_API_BASE:-https://ckb-utilit
 CKB_FAUCET_ENABLE_FALLBACK="${CKB_FAUCET_ENABLE_FALLBACK:-1}"
 CKB_FAUCET_AMOUNT="${CKB_FAUCET_AMOUNT:-100000}"
 CKB_FAUCET_WAIT_SECONDS="${CKB_FAUCET_WAIT_SECONDS:-20}"
+# Transient-failure retries: public testnet faucets intermittently return
+# 5xx/timeouts under load (a 504 aborted PR #517's run). Retry with linear
+# backoff before declaring the run dead.
+CKB_FAUCET_ATTEMPTS="${CKB_FAUCET_ATTEMPTS:-3}"
+CKB_FAUCET_RETRY_INTERVAL_SECONDS="${CKB_FAUCET_RETRY_INTERVAL_SECONDS:-20}"
+HOT_WALLET_INVENTORY_ATTEMPTS="${HOT_WALLET_INVENTORY_ATTEMPTS:-3}"
+HOT_WALLET_INVENTORY_RETRY_INTERVAL_SECONDS="${HOT_WALLET_INVENTORY_RETRY_INTERVAL_SECONDS:-10}"
 WITHDRAWAL_SIGNER_CACHE_PATH="${E2E_WITHDRAWAL_SIGNER_CACHE_PATH:-${ROOT_DIR}/.tmp/e2e-discourse-four-flows/withdrawal-signer.json}"
 WITHDRAWAL_RESERVE_CACHE_PATH="${E2E_WITHDRAWAL_RESERVE_CACHE_PATH:-${ROOT_DIR}/.tmp/e2e-discourse-four-flows/withdrawal-reserve.json}"
 WORKFLOW_RPC_PORT="${WORKFLOW_RPC_PORT:-${DEFAULT_WORKFLOW_RPC_PORT}}"
@@ -1019,14 +1026,18 @@ rebalance_withdrawal_signer_balance() {
   vlog "withdrawal signer balance after reserve rebalance: ${signer_balance} shannons"
 }
 
-request_ckb_faucet_for_address() {
+# One primary+fallback faucet attempt. Returns 0 on acceptance, 1 otherwise;
+# leaves the primary HTTP status in LAST_FAUCET_HTTP_CODE for the retry loop.
+request_ckb_faucet_for_address_attempt() {
   local address="$1"
   local label="$2"
+  local suffix="$3"
   local payload request_file response_file http_code
   local fallback_payload fallback_request_file fallback_response_file fallback_http_code
+  LAST_FAUCET_HTTP_CODE="000"
   payload="$(jq -cn --arg address "${address}" --arg amount "${CKB_FAUCET_AMOUNT}" '{claim_event:{address_hash:$address,amount:$amount}}')"
-  request_file="${ARTIFACTS_DIR}/ckb-faucet-${label}.request.json"
-  response_file="${ARTIFACTS_DIR}/ckb-faucet-${label}.response.json"
+  request_file="${ARTIFACTS_DIR}/ckb-faucet-${label}${suffix}.request.json"
+  response_file="${ARTIFACTS_DIR}/ckb-faucet-${label}${suffix}.response.json"
   printf '%s\n' "${payload}" > "${request_file}"
 
   set +e
@@ -1036,7 +1047,11 @@ request_ckb_faucet_for_address() {
     "${CKB_FAUCET_API_BASE%/}/claim_events")"
   local rc=$?
   set -e
-  if [[ "${rc}" -eq 0 && "${http_code}" -ge 200 && "${http_code}" -lt 300 ]] \
+  if [[ "${rc}" -ne 0 ]]; then
+    http_code="000"
+  fi
+  LAST_FAUCET_HTTP_CODE="${http_code}"
+  if [[ "${http_code}" -ge 200 && "${http_code}" -lt 300 ]] \
     && ! jq -e '(.error != null) or ((.errors | type) == "array" and (.errors | length) > 0)' "${response_file}" >/dev/null 2>&1; then
     log "ckb faucet(${label}) accepted; waiting ${CKB_FAUCET_WAIT_SECONDS}s"
     sleep "${CKB_FAUCET_WAIT_SECONDS}"
@@ -1045,8 +1060,8 @@ request_ckb_faucet_for_address() {
 
   if [[ "${CKB_FAUCET_ENABLE_FALLBACK}" == "1" ]]; then
     fallback_payload="$(jq -cn --arg address "${address}" '{address:$address,token:"ckb"}')"
-    fallback_request_file="${ARTIFACTS_DIR}/ckb-faucet-fallback-${label}.request.json"
-    fallback_response_file="${ARTIFACTS_DIR}/ckb-faucet-fallback-${label}.response.json"
+    fallback_request_file="${ARTIFACTS_DIR}/ckb-faucet-fallback-${label}${suffix}.request.json"
+    fallback_response_file="${ARTIFACTS_DIR}/ckb-faucet-fallback-${label}${suffix}.response.json"
     printf '%s\n' "${fallback_payload}" > "${fallback_request_file}"
     set +e
     fallback_http_code="$(curl -sS -o "${fallback_response_file}" -w "%{http_code}" \
@@ -1063,10 +1078,35 @@ request_ckb_faucet_for_address() {
     fi
   fi
 
-  if [[ "${http_code:-000}" == "422" ]]; then
-    log "ckb faucet(${label}) returned HTTP 422; continuing with existing signer balance"
-    return 0
-  fi
+  return 1
+}
+
+request_ckb_faucet_for_address() {
+  local address="$1"
+  local label="$2"
+  local attempt http_code=""
+  for (( attempt=1; attempt<=CKB_FAUCET_ATTEMPTS; attempt++ )); do
+    if request_ckb_faucet_for_address_attempt "${address}" "${label}" "-a${attempt}"; then
+      return 0
+    fi
+    http_code="${LAST_FAUCET_HTTP_CODE:-000}"
+
+    if [[ "${http_code}" == "422" ]]; then
+      log "ckb faucet(${label}) returned HTTP 422; continuing with existing signer balance"
+      return 0
+    fi
+
+    # Other 4xx (bad request/auth/eligibility) won't heal on retry; only
+    # network failures (000), timeouts (408), rate limits (429), and 5xx do.
+    if [[ "${http_code}" =~ ^4 && "${http_code}" != "408" && "${http_code}" != "429" ]]; then
+      break
+    fi
+
+    if (( attempt < CKB_FAUCET_ATTEMPTS )); then
+      log "ckb faucet(${label}) transient failure (http=${http_code}); retry ${attempt}/${CKB_FAUCET_ATTEMPTS} in $((CKB_FAUCET_RETRY_INTERVAL_SECONDS * attempt))s"
+      sleep $((CKB_FAUCET_RETRY_INTERVAL_SECONDS * attempt))
+    fi
+  done
 
   fatal "${EXIT_PRECHECK}" "ckb faucet request failed for ${label} (http=${http_code:-000})"
 }
@@ -1271,14 +1311,26 @@ capture_hot_wallet_inventory() {
   local output_path="$1"
   local asset="${2:-CKB}"
   local network="${3:-AGGRON4}"
+  local attempt
 
-  docker exec -w /app fiber-link-rpc sh -lc "bun -e '
+  # The provider queries the live CKB testnet indexer, which intermittently
+  # times out; retry with linear backoff before failing the run.
+  for (( attempt=1; attempt<=HOT_WALLET_INVENTORY_ATTEMPTS; attempt++ )); do
+    if docker exec -w /app fiber-link-rpc sh -lc "bun -e '
 import { createDefaultHotWalletInventoryProvider } from \"@fiber-link/fiber-adapter\";
 const provider = createDefaultHotWalletInventoryProvider();
 const inventory = await provider({ asset: \"${asset}\", network: \"${network}\" });
 console.log(JSON.stringify(inventory));
-' " > "${output_path}" 2>"${output_path%.json}.stderr.log" \
-    || fatal "${EXIT_ARTIFACT}" "failed to capture hot wallet inventory"
+' " > "${output_path}" 2>"${output_path%.json}.attempt${attempt}.stderr.log"; then
+      return 0
+    fi
+    if (( attempt < HOT_WALLET_INVENTORY_ATTEMPTS )); then
+      log "hot wallet inventory capture failed; retry ${attempt}/${HOT_WALLET_INVENTORY_ATTEMPTS} in $((HOT_WALLET_INVENTORY_RETRY_INTERVAL_SECONDS * attempt))s"
+      sleep $((HOT_WALLET_INVENTORY_RETRY_INTERVAL_SECONDS * attempt))
+    fi
+  done
+
+  fatal "${EXIT_ARTIFACT}" "failed to capture hot wallet inventory"
 }
 
 capture_withdrawal_liquidity_snapshot() {

--- a/scripts/lib/e2e-discourse-four-flows-common.sh
+++ b/scripts/lib/e2e-discourse-four-flows-common.sh
@@ -1102,6 +1102,12 @@ request_ckb_faucet_for_address() {
       break
     fi
 
+    # 2xx with a failed attempt means the response body carried a logical
+    # error — permanent, so don't burn retries on it.
+    if [[ "${http_code}" -ge 200 && "${http_code}" -lt 300 ]]; then
+      break
+    fi
+
     if (( attempt < CKB_FAUCET_ATTEMPTS )); then
       log "ckb faucet(${label}) transient failure (http=${http_code}); retry ${attempt}/${CKB_FAUCET_ATTEMPTS} in $((CKB_FAUCET_RETRY_INTERVAL_SECONDS * attempt))s"
       sleep $((CKB_FAUCET_RETRY_INTERVAL_SECONDS * attempt))


### PR DESCRIPTION
## Summary

PR #517's `visual-acceptance` runs died **twice** on external testnet flakiness: first the CKB faucet returned `504` for the withdrawal-signer top-up (phase 3), then the hot-wallet inventory capture — a live indexer UTXO query — failed (phase 5). Neither step had any retry, so a single testnet hiccup killed a ~15-minute run and required a manual re-trigger.

- [x] **`scripts/lib/e2e-discourse-four-flows-common.sh`**:
  - `request_ckb_faucet_for_address` now runs up to `CKB_FAUCET_ATTEMPTS` (default 3) primary+fallback cycles with linear backoff (`CKB_FAUCET_RETRY_INTERVAL_SECONDS`, default 20s). Only transient statuses retry (network failure `000`, `408`, `429`, `5xx`); hard 4xx still fails fast, and `422` keeps its existing continue-with-existing-balance behavior. Per-attempt request/response artifacts keep an `-aN` suffix trail.
  - `capture_hot_wallet_inventory` retries the indexer query up to `HOT_WALLET_INVENTORY_ATTEMPTS` (default 3) with backoff, keeping per-attempt stderr logs.
- [x] **`scripts/e2e-invoice-payment-accounting.sh`**: same transient-retry loop on its faucet request.
- [x] **`scripts/e2e-discourse-four-flows-common.test.sh`**: three new stubbed test blocks — retry-then-accept (2× 504 then 200, exactly 2 retry logs), hard-4xx fail-fast (403, exactly 1 attempt), and inventory retry-then-success.

## Scope

- [x] Three shell scripts under `scripts/`. No service, plugin, or workflow-yaml changes; defaults preserve current behavior apart from the added retries.

## Verification

- [x] The three new test blocks pass standalone (stubbed `curl`/`docker`/`sleep`/`fatal`).
- [x] `bash -n` clean on all three files.
- [x] Note: the pre-existing first block of the common test file requires a live Discourse on `:4200` (developer environment only — the file is not wired into CI), so the full file can't run in this sandbox; the new blocks were verified in isolation.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (CI-stability follow-up to the #517 re-trigger churn; adjacent to #472's ops-observability theme)
- [x] Required discussions or follow-ups are documented

## Notes

- Directly reduces false-red `visual-acceptance` runs for every future PR. Retry counts/intervals are env-tunable if the testnet gets rougher. Label: `enhancement`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_