### PR TITLE
sec(admin): durable audit trail for every admin mutation (#468)

### DIFF
--- a/fiber-link-service/apps/admin/src/server/api/context.ts
+++ b/fiber-link-service/apps/admin/src/server/api/context.ts
@@ -49,7 +49,12 @@ export function createTrpcContext(opts: CreateNextContextOptions): TrpcContext {
   if (proxySharedSecret) {
     const proxyToken = readHeader(opts.req, "x-admin-proxy-token")?.trim() ?? "";
     if (!timingSafeEquals(proxyToken, proxySharedSecret)) {
-      return { role: undefined, adminUserId: undefined, services: createAdminServices(env) };
+      return {
+        role: undefined,
+        adminUserId: undefined,
+        requestId: crypto.randomUUID(),
+        services: createAdminServices(env),
+      };
     }
   } else if (env.NODE_ENV === "production" && !warnedMissingProxySecret) {
     warnedMissingProxySecret = true;
@@ -70,6 +75,7 @@ export function createTrpcContext(opts: CreateNextContextOptions): TrpcContext {
   return {
     role,
     adminUserId,
+    requestId: crypto.randomUUID(),
     services: createAdminServices(env),
   };
 }

--- a/fiber-link-service/apps/admin/src/server/api/routers.test.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers.test.ts
@@ -124,3 +124,58 @@ describe("admin tRPC routers", () => {
     ).rejects.toBeInstanceOf(TRPCError);
   });
 });
+
+describe("admin mutation audit trail (#468)", () => {
+  it("writes an audit event for withdrawal policy upserts with the resolved actor", async () => {
+    const services = createFixtureAdminServices(fixture());
+    const ctx: TrpcContext = { role: "SUPER_ADMIN", adminUserId: "ops-user", requestId: "req-123", services };
+    const caller = createCaller(ctx);
+
+    await caller.withdrawalPolicy.upsert({
+      appId: "app-alpha",
+      allowedAssets: ["CKB"],
+      maxPerRequest: "100",
+      perUserDailyMax: "500",
+      perAppDailyMax: "5000",
+      cooldownSeconds: 60,
+    });
+
+    const events = services.__listAuditEventsForTests?.() ?? [];
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      action: "withdrawal_policy.upsert",
+      targetType: "withdrawal_policy",
+      targetId: "app-alpha",
+      actorId: "ops-user",
+      actorRole: "SUPER_ADMIN",
+      requestId: "req-123",
+    });
+    expect(events[0].after).toMatchObject({ appId: "app-alpha", cooldownSeconds: 60 });
+  });
+
+  it("writes audit events for ops mutations", async () => {
+    const services = createFixtureAdminServices(fixture());
+    const ctx: TrpcContext = { role: "SUPER_ADMIN", adminUserId: "ops-user", requestId: "req-ops", services };
+    const caller = createCaller(ctx);
+
+    await caller.ops.createRateLimitChangeSet({
+      enabled: true,
+      windowMs: "60000",
+      maxRequests: "100",
+    });
+
+    const actions = (services.__listAuditEventsForTests?.() ?? []).map((e) => e.action);
+    expect(actions).toContain("rate_limit.change_set.create");
+  });
+
+  it("does not audit denied mutations", async () => {
+    const services = createFixtureAdminServices(fixture());
+    const ctx: TrpcContext = { role: undefined, adminUserId: undefined, services };
+    const caller = createCaller(ctx);
+
+    await expect(caller.ops.createRateLimitChangeSet({ enabled: true, windowMs: "60000", maxRequests: "100" })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(services.__listAuditEventsForTests?.() ?? []).toHaveLength(0);
+  });
+});

