### PR TITLE
sec(plugin): staff-only webhook channels with SSRF-safe target validation (#469)

### DIFF
--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -91,7 +91,7 @@ module ::FiberLink
       # Webhook channel management is an operator surface: it configures
       # outbound deliveries (and their secrets) for the whole forum, so it is
       # restricted to staff rather than any logged-in creator.
-      if method.to_s.start_with?("notification.") && !current_user.staff?
+      if method.to_s.start_with?("notification.") && !current_user&.staff?
         render_error(request_id, :forbidden, -32001, "Unauthorized")
         return
       end
@@ -482,17 +482,26 @@ module ::FiberLink
       return false unless %w[http https].include?(uri.scheme)
       return false if uri.scheme == "http" && Rails.env.production?
 
-      host = uri.host.to_s.downcase
+      # A trailing dot is root-zone DNS syntax the resolver treats as the same
+      # host, so normalize it away before any comparison.
+      host = uri.host.to_s.downcase.chomp(".")
       return false if host.blank?
       return false if BLOCKED_WEBHOOK_HOSTS.include?(host)
       return false if host.end_with?(".local", ".internal", ".localhost")
 
       begin
-        ip = IPAddr.new(host)
+        # AI_NUMERICHOST parses every numeric literal form the backend's
+        # resolver would accept (shorthand 127.1, hex 0x7f000001, octal,
+        # plain decimal) WITHOUT doing DNS, closing the literal-form bypasses
+        # that IPAddr.new alone misses.
+        addrinfo = Socket.getaddrinfo(host, nil, nil, nil, nil, Socket::AI_NUMERICHOST)
+        ip_string = addrinfo.first[2]
+        ip = IPAddr.new(ip_string).native
         return false if ip.loopback? || ip.private? || ip.link_local? ||
           ip == IPAddr.new("0.0.0.0") || ip == IPAddr.new("::")
-      rescue IPAddr::InvalidAddressError
-        # Not an IP literal; hostname checks above apply.
+      rescue SocketError, IPAddr::InvalidAddressError
+        # Not an IP literal in any form; the hostname checks above apply and
+        # DNS-resolved private targets remain the worker network policy's job.
       end
 
       true

--- a/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
+++ b/fiber-link-discourse-plugin/app/controllers/fiber_link/rpc_controller.rb
@@ -88,6 +88,14 @@ module ::FiberLink
         return
       end
 
+      # Webhook channel management is an operator surface: it configures
+      # outbound deliveries (and their secrets) for the whole forum, so it is
+      # restricted to staff rather than any logged-in creator.
+      if method.to_s.start_with?("notification.") && !current_user.staff?
+        render_error(request_id, :forbidden, -32001, "Unauthorized")
+        return
+      end
+
       sanitized_params = sanitize_params(method, params, request_id)
       return unless sanitized_params
 
@@ -291,7 +299,7 @@ module ::FiberLink
 
       begin
         uri = URI.parse(target)
-        unless %w[http https].include?(uri.scheme)
+        unless webhook_target_allowed?(uri)
           render_error(request_id, :bad_request, -32602, "Invalid target URL")
           return nil
         end
@@ -460,6 +468,34 @@ module ::FiberLink
     rescue StandardError => error
       Rails.logger.warn("Fiber Link invoice QR generation failed: #{error.message}")
       nil
+    end
+
+    # Webhook targets must be public HTTP(S) endpoints. Loopback, RFC1918,
+    # link-local, and unspecified hosts are rejected to keep the worker from
+    # being used as an SSRF proxy into the deployment's own network, and
+    # production requires TLS. Hostnames are checked textually and, when they
+    # are IP literals, by range; DNS names resolving to private ranges are the
+    # worker network policy's responsibility.
+    BLOCKED_WEBHOOK_HOSTS = %w[localhost localhost.localdomain ip6-localhost ip6-loopback].freeze
+
+    def webhook_target_allowed?(uri)
+      return false unless %w[http https].include?(uri.scheme)
+      return false if uri.scheme == "http" && Rails.env.production?
+
+      host = uri.host.to_s.downcase
+      return false if host.blank?
+      return false if BLOCKED_WEBHOOK_HOSTS.include?(host)
+      return false if host.end_with?(".local", ".internal", ".localhost")
+
+      begin
+        ip = IPAddr.new(host)
+        return false if ip.loopback? || ip.private? || ip.link_local? ||
+          ip == IPAddr.new("0.0.0.0") || ip == IPAddr.new("::")
+      rescue IPAddr::InvalidAddressError
+        # Not an IP literal; hostname checks above apply.
+      end
+
+      true
     end
 
     def render_error(request_id, status, code, message)

--- a/fiber-link-discourse-plugin/assets/javascripts/discourse/controllers/fiber-link-dashboard.js
+++ b/fiber-link-discourse-plugin/assets/javascripts/discourse/controllers/fiber-link-dashboard.js
@@ -1,8 +1,15 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 
 export default class FiberLinkDashboardController extends Controller {
+  @service currentUser;
+
   queryParams = ["withdrawalState", "settlementState"];
+
+  get showWebhookPanel() {
+    return Boolean(this.currentUser?.staff);
+  }
 
   withdrawalState = "ALL";
   settlementState = "ALL";

--- a/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
+++ b/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
     end
 
     it "forwards notification.channel.delete with a validated channel id" do
-      sign_in(user)
+      sign_in(Fabricate(:admin))
 
       stub_request(:post, "https://fiber-link.example/rpc").to_return(
         status: 200,
@@ -208,7 +208,7 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
     end
 
     it "rejects notification.channel.delete and .test with a non-uuid channel id" do
-      sign_in(user)
+      sign_in(Fabricate(:admin))
 
       ["notification.channel.delete", "notification.channel.test"].each do |method|
         post "/fiber-link/rpc",
@@ -224,6 +224,87 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
         body = JSON.parse(response.body)
         expect(body.dig("error", "code")).to eq(-32602)
       end
+    end
+
+    it "rejects notification channel management for non-staff users" do
+      sign_in(user)
+
+      post "/fiber-link/rpc",
+           params: {
+             jsonrpc: "2.0",
+             id: "notif-denied",
+             method: "notification.channel.list",
+             params: {},
+           },
+           as: :json
+
+      expect(response).to have_http_status(:forbidden)
+      body = JSON.parse(response.body)
+      expect(body.dig("error", "code")).to eq(-32001)
+    end
+
+    it "rejects webhook targets pointing at loopback or private networks" do
+      admin = Fabricate(:admin)
+      sign_in(admin)
+
+      ["http://localhost/hook", "https://127.0.0.1/hook", "https://10.0.0.5/hook",
+       "https://192.168.1.10/hook", "https://169.254.169.254/latest", "https://service.internal/hook"].each do |target|
+        post "/fiber-link/rpc",
+             params: {
+               jsonrpc: "2.0",
+               id: "notif-ssrf",
+               method: "notification.channel.create",
+               params: { name: "hook", kind: "WEBHOOK", target: target, events: ["TIP_SETTLED"] },
+             },
+             as: :json
+
+        expect(response).to have_http_status(:bad_request), "expected #{target} to be rejected"
+        body = JSON.parse(response.body)
+        expect(body.dig("error", "message")).to eq("Invalid target URL")
+      end
+    end
+
+    it "requires https webhook targets in production" do
+      admin = Fabricate(:admin)
+      sign_in(admin)
+      allow(Rails.env).to receive(:production?).and_return(true)
+
+      post "/fiber-link/rpc",
+           params: {
+             jsonrpc: "2.0",
+             id: "notif-http-prod",
+             method: "notification.channel.create",
+             params: { name: "hook", kind: "WEBHOOK", target: "http://example.com/hook", events: ["TIP_SETTLED"] },
+           },
+           as: :json
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "accepts a public https webhook target from staff" do
+      admin = Fabricate(:admin)
+      sign_in(admin)
+
+      stub_request(:post, "https://fiber-link.example/rpc").to_return(
+        status: 200,
+        body: { jsonrpc: "2.0", id: "notif-ok", result: { id: "ch-1" } }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      post "/fiber-link/rpc",
+           params: {
+             jsonrpc: "2.0",
+             id: "notif-ok",
+             method: "notification.channel.create",
+             params: { name: "hook", kind: "WEBHOOK", target: "https://hooks.example.com/fiber", events: ["TIP_SETTLED"] },
+           },
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(WebMock).to have_requested(:post, "https://fiber-link.example/rpc").with { |request|
+        body = JSON.parse(request.body)
+        body.dig("params", "target") == "https://hooks.example.com/fiber"
+      }
     end
 
     it "rejects dashboard.summary includeAdmin for non-admin users" do

--- a/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
+++ b/fiber-link-discourse-plugin/spec/requests/fiber_link/rpc_controller_spec.rb
@@ -248,7 +248,9 @@ RSpec.describe ::FiberLink::RpcController, type: :request do
       sign_in(admin)
 
       ["http://localhost/hook", "https://127.0.0.1/hook", "https://10.0.0.5/hook",
-       "https://192.168.1.10/hook", "https://169.254.169.254/latest", "https://service.internal/hook"].each do |target|
+       "https://192.168.1.10/hook", "https://169.254.169.254/latest", "https://service.internal/hook",
+       "https://127.1/hook", "https://0x7f000001/hook", "https://2130706433/hook",
+       "https://127.0.0.1./hook", "https://localhost./hook"].each do |target|
         post "/fiber-link/rpc",
              params: {
                jsonrpc: "2.0",


### PR DESCRIPTION
## Summary

Implements the proxy-side scope of **#469 (P0)** — webhook notification channel management hardening:

- [x] **Staff-only**: `notification.*` RPC methods now require a staff user. Previously any logged-in creator could create webhook channels (and their signing secrets) for the whole forum. The creator dashboard renders the webhook panel only for staff, so non-staff never see a dead surface.
- [x] **SSRF-safe target validation** (was: only an http/https scheme check): loopback, RFC1918 private ranges, link-local (`169.254.169.254` metadata endpoints included), unspecified addresses, and `.local`/`.internal`/`.localhost` hostnames are rejected; **production requires HTTPS**. Checks are textual plus IP-literal range checks — DNS names resolving into private ranges remain the worker network policy's responsibility (documented in the code).
- [x] **Rate limiting**: `notification.channel.create` is classified as a mutating method (10/60s) instead of the read limit.
- [x] **Specs**: non-staff 403, each blocked target class, the production HTTPS requirement, and the staff happy path.

## Scope

- [x] Discourse plugin only: `rpc_controller.rb`, dashboard controller/template (staff-gated panel), request spec.

## Verification

- [x] `ruby -c` clean on controller and spec; `i18n-parity` passes. Plugin request specs run in `plugin-smoke` CI.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (proxy-side scope of #469; the lifecycle actions — delete/test — and delivery-log diagnostics ship in #524)
- [x] Required discussions or follow-ups are documented (see Notes)

## Notes

- Touches the same `MUTATING_METHODS` line as #524 (which adds `delete`/`test` to it) — whichever lands second gets a one-line rebase; I'll handle it. Label: `enhancement`, `security`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_