### PR TITLE
test(client): cover the SSE stream paths, lifting SDK coverage past 90% (#431)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .worktrees
 node_modules
 
+# Test coverage output (vitest --coverage)
+coverage/
+coverage-reports/
+
 # bun 1.3+ writes a text bun.lock on install; this repo's canonical lockfile is
 # the binary bun.lockb (referenced by CI cache keys and the service Dockerfile).
 # Ignore the text variant so it is never committed alongside the binary one.

--- a/fiber-link-service/packages/client/src/client.test.ts
+++ b/fiber-link-service/packages/client/src/client.test.ts
@@ -230,3 +230,139 @@ describe("FiberLinkClient signed mode header generation", () => {
     expect(headers["x-signature"]).toMatch(/^[0-9a-f]+$/);
   });
 });
+
+describe("FiberLinkClient streamTipStatus event handling", () => {
+  function makePresignedClient() {
+    return new FiberLinkClient({ endpoint: "http://localhost:3000/rpc", mode: "presigned" });
+  }
+
+  class CapturingEventSource {
+    static instances: CapturingEventSource[] = [];
+    url: string;
+    closed = false;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onerror: (() => void) | null = null;
+
+    constructor(url: string) {
+      this.url = url;
+      CapturingEventSource.instances.push(this);
+    }
+
+    close() {
+      this.closed = true;
+    }
+  }
+
+  it("forwards status events and closes on terminal SETTLED", () => {
+    CapturingEventSource.instances = [];
+    vi.stubGlobal("EventSource", CapturingEventSource);
+    try {
+      const events: unknown[] = [];
+      const handle = makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
+      const es = CapturingEventSource.instances[0];
+
+      es.onmessage?.({ data: JSON.stringify({ invoice: FAKE_INVOICE, status: "LISTENING" }) });
+      expect(es.closed).toBe(false);
+
+      es.onmessage?.({ data: JSON.stringify({ invoice: FAKE_INVOICE, status: "SETTLED" }) });
+      expect(events).toEqual([
+        { invoice: FAKE_INVOICE, status: "LISTENING" },
+        { invoice: FAKE_INVOICE, status: "SETTLED" },
+      ]);
+      expect(es.closed).toBe(true);
+      handle?.close();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("closes on terminal TIMEOUT", () => {
+    CapturingEventSource.instances = [];
+    vi.stubGlobal("EventSource", CapturingEventSource);
+    try {
+      const events: unknown[] = [];
+      makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
+      const es = CapturingEventSource.instances[0];
+
+      es.onmessage?.({ data: JSON.stringify({ invoice: FAKE_INVOICE, status: "TIMEOUT" }) });
+      expect(events).toEqual([{ invoice: FAKE_INVOICE, status: "TIMEOUT" }]);
+      expect(es.closed).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("ignores malformed and status-less events", () => {
+    CapturingEventSource.instances = [];
+    vi.stubGlobal("EventSource", CapturingEventSource);
+    try {
+      const events: unknown[] = [];
+      makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
+      const es = CapturingEventSource.instances[0];
+
+      es.onmessage?.({ data: "not-json{{" });
+      es.onmessage?.({ data: JSON.stringify({ hello: "world" }) });
+      es.onmessage?.({ data: JSON.stringify(null) });
+      expect(events).toEqual([]);
+      expect(es.closed).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("emits SSE_ERROR and closes on transport error", () => {
+    CapturingEventSource.instances = [];
+    vi.stubGlobal("EventSource", CapturingEventSource);
+    try {
+      const events: unknown[] = [];
+      makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
+      const es = CapturingEventSource.instances[0];
+
+      es.onerror?.();
+      expect(es.closed).toBe(true);
+      expect(events).toEqual([{ invoice: FAKE_INVOICE, status: "SSE_ERROR" }]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("returns null when the EventSource constructor throws", () => {
+    vi.stubGlobal(
+      "EventSource",
+      class {
+        constructor() {
+          throw new Error("blocked");
+        }
+      },
+    );
+    try {
+      expect(makePresignedClient().streamTipStatus(FAKE_INVOICE, vi.fn())).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("close() on the handle closes the underlying stream", () => {
+    CapturingEventSource.instances = [];
+    vi.stubGlobal("EventSource", CapturingEventSource);
+    try {
+      const handle = makePresignedClient().streamTipStatus(FAKE_INVOICE, vi.fn());
+      const es = CapturingEventSource.instances[0];
+      expect(es.closed).toBe(false);
+      handle?.close();
+      expect(es.closed).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("package entrypoint re-exports", () => {
+  it("exposes the client and error classes from ./index", async () => {
+    const entry = await import("./index");
+    expect(entry.FiberLinkClient).toBe(FiberLinkClient);
+    expect(typeof entry.FiberLinkValidationError).toBe("function");
+    expect(typeof entry.FiberLinkResponseError).toBe("function");
+    expect(typeof entry.FiberLinkNetworkError).toBe("function");
+  });
+});

--- a/fiber-link-service/packages/client/src/client.test.ts
+++ b/fiber-link-service/packages/client/src/client.test.ts
@@ -236,30 +236,46 @@ describe("FiberLinkClient streamTipStatus event handling", () => {
     return new FiberLinkClient({ endpoint: "http://localhost:3000/rpc", mode: "presigned" });
   }
 
-  class CapturingEventSource {
-    static instances: CapturingEventSource[] = [];
+  type MockEventSource = {
     url: string;
-    closed = false;
-    onmessage: ((event: { data: string }) => void) | null = null;
-    onerror: (() => void) | null = null;
+    closed: boolean;
+    close(): void;
+    onmessage: ((event: { data: string }) => void) | null;
+    onerror: (() => void) | null;
+  };
 
-    constructor(url: string) {
-      this.url = url;
-      CapturingEventSource.instances.push(this);
-    }
-
-    close() {
-      this.closed = true;
-    }
+  // Local factory instead of a static registry: each test gets its own
+  // instance list, so no shared mutable state can leak between tests.
+  function setupMockEventSource(): MockEventSource[] {
+    const instances: MockEventSource[] = [];
+    vi.stubGlobal(
+      "EventSource",
+      class {
+        constructor(url: string) {
+          const instance: MockEventSource = {
+            url,
+            closed: false,
+            close() {
+              this.closed = true;
+            },
+            onmessage: null,
+            onerror: null,
+          };
+          instances.push(instance);
+          // biome-ignore lint/correctness/noConstructorReturn: the mock hands back a plain capturing object.
+          return instance;
+        }
+      },
+    );
+    return instances;
   }
 
   it("forwards status events and closes on terminal SETTLED", () => {
-    CapturingEventSource.instances = [];
-    vi.stubGlobal("EventSource", CapturingEventSource);
+    const instances = setupMockEventSource();
     try {
       const events: unknown[] = [];
       const handle = makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
-      const es = CapturingEventSource.instances[0];
+      const es = instances[0];
 
       es.onmessage?.({ data: JSON.stringify({ invoice: FAKE_INVOICE, status: "LISTENING" }) });
       expect(es.closed).toBe(false);
@@ -277,12 +293,11 @@ describe("FiberLinkClient streamTipStatus event handling", () => {
   });
 
   it("closes on terminal TIMEOUT", () => {
-    CapturingEventSource.instances = [];
-    vi.stubGlobal("EventSource", CapturingEventSource);
+    const instances = setupMockEventSource();
     try {
       const events: unknown[] = [];
       makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
-      const es = CapturingEventSource.instances[0];
+      const es = instances[0];
 
       es.onmessage?.({ data: JSON.stringify({ invoice: FAKE_INVOICE, status: "TIMEOUT" }) });
       expect(events).toEqual([{ invoice: FAKE_INVOICE, status: "TIMEOUT" }]);
@@ -293,30 +308,29 @@ describe("FiberLinkClient streamTipStatus event handling", () => {
   });
 
   it("ignores malformed and status-less events", () => {
-    CapturingEventSource.instances = [];
-    vi.stubGlobal("EventSource", CapturingEventSource);
+    const instances = setupMockEventSource();
     try {
       const events: unknown[] = [];
-      makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
-      const es = CapturingEventSource.instances[0];
+      const handle = makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
+      const es = instances[0];
 
       es.onmessage?.({ data: "not-json{{" });
       es.onmessage?.({ data: JSON.stringify({ hello: "world" }) });
       es.onmessage?.({ data: JSON.stringify(null) });
       expect(events).toEqual([]);
       expect(es.closed).toBe(false);
+      handle?.close();
     } finally {
       vi.unstubAllGlobals();
     }
   });
 
   it("emits SSE_ERROR and closes on transport error", () => {
-    CapturingEventSource.instances = [];
-    vi.stubGlobal("EventSource", CapturingEventSource);
+    const instances = setupMockEventSource();
     try {
       const events: unknown[] = [];
       makePresignedClient().streamTipStatus(FAKE_INVOICE, (e) => events.push(e));
-      const es = CapturingEventSource.instances[0];
+      const es = instances[0];
 
       es.onerror?.();
       expect(es.closed).toBe(true);
@@ -343,11 +357,10 @@ describe("FiberLinkClient streamTipStatus event handling", () => {
   });
 
   it("close() on the handle closes the underlying stream", () => {
-    CapturingEventSource.instances = [];
-    vi.stubGlobal("EventSource", CapturingEventSource);
+    const instances = setupMockEventSource();
     try {
       const handle = makePresignedClient().streamTipStatus(FAKE_INVOICE, vi.fn());
-      const es = CapturingEventSource.instances[0];
+      const es = instances[0];
       expect(es.closed).toBe(false);
       handle?.close();
       expect(es.closed).toBe(true);


### PR DESCRIPTION
## Summary

Completes the last open criterion of **#431** (milestone #415/#420, Multi-platform Plugin SDK). The `packages/client/README.md` (installation, quick-start for both modes, full API reference with TS signatures, error types) and the `examples/vanilla-js/` integration example **already exist** — what was missing was the **"SDK has ≥90% line coverage"** requirement: the suite sat at ~86% because `streamTipStatus`'s `EventSource` handlers were entirely untested.

- [x] New `CapturingEventSource` fake covering: `LISTENING` passthrough, terminal `SETTLED`/`TIMEOUT` auto-close, malformed / status-less event ignore, transport error → `SSE_ERROR` + close, constructor-throw → `null`, and `handle.close()`.
- [x] Entrypoint re-export test brings `index.ts` (previously 0%) into the report.
- [x] Coverage now **95.68% lines / 100% functions** (24 tests, up from 17).
- [x] `.gitignore`: exclude `coverage/` output (vitest `--coverage` artifacts were previously committable).

## Scope

- [x] `packages/client/src/client.test.ts` + root `.gitignore`. No production code changes.

## Verification

- [x] 24/24 tests pass; coverage 95.68% lines.
- [x] `tsc --noEmit` and `biome ci` clean.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (completes #431's remaining criterion)
- [x] Required discussions or follow-ups are documented (see Notes)

## Notes

- **#430** (refactor the Discourse plugin to import `@fiber-link/client`) is intentionally **not** included: the plugin has no `package.json` and must remain installable into any Discourse instance standalone, while `@fiber-link/client` is not yet published to npm — so a literal npm import is blocked on publishing (the package became publishable in #504). The plugin's `fiber-link-api.js` documents that it deliberately mirrors the SDK's presigned-mode interface until then. Suggest revisiting #430 after an npm release. Label: `test`, `sdk`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_