### PR TITLE
feat(multi-asset): tip.status asset, withdrawal asset selector, asset docs (#442/#443/#444)

### DIFF
--- a/docs/multi-asset.md
+++ b/docs/multi-asset.md
@@ -1,0 +1,44 @@
+# Multi-Asset Support
+
+_How assets are modeled across Fiber Link, and the checklist for adding a new one._
+
+Fiber Link currently supports two assets end to end:
+
+| Asset | Kind | Fiber invoice currency | On-chain form |
+|---|---|---|---|
+| `CKB` | Native | `Fibb` / `Fibt` / `Fibd` (per network, via `FIBER_INVOICE_CURRENCY_CKB`) | Plain capacity transfer |
+| `USDI` | UDT (stablecoin) | `FIBER_INVOICE_CURRENCY_USDI` | `udt_type_script`-scoped cells |
+
+## Where the asset type lives
+
+- **Database** — the `asset` Postgres enum (`packages/db/src/schema.ts`, `assetEnum`) is the single registry. Every financial table carries it: `tip_intents`, `ledger_entries`, `withdrawals`, and `withdrawal_policies.allowed_assets` (jsonb list).
+- **Ledger** — balances are computed per `(app_id, user_id, asset)`; credits and debits never mix assets.
+- **RPC contracts** — `tip.create`, `tip.status`, `withdrawal.quote`, and `withdrawal.request` accept/return `asset` (`apps/rpc/src/contracts.ts`); `dashboard.summary` returns per-asset `assetBalances`.
+- **Fiber adapter** — `createInvoice({ amount, asset })` maps the asset to a Fiber invoice currency and, for UDT assets, attaches the `udt_type_script` (`packages/fiber-adapter/src/rpc-adapter/invoice-ops.ts`); `executeWithdrawal` does the same for payments (`withdrawal-ops.ts`). The UDT script resolves from `FIBER_USDI_UDT_TYPE_SCRIPT_JSON` or the node's `node_info` (`FIBER_USDI_UDT_NAME` picks the entry).
+- **Simulation adapter** — asset-aware invoice/withdrawal simulation for tests and demos (`simulation-adapter.ts`).
+- **Policy** — `withdrawal_policies.allowed_assets` gates which assets an app may withdraw; per-asset withdrawal minimums come from the destination kind (CKB address minimum cell capacity applies to `CKB` only).
+- **Surfaces** — the creator dashboard shows per-asset balance cards and an asset selector in the withdrawal form when more than one asset has balance; the admin withdrawal list has an `Asset` column.
+
+## Adding a new asset (checklist)
+
+1. **DB enum**: add the value to `assetEnum` in `packages/db/src/schema.ts` and generate a migration (`bun run db:generate`). `ALTER TYPE ... ADD VALUE` must follow the idempotency convention (`packages/db/README.md`) — wrap it in a `duplicate_object` guard.
+2. **Contracts**: extend the `z.enum(["CKB", "USDI", ...])` asset literals in `apps/rpc/src/contracts.ts` and regenerate `docs/rpc-schema.json` (`bun run schema:generate` in `apps/rpc`; the drift test enforces this).
+3. **Adapter mapping**: add the invoice currency env (`FIBER_INVOICE_CURRENCY_<ASSET>`) and, for UDT assets, the `udt_type_script` resolution (mirror the `USDI` handling in `invoice-ops.ts` / `withdrawal-ops.ts`).
+4. **Simulation adapter**: extend the asset union so tests and demo flows can settle the new asset offline.
+5. **Policy defaults**: decide whether existing apps' `allowed_assets` should include it (no automatic backfill).
+6. **Surfaces**: the dashboard's per-asset cards and the withdrawal asset selector pick the new asset up automatically from `assetBalances`; check the admin policy form's allowed-assets editor.
+7. **Tests**: extend `apps/worker/src/settlement.multi-asset.test.ts` (ledger credit + notification carry the asset) and the adapter's invoice tests (correct currency / `udt_type_script`).
+
+## Environment reference
+
+| Variable | Purpose |
+|---|---|
+| `FIBER_INVOICE_CURRENCY_CKB` | Fiber invoice currency code for CKB (`Fibb` mainnet, `Fibt` testnet, `Fibd` dev) |
+| `FIBER_INVOICE_CURRENCY_USDI` | Fiber invoice currency code for USDI |
+| `FIBER_USDI_UDT_TYPE_SCRIPT_JSON` | Explicit UDT type script (`{code_hash, hash_type, args}`); overrides node discovery |
+| `FIBER_USDI_UDT_NAME` | Name to select the UDT entry from `node_info` when the script isn't pinned |
+
+## Boundaries
+
+- Withdrawals to raw CKB addresses (`CKB_ADDRESS` destinations) support only `CKB` today; UDT assets withdraw over Fiber payment requests.
+- Zero-balance assets are hidden from the creator dashboard (cards and selector render only assets with entries).

--- a/docs/rpc-schema.json
+++ b/docs/rpc-schema.json
@@ -172,10 +172,18 @@
                   "SETTLED",
                   "FAILED"
                 ]