--- a/fiber-link-service/apps/admin/src/server/api/routers.test.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers.test.ts
@@ -173,7 +173,9 @@ describe("admin mutation audit trail (#468)", () => {
     const ctx: TrpcContext = { role: undefined, adminUserId: undefined, services };
     const caller = createCaller(ctx);
 
-    await expect(caller.ops.createRateLimitChangeSet({ enabled: true, windowMs: "60000", maxRequests: "100" })).rejects.toMatchObject({
+    await expect(
+      caller.ops.createRateLimitChangeSet({ enabled: true, windowMs: "60000", maxRequests: "100" }),
+    ).rejects.toMatchObject({
       code: "FORBIDDEN",
     });
     expect(services.__listAuditEventsForTests?.() ?? []).toHaveLength(0);

--- a/fiber-link-service/apps/admin/src/server/api/routers/ops.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/ops.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import type { DashboardRateLimitDraft } from "../../dashboard-rate-limit";
-import { router, superAdminProcedure } from "../trpc";
+import { recordAuditEvent, router, superAdminProcedure } from "../trpc";
 
 function parseRateLimitDraft(input: unknown): DashboardRateLimitDraft {
   if (typeof input !== "object" || input === null) {
@@ -41,7 +41,14 @@ export const opsRouter = router({
 
   createRateLimitChangeSet: superAdminProcedure.input(parseRateLimitDraft).mutation(async ({ ctx, input }) => {
     try {
-      return await ctx.services.createRateLimitChangeSet(input);
+      const changeSet = await ctx.services.createRateLimitChangeSet(input);
+      await recordAuditEvent(ctx, ctx.scope, {
+        action: "rate_limit.change_set.create",
+        targetType: "rate_limit_config",
+        targetId: "global",
+        after: input as Record<string, unknown>,
+      });
+      return changeSet;
     } catch (error) {
       throw new TRPCError({
         code: "BAD_REQUEST",
@@ -56,7 +63,13 @@ export const opsRouter = router({
 
   captureBackup: superAdminProcedure.mutation(async ({ ctx }) => {
     try {
-      return await ctx.services.captureBackup();
+      const result = await ctx.services.captureBackup();
+      await recordAuditEvent(ctx, ctx.scope, {
+        action: "backup.capture",
+        targetType: "backup_bundle",
+        targetId: (result as { backupId?: string }).backupId ?? "unknown",
+      });
+      return result;
     } catch (error) {
       throw toServiceError(error, "Failed to capture backup");
     }
@@ -64,7 +77,13 @@ export const opsRouter = router({
 
   restorePlan: superAdminProcedure.input(parseBackupId).mutation(async ({ ctx, input }) => {
     try {
-      return await ctx.services.buildBackupRestorePlan(input.backupId);
+      const plan = await ctx.services.buildBackupRestorePlan(input.backupId);
+      await recordAuditEvent(ctx, ctx.scope, {
+        action: "backup.restore_plan.build",
+        targetType: "backup_bundle",
+        targetId: input.backupId,
+      });
+      return plan;
     } catch (error) {
       throw toServiceError(error, "Failed to generate restore plan");
     }

--- a/fiber-link-service/apps/admin/src/server/api/routers/withdrawal-policy.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/withdrawal-policy.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { type WithdrawalPolicyInput, parseWithdrawalPolicyInput } from "../../../withdrawal-policy-input";
 import { PolicyScopeError, UnknownAppError } from "../../services/errors";
-import { adminProcedure, router } from "../trpc";
+import { adminProcedure, recordAuditEvent, router } from "../trpc";
 
 function parsePolicyInput(input: unknown): WithdrawalPolicyInput {
   try {
@@ -21,7 +21,14 @@ export const withdrawalPolicyRouter = router({
 
   upsert: adminProcedure.input(parsePolicyInput).mutation(async ({ ctx, input }) => {
     try {
-      return await ctx.services.upsertPolicy(ctx.scope, input);
+      const policy = await ctx.services.upsertPolicy(ctx.scope, input);
+      await recordAuditEvent(ctx, ctx.scope, {
+        action: "withdrawal_policy.upsert",
+        targetType: "withdrawal_policy",
+        targetId: input.appId,
+        after: input as unknown as Record<string, unknown>,
+      });
+      return policy;
     } catch (error) {
       if (error instanceof PolicyScopeError) {
         throw new TRPCError({ code: "FORBIDDEN", message: error.message });

--- a/fiber-link-service/apps/admin/src/server/api/trpc.ts
+++ b/fiber-link-service/apps/admin/src/server/api/trpc.ts
@@ -8,6 +8,8 @@ export type TrpcContext = {
   // (or the development env fallbacks). Undefined when no role was supplied.
   role?: UserRole;
   adminUserId?: string;
+  /** Correlates every audit event written during one tRPC request. */
+  requestId?: string;
   services: AdminServices;
 };
 
@@ -40,3 +42,33 @@ export const superAdminProcedure = t.procedure.use(({ ctx, next }) => {
   const scope: AdminScope = { role, adminUserId: ctx.adminUserId };
   return next({ ctx: { scope } });
 });
+
+/**
+ * Record a durable audit event for an admin mutation. Uses the resolved
+ * scope so the actor/role can never disagree with the authorization that
+ * admitted the mutation. Never throws (the services impl logs failures).
+ */
+export async function recordAuditEvent(
+  ctx: TrpcContext,
+  scope: AdminScope,
+  event: {
+    action: string;
+    targetType: string;
+    targetId: string;
+    reason?: string | null;
+    before?: Record<string, unknown> | null;
+    after?: Record<string, unknown> | null;
+  },
+): Promise<void> {
+  await ctx.services.appendAuditEvent({
+    actorId: scope.adminUserId ?? "unknown",
+    actorRole: scope.role,
+    action: event.action,
+    targetType: event.targetType,
+    targetId: event.targetId,
+    requestId: ctx.requestId ?? "unknown",
+    reason: event.reason ?? null,
+    before: event.before ?? null,
+    after: event.after ?? null,
+  });
+}

--- a/fiber-link-service/apps/admin/src/server/services/db-services.ts
+++ b/fiber-link-service/apps/admin/src/server/services/db-services.ts
@@ -1,4 +1,11 @@
-import { type DbClient, type WithdrawalState, createDbClient, withdrawalPolicies, withdrawals } from "@fiber-link/db";
+import {
+  type DbClient,
+  type WithdrawalState,
+  createDbAdminAuditRepo,
+  createDbClient,
+  withdrawalPolicies,
+  withdrawals,
+} from "@fiber-link/db";
 import { inArray, sql } from "drizzle-orm";
 import {
   type DashboardApp,
@@ -92,7 +99,16 @@ async function resolveScopedAppIds(db: DbClient, scope: AdminScope): Promise<"AL
 }
 
 export function createDbAdminServices(db: DbClient = createDbClient()): AdminServices {
+  const auditRepo = createDbAdminAuditRepo(db);
   return {
+    async appendAuditEvent(event) {
+      try {
+        await auditRepo.append(event);
+      } catch (error) {
+        console.error("[admin] failed to append audit event", { action: event.action, error });
+      }
+    },
+
     async listApps(scope): Promise<DashboardApp[]> {
       const scoped = await resolveScopedAppIds(db, scope);
       if (scoped !== "ALL" && scoped.length === 0) {

--- a/fiber-link-service/apps/admin/src/server/services/fixture-services.ts
+++ b/fiber-link-service/apps/admin/src/server/services/fixture-services.ts
@@ -13,6 +13,7 @@ import { buildDashboardBackupRestorePlan } from "../dashboard-backups";
 import { buildDashboardRateLimitChangeSet, parseDashboardRateLimitInput } from "../dashboard-rate-limit";
 import { PolicyScopeError, UnknownAppError } from "./errors";
 import {
+  type AdminAuditEventInput,
   type AdminScope,
   type AdminServices,
   type AdminWithdrawal,
@@ -80,6 +81,8 @@ function buildDefaultRateLimitConfig(): DashboardRateLimitConfig {
 }
 
 export function createFixtureAdminServices(fixture: DashboardFixture): AdminServices {
+  const auditEvents: AdminAuditEventInput[] = [];
+
   const snapshot = {
     apps: fixture.apps.map((app) => ({ ...app })),
     withdrawals: fixture.withdrawals.map(toAdminWithdrawal),
@@ -96,6 +99,13 @@ export function createFixtureAdminServices(fixture: DashboardFixture): AdminServ
   }
 
   return {
+    async appendAuditEvent(event) {
+      auditEvents.push({ ...event });
+    },
+    __listAuditEventsForTests() {
+      return auditEvents.map((e) => ({ ...e }));
+    },
+
     async listApps(scope) {
       return snapshot.apps
         .filter((app) => inScope(scope, app.appId))

--- a/fiber-link-service/apps/admin/src/server/services/types.ts
+++ b/fiber-link-service/apps/admin/src/server/services/types.ts
@@ -16,6 +16,18 @@ import type { DashboardRateLimitChangeSet, DashboardRateLimitDraft } from "../da
  * scoped by this so COMMUNITY_ADMIN access can be narrowed to assigned apps in
  * one place (the services seam) rather than being re-derived in each router.
  */
+export type AdminAuditEventInput = {
+  actorId: string;
+  actorRole: "SUPER_ADMIN" | "COMMUNITY_ADMIN";
+  action: string;
+  targetType: string;
+  targetId: string;
+  requestId: string;
+  reason?: string | null;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+};
+
 export type AdminScope = {
   role: UserRole;
   adminUserId?: string;
@@ -62,6 +74,16 @@ export const WITHDRAWAL_LIST_LIMIT = 200;
  * acceptance harness end to end.
  */
 export interface AdminServices {
+  /**
+   * Append a durable audit event for an admin mutation. Implementations must
+   * never throw into the caller: auditing is recorded best-effort with an
+   * error log, so a broken audit sink cannot take admin operations down —
+   * but every mutation path MUST call it.
+   */
+  appendAuditEvent(event: AdminAuditEventInput): Promise<void>;
+  /** Test hook exposed by the fixture implementation only. */
+  __listAuditEventsForTests?: () => AdminAuditEventInput[];
+
   listApps(scope: AdminScope): Promise<DashboardApp[]>;
   /** Newest first, capped at {@link WITHDRAWAL_LIST_LIMIT} rows. */
   listWithdrawals(scope: AdminScope, filters?: AdminWithdrawalFilters): Promise<AdminWithdrawal[]>;

--- a/fiber-link-service/packages/db/src/admin-audit-repo.ts
+++ b/fiber-link-service/packages/db/src/admin-audit-repo.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import type { DbClient } from "./client";
 import { type UserRole, adminAuditEvents } from "./schema";
 
@@ -72,10 +72,10 @@ export function createDbAdminAuditRepo(db: DbClient): AdminAuditRepo {
       const rows = await db
         .select()
         .from(adminAuditEvents)
-        .where(eq(adminAuditEvents.targetType, targetType))
+        .where(and(eq(adminAuditEvents.targetType, targetType), eq(adminAuditEvents.targetId, targetId)))
         .orderBy(desc(adminAuditEvents.createdAt), desc(adminAuditEvents.id))
         .limit(limit);
-      return rows.filter((r) => r.targetId === targetId).map(toRecord);
+      return rows.map(toRecord);
     },
   };
 }

--- a/fiber-link-service/packages/db/src/admin-audit-repo.ts
+++ b/fiber-link-service/packages/db/src/admin-audit-repo.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from "node:crypto";
+import { desc, eq } from "drizzle-orm";
+import type { DbClient } from "./client";
+import { type UserRole, adminAuditEvents } from "./schema";
+
+export type AppendAdminAuditEventInput = {
+  actorId: string;
+  actorRole: UserRole;
+  action: string;
+  targetType: string;
+  targetId: string;
+  requestId: string;
+  reason?: string | null;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+};
+
+export type AdminAuditEventRecord = AppendAdminAuditEventInput & {
+  id: string;
+  reason: string | null;
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  createdAt: Date;
+};
+
+export type AdminAuditRepo = {
+  append(input: AppendAdminAuditEventInput): Promise<AdminAuditEventRecord>;
+  listRecentByTarget(targetType: string, targetId: string, limit?: number): Promise<AdminAuditEventRecord[]>;
+  __resetForTests?: () => void;
+  __listForTests?: () => AdminAuditEventRecord[];
+};
+
+type Row = typeof adminAuditEvents.$inferSelect;
+
+function toRecord(row: Row): AdminAuditEventRecord {
+  return {
+    id: row.id,
+    actorId: row.actorId,
+    actorRole: row.actorRole,
+    action: row.action,
+    targetType: row.targetType,
+    targetId: row.targetId,
+    requestId: row.requestId,
+    reason: row.reason ?? null,
+    before: row.before ?? null,
+    after: row.after ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+export function createDbAdminAuditRepo(db: DbClient): AdminAuditRepo {
+  return {
+    async append(input) {
+      const [row] = await db
+        .insert(adminAuditEvents)
+        .values({
+          actorId: input.actorId,
+          actorRole: input.actorRole,
+          action: input.action,
+          targetType: input.targetType,
+          targetId: input.targetId,
+          requestId: input.requestId,
+          reason: input.reason ?? null,
+          before: input.before ?? null,
+          after: input.after ?? null,
+        })
+        .returning();
+      return toRecord(row);
+    },
+
+    async listRecentByTarget(targetType, targetId, limit = 50) {
+      const rows = await db
+        .select()
+        .from(adminAuditEvents)
+        .where(eq(adminAuditEvents.targetType, targetType))
+        .orderBy(desc(adminAuditEvents.createdAt), desc(adminAuditEvents.id))
+        .limit(limit);
+      return rows.filter((r) => r.targetId === targetId).map(toRecord);
+    },
+  };
+}
+
+export function createInMemoryAdminAuditRepo(): AdminAuditRepo {
+  let records: AdminAuditEventRecord[] = [];
+  return {
+    async append(input) {
+      const record: AdminAuditEventRecord = {
+        id: randomUUID(),
+        actorId: input.actorId,
+        actorRole: input.actorRole,
+        action: input.action,
+        targetType: input.targetType,
+        targetId: input.targetId,
+        requestId: input.requestId,
+        reason: input.reason ?? null,
+        before: input.before ?? null,
+        after: input.after ?? null,
+        createdAt: new Date(),
+      };
+      records.push(record);
+      return { ...record };
+    },
+    async listRecentByTarget(targetType, targetId, limit = 50) {
+      return records
+        .filter((r) => r.targetType === targetType && r.targetId === targetId)
+        .slice()
+        .reverse()
+        .slice(0, limit);
+    },
+    __resetForTests() {
+      records = [];
+    },
+    __listForTests() {
+      return records.map((r) => ({ ...r }));
+    },
+  };
+}

--- a/fiber-link-service/packages/db/src/index.ts
+++ b/fiber-link-service/packages/db/src/index.ts
@@ -11,3 +11,4 @@ export * from "./amount";
 export * from "./retry";
 export * from "./analytics-repo";
 export * from "./worker-state-repo";
+export * from "./admin-audit-repo";


### PR DESCRIPTION
## Summary

Implements the audit-logging scope of **#468 (P0)**. The `admin_audit_events` table existed but **nothing wrote to it** — withdrawal-policy changes, rate-limit change sets, and backup capture/restore-plan actions left no durable trace.

- [x] **DB**: `admin-audit-repo` (db + in-memory) over the existing table, with `append` and `listRecentByTarget`.
- [x] **Services**: `appendAuditEvent` joins the `AdminServices` contract; the db implementation records via the repo and logs (never throws) on sink failure — a broken audit store cannot take admin operations down — while the fixture implementation records in memory with a test hook.
- [x] **tRPC**: per-request `requestId` in the context, and a `recordAuditEvent` helper that takes the **resolved authorization scope**, so the recorded actor/role can never disagree with what admitted the mutation.
- [x] **Routers**: `withdrawal_policy.upsert`, `rate_limit.change_set.create`, `backup.capture`, and `backup.restore_plan.build` all write audit events after success (action, target type/id, actor, role, request id, input snapshot where meaningful).
- [x] **Tests**: audit event content for policy upsert (actor/role/requestId/after snapshot), ops coverage, and the denial path writing nothing.

## Scope

- [x] `packages/db` (new repo + export), `apps/admin` (services contract + both impls, trpc context/helper, two routers, router tests). No schema changes — the table shipped previously.

## Verification

- [x] Admin suite **21 files green** (incl. 3 new audit tests); db suite green; `tsc --noEmit` clean; `biome ci` clean.

## PR Readiness Checklist

- [x] PR description includes key commit changes
- [x] Issue/Task linkage is provided (audit scope of #468)
- [x] Required discussions or follow-ups are documented (see Notes)

## Notes

- The auth-hardening half of #468 largely shipped earlier: the env-role fallback is already `NODE_ENV`-gated off in production and `ADMIN_PROXY_SHARED_SECRET` fails closed (PR B). Wiring a real IdP (OIDC/SSO) is deployment-specific configuration and stays tracked in #468. Label: `enhancement`, `security`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_