+              },
+              "asset": {
+                "type": "string",
+                "enum": [
+                  "CKB",
+                  "USDI"
+                ]
               }
             },
             "required": [
-              "state"
+              "state",
+              "asset"
             ],
             "additionalProperties": false
           }
@@ -218,10 +226,18 @@
                   "SETTLED",
                   "FAILED"
                 ]
+              },
+              "asset": {
+                "type": "string",
+                "enum": [
+                  "CKB",
+                  "USDI"
+                ]
               }
             },
             "required": [
-              "state"
+              "state",
+              "asset"
             ],
             "additionalProperties": false
           }

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
@@ -10,6 +10,7 @@ import { i18n } from "discourse-i18n";
 import { quoteWithdrawal, requestWithdrawal } from "../services/fiber-link-api";
 
 const MIN_WITHDRAW_AMOUNT = 61;
+const eq = (a, b) => a === b;
 const ADDRESS_PATTERN = /^(?:ckt|ckb)1[0-9a-zA-Z]+$/;
 const QUOTE_DEBOUNCE_MS = 300;
 
@@ -49,6 +50,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
   @tracked requestedId = null;
   @tracked requestedState = null;
   @tracked hasSubmitted = false;
+  @tracked selectedAsset = null;
 
   _quoteTimer = null;
 
@@ -58,15 +60,44 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   get asset() {
+    if (this.selectedAsset) {
+      return this.selectedAsset;
+    }
     return this.args.asset === "USDI" ? "USDI" : "CKB";
   }
 
+  // Assets the creator actually holds; the selector only renders when there
+  // is more than one, so single-asset creators keep the uncluttered form.
+  get selectableAssets() {
+    const balances = Array.isArray(this.args.assetBalances) ? this.args.assetBalances : [];
+    return balances.map((entry) => entry.asset).filter(Boolean);
+  }
+
+  get showAssetSelector() {
+    return this.selectableAssets.length > 1;
+  }
+
+  get selectedAssetBalances() {
+    const balances = Array.isArray(this.args.assetBalances) ? this.args.assetBalances : [];
+    return balances.find((entry) => entry.asset === this.asset) ?? null;
+  }
+
   get availableBalance() {
-    return normalizeValue(this.quote?.availableBalance) || normalizeValue(this.args.availableBalance) || "0";
+    return (
+      normalizeValue(this.quote?.availableBalance) ||
+      normalizeValue(this.selectedAssetBalances?.available) ||
+      normalizeValue(this.args.availableBalance) ||
+      "0"
+    );
   }
 
   get lockedBalance() {
-    return normalizeValue(this.quote?.lockedBalance) || normalizeValue(this.args.lockedBalance) || "0";
+    return (
+      normalizeValue(this.quote?.lockedBalance) ||
+      normalizeValue(this.selectedAssetBalances?.locked) ||
+      normalizeValue(this.args.lockedBalance) ||
+      "0"
+    );
   }
 
   get receiveAmount() {
@@ -266,6 +297,16 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   @action
+  onAssetChange(event) {
+    this.selectedAsset = event?.target?.value === "USDI" ? "USDI" : "CKB";
+    this.quote = null;
+    this.errorMessage = null;
+    this.quoteErrorMessage = null;
+    this.hasSubmitted = false;
+    this._scheduleQuoteRefresh();
+  }
+
+  @action
   onAmountInput(event) {
     this.amount = event?.target?.value ?? "";
     this.errorMessage = null;
@@ -433,6 +474,21 @@ export default class FiberLinkWithdrawalPanel extends Component {
 
       <div class="fiber-link-dashboard__withdrawal-form">
         <label class="fiber-link-tip-field">
+          {{#if this.showAssetSelector}}
+            <span class="fiber-link-dashboard__field-row">
+              <span class="fiber-link-tip-label">{{i18n "fiber_link.withdrawal.asset_label"}}</span>
+              <select
+                class="fiber-link-dashboard__withdrawal-asset"
+                data-fiber-link-withdrawal-input="asset"
+                aria-label={{i18n "fiber_link.withdrawal.asset_label"}}
+                {{on "change" this.onAssetChange}}
+              >
+                {{#each this.selectableAssets as |assetOption|}}
+                  <option value={{assetOption}} selected={{eq assetOption this.asset}}>{{assetOption}}</option>
+                {{/each}}
+              </select>
+            </span>
+          {{/if}}
           <span class="fiber-link-dashboard__field-row">
             <span class="fiber-link-tip-label">{{i18n "fiber_link.withdrawal.amount_label"}}</span>
             <span>{{i18n "fiber_link.withdrawal.network_fee" fee=this.networkFee asset=this.asset}}</span>

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/components/fiber-link-withdrawal-panel.gjs
@@ -60,10 +60,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   get asset() {
-    if (this.selectedAsset) {
-      return this.selectedAsset;
-    }
-    return this.args.asset === "USDI" ? "USDI" : "CKB";
+    return this.selectedAsset || this.args.asset || "CKB";
   }
 
   // Assets the creator actually holds; the selector only renders when there
@@ -82,11 +79,17 @@ export default class FiberLinkWithdrawalPanel extends Component {
     return balances.find((entry) => entry.asset === this.asset) ?? null;
   }
 
+  get isPrimaryAssetSelected() {
+    return this.asset === (this.args.asset || "CKB");
+  }
+
   get availableBalance() {
+    // The scalar args balances describe the primary asset only; never let
+    // them bleed into another asset's display while balances/quote load.
     return (
       normalizeValue(this.quote?.availableBalance) ||
       normalizeValue(this.selectedAssetBalances?.available) ||
-      normalizeValue(this.args.availableBalance) ||
+      (this.isPrimaryAssetSelected ? normalizeValue(this.args.availableBalance) : "") ||
       "0"
     );
   }
@@ -95,7 +98,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
     return (
       normalizeValue(this.quote?.lockedBalance) ||
       normalizeValue(this.selectedAssetBalances?.locked) ||
-      normalizeValue(this.args.lockedBalance) ||
+      (this.isPrimaryAssetSelected ? normalizeValue(this.args.lockedBalance) : "") ||
       "0"
     );
   }
@@ -126,8 +129,8 @@ export default class FiberLinkWithdrawalPanel extends Component {
       return i18n("fiber_link.withdrawal.error_amount_numeric");
     }
 
-    if (Number(value) < MIN_WITHDRAW_AMOUNT) {
-      return i18n("fiber_link.withdrawal.error_amount_min", { min: MIN_WITHDRAW_AMOUNT });
+    if (this.minimumWithdrawalAmount > 0 && Number(value) < this.minimumWithdrawalAmount) {
+      return i18n("fiber_link.withdrawal.error_amount_min", { min: this.minimumWithdrawalAmount });
     }
 
     if (Number(value) > this.availableBalanceNumber) {
@@ -247,7 +250,13 @@ export default class FiberLinkWithdrawalPanel extends Component {
   }
 
   get minimumWithdrawalAmount() {
-    return MIN_WITHDRAW_AMOUNT;
+    const quoted = Number(this.quote?.minimumAmount);
+    if (Number.isFinite(quoted) && quoted > 0) {
+      return quoted;
+    }
+    // The 61 floor is the CKB minimal cell capacity; UDT assets have no
+    // client-side floor until the server quotes one.
+    return this.asset === "CKB" ? MIN_WITHDRAW_AMOUNT : 0;
   }
 
   get availableBalanceNumber() {
@@ -298,7 +307,7 @@ export default class FiberLinkWithdrawalPanel extends Component {
 
   @action
   onAssetChange(event) {
-    this.selectedAsset = event?.target?.value === "USDI" ? "USDI" : "CKB";
+    this.selectedAsset = event?.target?.value || "CKB";
     this.quote = null;
     this.errorMessage = null;
     this.quoteErrorMessage = null;

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/templates/fiber-link-dashboard.hbs
@@ -142,6 +142,7 @@
   <div class="fiber-link-dashboard__content-grid">
     <FiberLinkWithdrawalPanel
       @asset={{this.model.balanceAsset}}
+      @assetBalances={{this.model.assetBalances}}
       @availableBalance={{this.model.availableBalance}}
       @lockedBalance={{this.model.lockedBalance}}
     />

--- a/fiber-link-discourse-plugin/config/locales/client.en.yml
+++ b/fiber-link-discourse-plugin/config/locales/client.en.yml
@@ -114,6 +114,7 @@ en:
         rel_days: "%{n}d ago"
         rel_weeks: "%{n}w ago"
       withdrawal:
+        asset_label: "Asset"
         kicker: "WITHDRAW"
         title_lead: "Move your"
         title_emphasis: "settled"

--- a/fiber-link-discourse-plugin/config/locales/client.zh_CN.yml
+++ b/fiber-link-discourse-plugin/config/locales/client.zh_CN.yml
@@ -114,6 +114,7 @@ zh_CN:
         rel_days: "%{n} 天前"
         rel_weeks: "%{n} 周前"
       withdrawal:
+        asset_label: "资产"
         kicker: "提现"
         title_lead: "转出你"
         title_emphasis: "已结算"

--- a/fiber-link-service/apps/rpc/src/contracts.test.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.test.ts
@@ -68,7 +68,8 @@ describe("rpc contracts", () => {
     ).toBe(false);
 
     expect(TipCreateResultSchema.safeParse({ invoice: "invoice-1" }).success).toBe(true);
-    expect(TipStatusResultSchema.safeParse({ state: "SETTLED" }).success).toBe(true);
+    expect(TipStatusResultSchema.safeParse({ state: "SETTLED", asset: "CKB" }).success).toBe(true);
+    expect(TipStatusResultSchema.safeParse({ state: "SETTLED" }).success).toBe(false);
     expect(TipStatusResultSchema.safeParse({ state: "BROKEN" }).success).toBe(false);
     expect(
       WithdrawalRequestParamsSchema.safeParse({

--- a/fiber-link-service/apps/rpc/src/contracts.ts
+++ b/fiber-link-service/apps/rpc/src/contracts.ts
@@ -37,6 +37,7 @@ export const TipStatusParamsSchema = z.object({
 
 export const TipStatusResultSchema = z.object({
   state: z.enum(["UNPAID", "SETTLED", "FAILED"]),
+  asset: z.enum(["CKB", "USDI"]),
 });
 
 const WithdrawalRequestBaseParamsSchema = z.object({

--- a/fiber-link-service/apps/rpc/src/methods/tip.ts
+++ b/fiber-link-service/apps/rpc/src/methods/tip.ts
@@ -324,7 +324,7 @@ export async function handleTipStatus(input: HandleTipStatusInput, options: Hand
     },
     options.log,
   );
-  return { state: tipIntent.invoiceState };
+  return { state: tipIntent.invoiceState, asset: tipIntent.asset };
 }
 
 export async function handleTipSettledFeed(

--- a/fiber-link-service/apps/rpc/src/methods/tip.ts
+++ b/fiber-link-service/apps/rpc/src/methods/tip.ts
@@ -235,7 +235,7 @@ export async function handleTipStatus(input: HandleTipStatusInput, options: Hand
       },
       options.log,
     );
-    return { state: tipIntent.invoiceState };
+    return { state: tipIntent.invoiceState, asset: tipIntent.asset };
   }
 
   const invoiceStatus = await adapter.getInvoiceStatus({ invoice: input.invoice });
@@ -275,7 +275,7 @@ export async function handleTipStatus(input: HandleTipStatusInput, options: Hand
       },
       options.log,
     );
-    return { state: nextState };
+    return { state: nextState, asset: tipIntent.asset };
   }
 
   if (invoiceStatus.state === "FAILED") {
@@ -306,7 +306,7 @@ export async function handleTipStatus(input: HandleTipStatusInput, options: Hand
       },
       options.log,
     );
-    return { state: nextState };
+    return { state: nextState, asset: tipIntent.asset };
   }
 
   await appendTipTimelineEvent(

--- a/fiber-link-service/apps/rpc/src/rpc.test.ts
+++ b/fiber-link-service/apps/rpc/src/rpc.test.ts
@@ -363,7 +363,7 @@ describe("json-rpc", () => {
 
   it("returns tip.status result from handler", async () => {
     const app = buildServer();
-    const tipStatusSpy = vi.spyOn(tipMethods, "handleTipStatus").mockResolvedValue({ state: "UNPAID" });
+    const tipStatusSpy = vi.spyOn(tipMethods, "handleTipStatus").mockResolvedValue({ state: "UNPAID", asset: "CKB" });
     try {
       const payload = { jsonrpc: "2.0", id: "s1", method: "tip.status", params: { invoice: "inv-1" } };
       const ts = String(Math.floor(Date.now() / 1000));
@@ -389,7 +389,7 @@ describe("json-rpc", () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.json()).toEqual({ jsonrpc: "2.0", id: "s1", result: { state: "UNPAID" } });
+      expect(res.json()).toEqual({ jsonrpc: "2.0", id: "s1", result: { state: "UNPAID", asset: "CKB" } });
       expect(tipStatusSpy).toHaveBeenCalledWith(
         { invoice: "inv-1" },
         expect.objectContaining({ log: expect.anything() }),
@@ -401,7 +401,7 @@ describe("json-rpc", () => {
 
   it("returns tip.get result from handler", async () => {
     const app = buildServer();
-    const tipStatusSpy = vi.spyOn(tipMethods, "handleTipStatus").mockResolvedValue({ state: "UNPAID" });
+    const tipStatusSpy = vi.spyOn(tipMethods, "handleTipStatus").mockResolvedValue({ state: "UNPAID", asset: "CKB" });
     try {
       const payload = { jsonrpc: "2.0", id: "g1", method: "tip.get", params: { invoice: "inv-1" } };
       const ts = String(Math.floor(Date.now() / 1000));
@@ -427,7 +427,7 @@ describe("json-rpc", () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.json()).toEqual({ jsonrpc: "2.0", id: "g1", result: { state: "UNPAID" } });
+      expect(res.json()).toEqual({ jsonrpc: "2.0", id: "g1", result: { state: "UNPAID", asset: "CKB" } });
       expect(tipStatusSpy).toHaveBeenCalledWith(
         { invoice: "inv-1" },
         expect.objectContaining({ log: expect.anything() }),
@@ -1044,7 +1044,8 @@ describe("json-rpc", () => {
     const app = buildServer();
     const tipCreateSpy = vi.spyOn(tipMethods, "handleTipCreate").mockResolvedValue({ invoice: "inv-happy-1" });
     const tipStatusSpy = vi.spyOn(tipMethods, "handleTipStatus").mockImplementation(async ({ invoice }) => ({
-      state: invoice === "inv-happy-1" ? "UNPAID" : "FAILED",
+      state: invoice === "inv-happy-1" ? ("UNPAID" as const) : ("FAILED" as const),
+      asset: "CKB" as const,
     }));
     try {
       const createPayload = {
@@ -1125,7 +1126,7 @@ describe("json-rpc", () => {
       expect(getRes.json()).toEqual({
         jsonrpc: "2.0",
         id: "get-1",
-        result: { state: "UNPAID" },
+        result: { state: "UNPAID", asset: "CKB" },
       });
       expect(tipStatusSpy).toHaveBeenCalledWith(
         { invoice: "inv-happy-1" },

--- a/fiber-link-service/apps/worker/src/settlement.multi-asset.test.ts
+++ b/fiber-link-service/apps/worker/src/settlement.multi-asset.test.ts
@@ -1,0 +1,53 @@
+import { createInMemoryLedgerRepo, createInMemoryTipIntentRepo } from "@fiber-link/db";
+import type { AnyNotificationEvent, NotificationDispatcher } from "@fiber-link/notifications";
+import { describe, expect, it, vi } from "vitest";
+import { markSettled } from "./settlement";
+
+/**
+ * Multi-asset regression (#444): a USDI tip settles into a USDI ledger
+ * credit and the TIP_SETTLED notification carries the asset, with no CKB
+ * fallback anywhere in the path.
+ */
+describe("markSettled multi-asset", () => {
+  it("credits the ledger and dispatches TIP_SETTLED with asset USDI", async () => {
+    const tipIntentRepo = createInMemoryTipIntentRepo();
+    const ledgerRepo = createInMemoryLedgerRepo();
+
+    await tipIntentRepo.create({
+      appId: "app-1",
+      postId: "post-1",
+      fromUserId: "tipper",
+      toUserId: "creator",
+      asset: "USDI",
+      amount: "12.5",
+      invoice: "inv-usdi-1",
+    });
+
+    const dispatchTipSettledEvent = vi.fn(async (_event: AnyNotificationEvent) => ({ delivered: 0, failed: 0 }));
+    const dispatcher = {
+      dispatchTipSettledEvent,
+      dispatchWithdrawalEvent: vi.fn(async (_event: AnyNotificationEvent) => ({ delivered: 0, failed: 0 })),
+    } as unknown as NotificationDispatcher;
+
+    const result = await markSettled({ invoice: "inv-usdi-1" }, { tipIntentRepo, ledgerRepo, dispatcher });
+
+    expect(result.credited).toBe(true);
+    const entries = ledgerRepo.__listForTests?.() ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ asset: "USDI", amount: "12.5", userId: "creator" });
+
+    expect(dispatchTipSettledEvent).toHaveBeenCalledOnce();
+    expect(dispatchTipSettledEvent.mock.calls[0][0]).toMatchObject({
+      type: "TIP_SETTLED",
+      asset: "USDI",
+      amount: "12.5",
+      invoice: "inv-usdi-1",
+    });
+
+    const balance = await ledgerRepo.getBalance({ appId: "app-1", userId: "creator", asset: "USDI" });
+    expect(balance).toBe("12.5");
+    // No cross-asset bleed: the CKB balance stays zero.
+    const ckb = await ledgerRepo.getBalance({ appId: "app-1", userId: "creator", asset: "CKB" });
+    expect(ckb).toBe("0");
+  });
+});


### PR DESCRIPTION
## Summary

Gap-fill for milestone **#418 Multi-Asset Support** (units #441–#444). Most of multi-asset had already shipped — the adapter maps CKB/USDI to Fiber invoice currencies and attaches the USDI `udt_type_script` on invoices **and** withdrawals (#441 ✅), `tip.create`/`withdrawal.*` accept `asset`, `dashboard.summary` returns per-asset balances, the creator dashboard renders per-asset cards, and the admin withdrawal list has an Asset column. This PR lands the remaining acceptance items:

- [x] **RPC (#442)**: `tip.status` now returns the tip's `asset` alongside its state; contracts + committed `docs/rpc-schema.json` regenerated; the pinned contract test asserts `asset` is required.
- [x] **Plugin (#443)**: the withdrawal form gains an **asset selector** (defaulting to the primary asset) that only renders when the creator holds more than one asset — single-asset creators keep the uncluttered form. Displayed balances follow the selected asset via `assetBalances`, and quoting/submission use it. `en` + `zh_CN` labels (parity-checked).
- [x] **Tests (#444)**: `settlement.multi-asset.test.ts` pins that a USDI tip settles into a **USDI ledger credit** and a `TIP_SETTLED` notification carrying the asset, with no cross-asset bleed into CKB.
- [x] **Docs (#444)**: `docs/multi-asset.md` documents the asset registry, the adapter env mapping (`FIBER_INVOICE_CURRENCY_*`, `FIBER_USDI_UDT_*`), current boundaries, and the add-a-new-asset checklist.

## Scope

- [x] `apps/rpc` (tip handler + contracts + schema doc + tests), `apps/worker` (one new test), Discourse plugin (withdrawal panel + dashboard wiring + locales), `docs/multi-asset.md`.

## Verification

- [x] rpc suite 19 files green (incl. the schema drift test and the updated contract pin); worker suite green incl. the new multi-asset test.
- [x] `biome ci` clean; `i18n-parity.test.sh` passes (195 referenced keys, 197/197).
- [x] `tsc --noEmit` clean on rpc + worker.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (completes the open scope of #442, #443, #444; with the already-shipped #441 this closes milestone #418's remaining items — note #440's schema landed previously)
- [x] Required discussions or follow-ups are documented (see Notes)

## Notes

- The migration-safety part of #444 is additionally covered by the PGlite harness from #521, which applies every committed migration on a fresh instance in the db test suite. The `dashboard.balance` per-asset map described in the issues shipped earlier as `dashboard.summary.assetBalances`. Label: `enhancement`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_