### PR TITLE
Ops: settlement investigation timeline, retry-now, and ops notes in admin (#470)

### DIFF
--- a/fiber-link-service/apps/admin/src/components/settlement-state-badge.tsx
+++ b/fiber-link-service/apps/admin/src/components/settlement-state-badge.tsx
@@ -1,0 +1,12 @@
+import type { InvoiceState } from "@fiber-link/db";
+import { Badge, type BadgeProps } from "./ui/badge";
+
+const STATE_VARIANT: Record<InvoiceState, BadgeProps["variant"]> = {
+  UNPAID: "warning",
+  SETTLED: "success",
+  FAILED: "destructive",
+};
+
+export function SettlementStateBadge({ state }: { state: InvoiceState }) {
+  return <Badge variant={STATE_VARIANT[state] ?? "outline"}>{state}</Badge>;
+}

--- a/fiber-link-service/apps/admin/src/pages/settlements/[id].tsx
+++ b/fiber-link-service/apps/admin/src/pages/settlements/[id].tsx
@@ -1,20 +1,64 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { type ReactNode, useState } from "react";
+import { toast } from "sonner";
 import { PageHeader, QueryBoundary, RoleGate } from "../../components/page";
+import { SettlementStateBadge } from "../../components/settlement-state-badge";
+import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { Label } from "../../components/ui/label";
+import { formatDateTime, shorten } from "../../lib/format";
 import { trpc } from "../../utils/trpc";
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5 text-sm">{children}</dd>
+    </div>
+  );
+}
 
 export default function SettlementDetailPage() {
   const router = useRouter();
-  const id = typeof router.query.id === "string" ? router.query.id : "";
+  const invoice = typeof router.query.id === "string" ? router.query.id : "";
   const session = trpc.session.me.useQuery();
   const isSuperAdmin = session.data?.role === "SUPER_ADMIN";
+  const utils = trpc.useUtils();
+  const [note, setNote] = useState("");
+
+  const timeline = trpc.settlements.timeline.useQuery(
+    { invoice },
+    { enabled: isSuperAdmin && router.isReady && Boolean(invoice) },
+  );
+
+  const retryNow = trpc.settlements.retryNow.useMutation({
+    onSuccess: async () => {
+      toast.success("Retry state cleared; the worker re-checks this invoice on its next poll");
+      await utils.settlements.timeline.invalidate({ invoice });
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const addOpsNote = trpc.settlements.addOpsNote.useMutation({
+    onSuccess: async () => {
+      toast.success("Ops note recorded");
+      setNote("");
+      await utils.settlements.timeline.invalidate({ invoice });
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const intent = timeline.data?.intent;
+  const events = timeline.data?.events ?? [];
+  const adminActions = timeline.data?.adminActions ?? [];
 
   return (
     <div>
       <PageHeader
-        title={`Settlement ${id}`}
-        description="Tip-intent timeline and recovery hint."
+        title={`Settlement ${shorten(invoice, 12, 8)}`}
+        description="Tip-intent lifecycle timeline and recovery actions."
         actions={
           <Link className="text-sm text-primary hover:underline" href="/settlements">
             ← Settlements
@@ -23,17 +67,162 @@ export default function SettlementDetailPage() {
       />
       <QueryBoundary isLoading={session.isLoading} error={session.error}>
         <RoleGate allowed={isSuperAdmin}>
-          <Card>
-            <CardHeader>
-              <CardTitle>Lifecycle timeline</CardTitle>
-              <CardDescription>
-                Rendered from <code>tip_intent_events</code> in milestone 2.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">No events to display yet.</p>
-            </CardContent>
-          </Card>
+          <QueryBoundary isLoading={timeline.isLoading} error={timeline.error}>
+            {intent ? (
+              <div className="space-y-6">
+                <Card data-testid="settlement-intent-summary">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-3">
+                      <span className="font-mono text-sm" title={intent.invoice}>
+                        {shorten(intent.invoice, 16, 10)}
+                      </span>
+                      <SettlementStateBadge state={intent.invoiceState} />
+                    </CardTitle>
+                    <CardDescription>
+                      {intent.amount} {intent.asset} tipped on post {intent.postId} in{" "}
+                      <Link className="text-primary hover:underline" href={`/apps/${intent.appId}`}>
+                        {intent.appId}
+                      </Link>
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <dl className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                      <Field label="From user">
+                        <span className="font-mono text-xs">{intent.fromUserId || "—"}</span>
+                      </Field>
+                      <Field label="To user">
+                        <span className="font-mono text-xs">{intent.toUserId || "—"}</span>
+                      </Field>
+                      <Field label="Created">{formatDateTime(intent.createdAt)}</Field>
+                      <Field label="Settled">{formatDateTime(intent.settledAt)}</Field>
+                      <Field label="Retry count">{intent.settlementRetryCount}</Field>
+                      <Field label="Next retry">{formatDateTime(intent.settlementNextRetryAt)}</Field>
+                      <Field label="Last checked">{formatDateTime(intent.settlementLastCheckedAt)}</Field>
+                      <Field label="Failure reason">
+                        {intent.settlementFailureReason ? (
+                          <span className="font-medium text-destructive">{intent.settlementFailureReason}</span>
+                        ) : (
+                          "—"
+                        )}
+                      </Field>
+                    </dl>
+                    {intent.settlementLastError ? (
+                      <p className="mt-4 rounded-md bg-destructive/10 p-3 font-mono text-xs text-destructive">
+                        {intent.settlementLastError}
+                      </p>
+                    ) : null}
+                    <div className="mt-4 flex flex-wrap items-end gap-4">
+                      <Button
+                        data-testid="settlement-retry-now"
+                        disabled={intent.invoiceState !== "UNPAID" || retryNow.isPending}
+                        onClick={() => retryNow.mutate({ invoice })}
+                      >
+                        Retry now
+                      </Button>
+                      {intent.invoiceState !== "UNPAID" ? (
+                        <p className="text-xs text-muted-foreground">
+                          Retry is only available while the invoice is UNPAID; {intent.invoiceState} is terminal.
+                        </p>
+                      ) : null}
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Card data-testid="settlement-timeline">
+                  <CardHeader>
+                    <CardTitle>Lifecycle timeline</CardTitle>
+                    <CardDescription>
+                      Creation, status checks, retries, failures, settlement, and credit application from{" "}
+                      <code>tip_intent_events</code>.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    {events.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">No lifecycle events recorded for this invoice.</p>
+                    ) : (
+                      <ol className="space-y-3">
+                        {events.map((event) => (
+                          <li key={event.id} className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm">
+                            <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                              {formatDateTime(event.createdAt)}
+                            </span>
+                            <span className="font-medium">{event.type}</span>
+                            <span className="text-xs text-muted-foreground">{event.source}</span>
+                            {event.previousInvoiceState || event.nextInvoiceState ? (
+                              <span className="text-xs text-muted-foreground">
+                                {event.previousInvoiceState ?? "?"} → {event.nextInvoiceState ?? "?"}
+                              </span>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ol>
+                    )}
+                  </CardContent>
+                </Card>
+
+                <Card data-testid="settlement-admin-actions">
+                  <CardHeader>
+                    <CardTitle>Investigation log</CardTitle>
+                    <CardDescription>Audited admin actions (retries and ops notes) for this invoice.</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <form
+                      className="mb-4 flex flex-wrap items-end gap-2"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        if (note.trim()) {
+                          addOpsNote.mutate({ invoice, note: note.trim() });
+                        }
+                      }}
+                    >
+                      <div className="min-w-64 flex-1">
+                        <Label htmlFor="ops-note" className="mb-1 block text-xs text-muted-foreground">
+                          Ops note
+                        </Label>
+                        <Input
+                          id="ops-note"
+                          data-testid="settlement-ops-note-input"
+                          value={note}
+                          maxLength={2000}
+                          placeholder="e.g. Confirmed with the payer; awaiting channel rebalance."
+                          onChange={(event) => setNote(event.target.value)}
+                        />
+                      </div>
+                      <Button
+                        type="submit"
+                        variant="outline"
+                        data-testid="settlement-ops-note-submit"
+                        disabled={!note.trim() || addOpsNote.isPending}
+                      >
+                        Add note
+                      </Button>
+                    </form>
+                    {adminActions.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">No admin actions recorded yet.</p>
+                    ) : (
+                      <ol className="space-y-3">
+                        {adminActions.map((action, index) => (
+                          <li
+                            key={`${action.createdAt}-${index}`}
+                            className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm"
+                          >
+                            <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                              {formatDateTime(action.createdAt)}
+                            </span>
+                            <span className="font-medium">{action.action}</span>
+                            <span className="text-xs text-muted-foreground">
+                              {action.actorId} ({action.actorRole})
+                            </span>
+                            {action.reason ? <span className="basis-full text-sm">{action.reason}</span> : null}
+                          </li>
+                        ))}
+                      </ol>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            ) : null}
+          </QueryBoundary>
         </RoleGate>
       </QueryBoundary>
     </div>

--- a/fiber-link-service/apps/admin/src/pages/settlements/index.tsx
+++ b/fiber-link-service/apps/admin/src/pages/settlements/index.tsx
@@ -1,43 +1,139 @@
+import type { InvoiceState } from "@fiber-link/db";
+import Link from "next/link";
+import { useRouter } from "next/router";
 import { PageHeader, QueryBoundary, RoleGate, StatCard } from "../../components/page";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
+import { SettlementStateBadge } from "../../components/settlement-state-badge";
+import { Card, CardContent } from "../../components/ui/card";
+import { Label } from "../../components/ui/label";
+import { Select } from "../../components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { formatDateTime, shorten } from "../../lib/format";
 import { trpc } from "../../utils/trpc";
 
+const INVOICE_STATES: InvoiceState[] = ["UNPAID", "SETTLED", "FAILED"];
+
+function queryValue(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+  return value ?? "";
+}
+
 export default function SettlementsPage() {
+  const router = useRouter();
   const session = trpc.session.me.useQuery();
   const isSuperAdmin = session.data?.role === "SUPER_ADMIN";
   const monitoring = trpc.ops.monitoring.useQuery(undefined, { enabled: isSuperAdmin });
 
+  const rawState = queryValue(router.query.state);
+  const stateFilter = INVOICE_STATES.includes(rawState as InvoiceState) ? (rawState as InvoiceState) : undefined;
+
+  const settlements = trpc.settlements.list.useQuery(stateFilter ? { state: stateFilter } : {}, {
+    enabled: isSuperAdmin && router.isReady,
+  });
+
+  function setStateFilter(value: string) {
+    const next = { ...router.query };
+    if (value) {
+      next.state = value;
+    } else {
+      delete next.state;
+    }
+    router.replace({ pathname: router.pathname, query: next }, undefined, { shallow: true });
+  }
+
   return (
     <div>
-      <PageHeader title="Settlements" description="Settlement pipeline health and backlog." />
+      <PageHeader
+        title="Settlements"
+        description="Settlement pipeline health, backlog, and per-invoice investigation timelines."
+      />
       <QueryBoundary isLoading={session.isLoading} error={session.error}>
         <RoleGate allowed={isSuperAdmin}>
-          <QueryBoundary isLoading={monitoring.isLoading} error={monitoring.error}>
-            <section className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-3">
-              <StatCard
-                label="Unpaid backlog"
-                value={monitoring.data?.unpaidBacklog ?? "—"}
-                tone={(monitoring.data?.unpaidBacklog ?? 0) > 0 ? "warning" : "default"}
-              />
-              <StatCard
-                label="Retry pending"
-                value={monitoring.data?.retryPendingCount ?? "—"}
-                tone={(monitoring.data?.retryPendingCount ?? 0) > 0 ? "warning" : "default"}
-              />
-              <StatCard label="Pipeline status" value={monitoring.data?.status ?? "—"} />
-            </section>
+          <section className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-3">
+            <StatCard
+              label="Unpaid backlog"
+              value={monitoring.data?.unpaidBacklog ?? "—"}
+              tone={(monitoring.data?.unpaidBacklog ?? 0) > 0 ? "warning" : "default"}
+            />
+            <StatCard
+              label="Retry pending"
+              value={monitoring.data?.retryPendingCount ?? "—"}
+              tone={(monitoring.data?.retryPendingCount ?? 0) > 0 ? "warning" : "default"}
+            />
+            <StatCard label="Pipeline status" value={monitoring.data?.status ?? "—"} />
+          </section>
+
+          <div className="mb-4 w-48">
+            <Label htmlFor="settlement-state-filter" className="mb-1 block text-xs text-muted-foreground">
+              State
+            </Label>
+            <Select
+              id="settlement-state-filter"
+              data-testid="settlement-state-filter"
+              value={stateFilter ?? ""}
+              onChange={(event) => setStateFilter(event.target.value)}
+            >
+              <option value="">All states</option>
+              {INVOICE_STATES.map((state) => (
+                <option key={state} value={state}>
+                  {state}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          <QueryBoundary
+            isLoading={settlements.isLoading}
+            error={settlements.error}
+            isEmpty={settlements.data?.length === 0}
+            emptyMessage="No settlement intents match the current filters."
+          >
             <Card>
-              <CardHeader>
-                <CardTitle>Settlement intents</CardTitle>
-                <CardDescription>
-                  The detailed intent list and the per-intent <code>tip_intent_events</code> timeline are added in
-                  milestone 2 (read-only operational surfaces).
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  Backlog counts above are derived from the monitoring summary.
-                </p>
+              <CardContent className="p-0">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Invoice</TableHead>
+                      <TableHead>App</TableHead>
+                      <TableHead>Asset</TableHead>
+                      <TableHead>Amount</TableHead>
+                      <TableHead>State</TableHead>
+                      <TableHead>Retries</TableHead>
+                      <TableHead>Failure reason</TableHead>
+                      <TableHead>Created</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(settlements.data ?? []).map((row) => (
+                      <TableRow key={row.id} data-testid={`settlement-row-${row.id}`}>
+                        <TableCell className="font-mono text-xs" title={row.invoice}>
+                          <Link
+                            className="text-primary hover:underline"
+                            href={`/settlements/${encodeURIComponent(row.invoice)}`}
+                          >
+                            {shorten(row.invoice, 12, 8)}
+                          </Link>
+                        </TableCell>
+                        <TableCell>
+                          <Link className="text-primary hover:underline" href={`/apps/${row.appId}`}>
+                            {row.appId}
+                          </Link>
+                        </TableCell>
+                        <TableCell>{row.asset}</TableCell>
+                        <TableCell className="font-mono">{row.amount}</TableCell>
+                        <TableCell>
+                          <SettlementStateBadge state={row.invoiceState} />
+                        </TableCell>
+                        <TableCell>{row.settlementRetryCount}</TableCell>
+                        <TableCell className="text-xs text-destructive">{row.settlementFailureReason ?? "—"}</TableCell>
+                        <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                          {formatDateTime(row.createdAt)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
               </CardContent>
             </Card>
           </QueryBoundary>

--- a/fiber-link-service/apps/admin/src/server/api/root.ts
+++ b/fiber-link-service/apps/admin/src/server/api/root.ts
@@ -1,6 +1,7 @@
 import { appsRouter } from "./routers/apps";
 import { opsRouter } from "./routers/ops";
 import { sessionRouter } from "./routers/session";
+import { settlementsRouter } from "./routers/settlements";
 import { withdrawalPolicyRouter } from "./routers/withdrawal-policy";
 import { withdrawalsRouter } from "./routers/withdrawals";
 import { router } from "./trpc";
@@ -10,6 +11,7 @@ export const appRouter = router({
   apps: appsRouter,
   withdrawals: withdrawalsRouter,
   withdrawalPolicy: withdrawalPolicyRouter,
+  settlements: settlementsRouter,
   ops: opsRouter,
 });
 

--- a/fiber-link-service/apps/admin/src/server/api/routers.test.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers.test.ts
@@ -26,6 +26,29 @@ function fixture(): DashboardFixture {
       },
     ],
     policies: [],
+    settlements: [
+      {
+        invoice: "lnfib1unpaidalpha",
+        appId: "app-alpha",
+        invoiceState: "UNPAID",
+        settlementRetryCount: 2,
+        settlementNextRetryAt: "2026-03-18T01:00:00.000Z",
+        settlementLastError: "upstream timeout",
+        settlementFailureReason: "RETRY_TRANSIENT_ERROR",
+        createdAt: "2026-03-18T00:05:00.000Z",
+        events: [
+          { type: "TIP_CREATED", source: "TIP_CREATE", nextInvoiceState: "UNPAID" },
+          { type: "SETTLEMENT_RETRY_SCHEDULED", source: "SETTLEMENT_DISCOVERY" },
+        ],
+      },
+      {
+        invoice: "lnfib1settledalpha",
+        appId: "app-alpha",
+        invoiceState: "SETTLED",
+        settledAt: "2026-03-18T00:10:00.000Z",
+        createdAt: "2026-03-18T00:01:00.000Z",
+      },
+    ],
     communityAdminAppIds: ["app-alpha"],
     backupBundles: [
       {
@@ -122,6 +145,111 @@ describe("admin tRPC routers", () => {
     await expect(
       caller.ops.createRateLimitChangeSet({ enabled: true, windowMs: "abc", maxRequests: "10" }),
     ).rejects.toBeInstanceOf(TRPCError);
+  });
+});
+
+describe("settlement investigation workflow (#470)", () => {
+  it("lists settlements newest-first and filters by state for SUPER_ADMIN", async () => {
+    const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
+    const all = await caller.settlements.list({});
+    expect(all.map((s) => s.invoice)).toEqual(["lnfib1unpaidalpha", "lnfib1settledalpha"]);
+
+    const settled = await caller.settlements.list({ state: "SETTLED" });
+    expect(settled).toHaveLength(1);
+    expect(settled[0].invoice).toBe("lnfib1settledalpha");
+
+    await expect(caller.settlements.list({ state: "NOPE" } as never)).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("denies settlement procedures to COMMUNITY_ADMIN and anonymous callers", async () => {
+    const community = createCaller(ctxFor("COMMUNITY_ADMIN", "c1"));
+    await expect(community.settlements.list({})).rejects.toMatchObject({ code: "FORBIDDEN" });
+    await expect(community.settlements.retryNow({ invoice: "lnfib1unpaidalpha" })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    await expect(createCaller(ctxFor(undefined)).settlements.timeline({ invoice: "x" })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("returns the lifecycle timeline for one invoice and NOT_FOUND for unknown invoices", async () => {
+    const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
+    const timeline = await caller.settlements.timeline({ invoice: "lnfib1unpaidalpha" });
+    expect(timeline.intent.invoiceState).toBe("UNPAID");
+    expect(timeline.intent.settlementFailureReason).toBe("RETRY_TRANSIENT_ERROR");
+    expect(timeline.events.map((e) => e.type)).toEqual(["TIP_CREATED", "SETTLEMENT_RETRY_SCHEDULED"]);
+    expect(timeline.adminActions).toEqual([]);
+
+    await expect(caller.settlements.timeline({ invoice: "lnfib1missing" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("retryNow clears retry state and writes an audit record", async () => {
+    const services = createFixtureAdminServices(fixture());
+    const ctx: TrpcContext = { role: "SUPER_ADMIN", adminUserId: "ops-user", requestId: "req-retry", services };
+    const caller = createCaller(ctx);
+
+    const intent = await caller.settlements.retryNow({ invoice: "lnfib1unpaidalpha" });
+    expect(intent.settlementRetryCount).toBe(0);
+    expect(intent.settlementNextRetryAt).toBeNull();
+    expect(intent.settlementLastError).toBeNull();
+    expect(intent.settlementFailureReason).toBeNull();
+
+    const events = services.__listAuditEventsForTests?.() ?? [];
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      action: "settlement.retry_now",
+      targetType: "tip_intent",
+      targetId: "lnfib1unpaidalpha",
+      actorId: "ops-user",
+      actorRole: "SUPER_ADMIN",
+      requestId: "req-retry",
+    });
+
+    const timeline = await caller.settlements.timeline({ invoice: "lnfib1unpaidalpha" });
+    expect(timeline.adminActions.map((a) => a.action)).toEqual(["settlement.retry_now"]);
+  });
+
+  it("retryNow rejects terminal invoices and audits nothing", async () => {
+    const services = createFixtureAdminServices(fixture());
+    const ctx: TrpcContext = { role: "SUPER_ADMIN", adminUserId: "ops-user", requestId: "req-x", services };
+    const caller = createCaller(ctx);
+
+    await expect(caller.settlements.retryNow({ invoice: "lnfib1settledalpha" })).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+    });
+    expect(services.__listAuditEventsForTests?.() ?? []).toHaveLength(0);
+  });
+
+  it("addOpsNote records an audited note that shows up in the timeline", async () => {
+    const services = createFixtureAdminServices(fixture());
+    const ctx: TrpcContext = { role: "SUPER_ADMIN", adminUserId: "ops-user", requestId: "req-note", services };
+    const caller = createCaller(ctx);
+
+    await caller.settlements.addOpsNote({ invoice: "lnfib1unpaidalpha", note: "confirmed with payer" });
+
+    const events = services.__listAuditEventsForTests?.() ?? [];
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      action: "settlement.ops_note.add",
+      targetType: "tip_intent",
+      targetId: "lnfib1unpaidalpha",
+      reason: "confirmed with payer",
+    });
+
+    const timeline = await caller.settlements.timeline({ invoice: "lnfib1unpaidalpha" });
+    expect(timeline.adminActions[0]).toMatchObject({
+      action: "settlement.ops_note.add",
+      reason: "confirmed with payer",
+    });
+
+    await expect(caller.settlements.addOpsNote({ invoice: "lnfib1missing", note: "x" })).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    await expect(caller.settlements.addOpsNote({ invoice: "lnfib1unpaidalpha", note: "  " })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
   });
 });
 

--- a/fiber-link-service/apps/admin/src/server/api/routers/settlements.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/settlements.ts
@@ -1,0 +1,117 @@
+import type { InvoiceState } from "@fiber-link/db";
+import { TRPCError } from "@trpc/server";
+import { SettlementNotFoundError, SettlementRetryStateError } from "../../services/errors";
+import type { AdminSettlementFilters } from "../../services/types";
+import { recordAuditEvent, router, superAdminProcedure } from "../trpc";
+
+const INVOICE_STATES: readonly InvoiceState[] = ["UNPAID", "SETTLED", "FAILED"];
+
+/** Fiber invoices are long bech32-ish strings, but bounded; reject junk early. */
+const INVOICE_MAX_LENGTH = 4096;
+const OPS_NOTE_MAX_LENGTH = 2000;
+
+function parseSettlementFilters(input: unknown): AdminSettlementFilters {
+  if (input === undefined || input === null) {
+    return {};
+  }
+  if (typeof input !== "object") {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "invalid settlement filters" });
+  }
+
+  const raw = input as Record<string, unknown>;
+  const filters: AdminSettlementFilters = {};
+
+  if (typeof raw.appId === "string" && raw.appId.trim()) {
+    filters.appId = raw.appId.trim();
+  }
+  if (typeof raw.state === "string" && raw.state.trim()) {
+    const state = raw.state.trim();
+    if (!INVOICE_STATES.includes(state as InvoiceState)) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: `unknown settlement state: ${state}` });
+    }
+    filters.state = state as InvoiceState;
+  }
+  return filters;
+}
+
+function parseInvoice(input: unknown): { invoice: string } {
+  const raw = (typeof input === "object" && input !== null ? input : {}) as Record<string, unknown>;
+  const invoice = typeof raw.invoice === "string" ? raw.invoice.trim() : "";
+  if (!invoice || invoice.length > INVOICE_MAX_LENGTH) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "invoice is required" });
+  }
+  return { invoice };
+}
+
+function parseOpsNote(input: unknown): { invoice: string; note: string } {
+  const { invoice } = parseInvoice(input);
+  const raw = input as Record<string, unknown>;
+  const note = typeof raw.note === "string" ? raw.note.trim() : "";
+  if (!note) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "note is required" });
+  }
+  if (note.length > OPS_NOTE_MAX_LENGTH) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: `note exceeds ${OPS_NOTE_MAX_LENGTH} characters` });
+  }
+  return { invoice, note };
+}
+
+function mapSettlementError(error: unknown): never {
+  if (error instanceof SettlementNotFoundError) {
+    throw new TRPCError({ code: "NOT_FOUND", message: error.message });
+  }
+  if (error instanceof SettlementRetryStateError) {
+    throw new TRPCError({ code: "PRECONDITION_FAILED", message: error.message });
+  }
+  throw error;
+}
+
+export const settlementsRouter = router({
+  list: superAdminProcedure.input(parseSettlementFilters).query(async ({ ctx, input }) => {
+    return ctx.services.listSettlements(ctx.scope, input);
+  }),
+
+  timeline: superAdminProcedure.input(parseInvoice).query(async ({ ctx, input }) => {
+    try {
+      return await ctx.services.getSettlementTimeline(ctx.scope, input.invoice);
+    } catch (error) {
+      mapSettlementError(error);
+    }
+  }),
+
+  retryNow: superAdminProcedure.input(parseInvoice).mutation(async ({ ctx, input }) => {
+    try {
+      const intent = await ctx.services.retrySettlementNow(ctx.scope, input.invoice);
+      await recordAuditEvent(ctx, ctx.scope, {
+        action: "settlement.retry_now",
+        targetType: "tip_intent",
+        targetId: input.invoice,
+        after: {
+          invoiceState: intent.invoiceState,
+          settlementRetryCount: intent.settlementRetryCount,
+          settlementNextRetryAt: intent.settlementNextRetryAt,
+        },
+      });
+      return intent;
+    } catch (error) {
+      mapSettlementError(error);
+    }
+  }),
+
+  addOpsNote: superAdminProcedure.input(parseOpsNote).mutation(async ({ ctx, input }) => {
+    try {
+      // Resolve first so notes cannot be attached to unknown/out-of-scope
+      // invoices, and so a failed lookup is NOT_FOUND rather than a silent write.
+      await ctx.services.getSettlementTimeline(ctx.scope, input.invoice);
+    } catch (error) {
+      mapSettlementError(error);
+    }
+    await recordAuditEvent(ctx, ctx.scope, {
+      action: "settlement.ops_note.add",
+      targetType: "tip_intent",
+      targetId: input.invoice,
+      reason: input.note,
+    });
+    return { ok: true as const };
+  }),
+});

--- a/fiber-link-service/apps/admin/src/server/services/db-services.ts
+++ b/fiber-link-service/apps/admin/src/server/services/db-services.ts
@@ -1,8 +1,12 @@
 import {
   type DbClient,
+  TipIntentNotFoundError,
+  type TipIntentRecord,
   type WithdrawalState,
   createDbAdminAuditRepo,
   createDbClient,
+  createDbTipIntentEventRepo,
+  createDbTipIntentRepo,
   withdrawalPolicies,
   withdrawals,
 } from "@fiber-link/db";
@@ -32,12 +36,15 @@ import {
   loadDashboardRateLimitConfig,
   parseDashboardRateLimitInput,
 } from "../dashboard-rate-limit";
-import { PolicyScopeError, UnknownAppError } from "./errors";
+import { PolicyScopeError, SettlementNotFoundError, SettlementRetryStateError, UnknownAppError } from "./errors";
 import {
   type AdminScope,
   type AdminServices,
+  type AdminSettlementIntent,
+  type AdminSettlementTimeline,
   type AdminWithdrawal,
   type AdminWithdrawalFilters,
+  SETTLEMENT_LIST_LIMIT,
   WITHDRAWAL_LIST_LIMIT,
 } from "./types";
 
@@ -76,6 +83,27 @@ function isoOrNull(value: Date | null | undefined): string | null {
   return value ? value.toISOString() : null;
 }
 
+function toSettlementIntent(record: TipIntentRecord): AdminSettlementIntent {
+  return {
+    id: record.id,
+    invoice: record.invoice,
+    appId: record.appId,
+    postId: record.postId,
+    fromUserId: record.fromUserId,
+    toUserId: record.toUserId,
+    asset: record.asset,
+    amount: record.amount,
+    invoiceState: record.invoiceState,
+    settlementRetryCount: record.settlementRetryCount,
+    settlementNextRetryAt: isoOrNull(record.settlementNextRetryAt),
+    settlementLastError: record.settlementLastError ?? null,
+    settlementFailureReason: record.settlementFailureReason ?? null,
+    settlementLastCheckedAt: isoOrNull(record.settlementLastCheckedAt),
+    createdAt: record.createdAt.toISOString(),
+    settledAt: isoOrNull(record.settledAt),
+  };
+}
+
 /**
  * Resolve the set of app ids the scope may read. Returns `"ALL"` for
  * SUPER_ADMIN, the assigned app ids for COMMUNITY_ADMIN, or an empty array
@@ -100,6 +128,27 @@ async function resolveScopedAppIds(db: DbClient, scope: AdminScope): Promise<"AL
 
 export function createDbAdminServices(db: DbClient = createDbClient()): AdminServices {
   const auditRepo = createDbAdminAuditRepo(db);
+  const tipIntentRepo = createDbTipIntentRepo(db);
+  const tipIntentEventRepo = createDbTipIntentEventRepo(db);
+
+  /** Resolve an in-scope tip intent or collapse to "not found" (no probing). */
+  async function findScopedTipIntent(scope: AdminScope, invoice: string): Promise<TipIntentRecord> {
+    const scoped = await resolveScopedAppIds(db, scope);
+    let record: TipIntentRecord;
+    try {
+      record = await tipIntentRepo.findByInvoiceOrThrow(invoice);
+    } catch (error) {
+      if (error instanceof TipIntentNotFoundError) {
+        throw new SettlementNotFoundError(invoice);
+      }
+      throw error;
+    }
+    if (scoped !== "ALL" && !scoped.includes(record.appId)) {
+      throw new SettlementNotFoundError(invoice);
+    }
+    return record;
+  }
+
   return {
     async appendAuditEvent(event) {
       try {
@@ -264,6 +313,97 @@ export function createDbAdminServices(db: DbClient = createDbClient()): AdminSer
         createdAt: row.createdAt.toISOString(),
         updatedAt: row.updatedAt.toISOString(),
       };
+    },
+
+    async listSettlements(scope, filters): Promise<AdminSettlementIntent[]> {
+      const scoped = await resolveScopedAppIds(db, scope);
+      if (scoped !== "ALL" && scoped.length === 0) {
+        return [];
+      }
+
+      const rows = await db.query.tipIntents.findMany({
+        orderBy: (t, { desc }) => [desc(t.createdAt), desc(t.id)],
+        limit: SETTLEMENT_LIST_LIMIT,
+        where: (t, { and, eq, inArray }) => {
+          const clauses = [];
+          if (scoped !== "ALL") {
+            clauses.push(inArray(t.appId, scoped));
+          }
+          if (filters?.appId) {
+            clauses.push(eq(t.appId, filters.appId));
+          }
+          if (filters?.state) {
+            clauses.push(eq(t.invoiceState, filters.state));
+          }
+          return clauses.length > 0 ? and(...clauses) : undefined;
+        },
+      });
+
+      const redactPii = scope.role === "COMMUNITY_ADMIN";
+      return rows.map((row) => ({
+        id: row.id,
+        invoice: row.invoice,
+        appId: row.appId,
+        postId: row.postId,
+        fromUserId: redactPii ? "" : row.fromUserId,
+        toUserId: redactPii ? "" : row.toUserId,
+        asset: row.asset,
+        amount: typeof row.amount === "string" ? row.amount : String(row.amount),
+        invoiceState: row.invoiceState,
+        settlementRetryCount: row.settlementRetryCount ?? 0,
+        settlementNextRetryAt: isoOrNull(row.settlementNextRetryAt),
+        settlementLastError: row.settlementLastError ?? null,
+        settlementFailureReason: row.settlementFailureReason ?? null,
+        settlementLastCheckedAt: isoOrNull(row.settlementLastCheckedAt),
+        createdAt: row.createdAt.toISOString(),
+        settledAt: isoOrNull(row.settledAt),
+      }));
+    },
+
+    async getSettlementTimeline(scope, invoice): Promise<AdminSettlementTimeline> {
+      const record = await findScopedTipIntent(scope, invoice);
+      const [events, auditEvents] = await Promise.all([
+        tipIntentEventRepo.listByInvoice(invoice),
+        auditRepo.listRecentByTarget("tip_intent", invoice),
+      ]);
+
+      const intent = toSettlementIntent(record);
+      if (scope.role === "COMMUNITY_ADMIN") {
+        intent.fromUserId = "";
+        intent.toUserId = "";
+      }
+
+      return {
+        intent,
+        events: events.map((event) => ({
+          id: event.id,
+          source: event.source,
+          type: event.type,
+          previousInvoiceState: event.previousInvoiceState,
+          nextInvoiceState: event.nextInvoiceState,
+          metadata: event.metadata,
+          createdAt: event.createdAt.toISOString(),
+        })),
+        adminActions: auditEvents.map((event) => ({
+          action: event.action,
+          actorId: event.actorId,
+          actorRole: event.actorRole,
+          reason: event.reason,
+          createdAt: event.createdAt.toISOString(),
+        })),
+      };
+    },
+
+    async retrySettlementNow(scope, invoice): Promise<AdminSettlementIntent> {
+      const record = await findScopedTipIntent(scope, invoice);
+      // SETTLED and FAILED are terminal; the worker only re-polls UNPAID
+      // intents, so clearing retry state on anything else would be a silent
+      // no-op that misleads the operator.
+      if (record.invoiceState !== "UNPAID") {
+        throw new SettlementRetryStateError(record.invoiceState);
+      }
+      const updated = await tipIntentRepo.clearSettlementFailure(invoice, { now: new Date() });
+      return toSettlementIntent(updated);
     },
 
     async loadMonitoringSummary(): Promise<DashboardMonitoringSummary> {

--- a/fiber-link-service/apps/admin/src/server/services/errors.ts
+++ b/fiber-link-service/apps/admin/src/server/services/errors.ts
@@ -15,3 +15,23 @@ export class UnknownAppError extends Error {
     this.name = "UnknownAppError";
   }
 }
+
+/**
+ * Unknown invoice, or an invoice outside the caller's app scope. Both cases
+ * intentionally collapse into "not found" so a scoped admin cannot probe for
+ * the existence of other communities' invoices.
+ */
+export class SettlementNotFoundError extends Error {
+  constructor(public readonly invoice: string) {
+    super(`unknown settlement invoice: ${invoice}`);
+    this.name = "SettlementNotFoundError";
+  }
+}
+
+/** Retry requested for an invoice that is not in a retryable (UNPAID) state. */
+export class SettlementRetryStateError extends Error {
+  constructor(public readonly invoiceState: string) {
+    super(`settlement retry is only available while the invoice is UNPAID (current state: ${invoiceState})`);
+    this.name = "SettlementRetryStateError";
+  }
+}

--- a/fiber-link-service/apps/admin/src/server/services/fixture-services.ts
+++ b/fiber-link-service/apps/admin/src/server/services/fixture-services.ts
@@ -11,13 +11,16 @@ import {
 } from "../../dashboard/dashboard-page-model";
 import { buildDashboardBackupRestorePlan } from "../dashboard-backups";
 import { buildDashboardRateLimitChangeSet, parseDashboardRateLimitInput } from "../dashboard-rate-limit";
-import { PolicyScopeError, UnknownAppError } from "./errors";
+import { PolicyScopeError, SettlementNotFoundError, SettlementRetryStateError, UnknownAppError } from "./errors";
 import {
   type AdminAuditEventInput,
   type AdminScope,
   type AdminServices,
+  type AdminSettlementEvent,
+  type AdminSettlementIntent,
   type AdminWithdrawal,
   type AdminWithdrawalFilters,
+  SETTLEMENT_LIST_LIMIT,
   WITHDRAWAL_LIST_LIMIT,
 } from "./types";
 
@@ -26,10 +29,20 @@ import {
  * rows accept the optional recovery columns so fixtures can exercise the queue
  * and detail surfaces without standing up Postgres.
  */
+/**
+ * Settlement fixture rows only need the identity fields; everything else
+ * defaults to a fresh UNPAID intent so tests stay terse.
+ */
+export type DashboardFixtureSettlement = Partial<AdminSettlementIntent> &
+  Pick<AdminSettlementIntent, "invoice" | "appId"> & {
+    events?: Array<Partial<AdminSettlementEvent> & Pick<AdminSettlementEvent, "type">>;
+  };
+
 export type DashboardFixture = {
   apps: DashboardApp[];
   withdrawals: Array<DashboardWithdrawal & Partial<AdminWithdrawal>>;
   policies: DashboardWithdrawalPolicy[];
+  settlements?: DashboardFixtureSettlement[];
   communityAdminAppIds?: string[];
   monitoringSummary?: DashboardMonitoringSummary;
   rateLimitConfig?: DashboardRateLimitConfig;
@@ -57,6 +70,42 @@ function toAdminWithdrawal(row: DashboardWithdrawal & Partial<AdminWithdrawal>):
   };
 }
 
+function toFixtureSettlement(row: DashboardFixtureSettlement): {
+  intent: AdminSettlementIntent;
+  events: AdminSettlementEvent[];
+} {
+  const createdAt = row.createdAt ?? "2026-03-18T00:00:00.000Z";
+  return {
+    intent: {
+      id: row.id ?? row.invoice,
+      invoice: row.invoice,
+      appId: row.appId,
+      postId: row.postId ?? "post-1",
+      fromUserId: row.fromUserId ?? "tipper-1",
+      toUserId: row.toUserId ?? "author-1",
+      asset: row.asset ?? "CKB",
+      amount: row.amount ?? "100",
+      invoiceState: row.invoiceState ?? "UNPAID",
+      settlementRetryCount: row.settlementRetryCount ?? 0,
+      settlementNextRetryAt: row.settlementNextRetryAt ?? null,
+      settlementLastError: row.settlementLastError ?? null,
+      settlementFailureReason: row.settlementFailureReason ?? null,
+      settlementLastCheckedAt: row.settlementLastCheckedAt ?? null,
+      createdAt,
+      settledAt: row.settledAt ?? null,
+    },
+    events: (row.events ?? []).map((event, index) => ({
+      id: event.id ?? `${row.invoice}-event-${index + 1}`,
+      source: event.source ?? "SETTLEMENT_DISCOVERY",
+      type: event.type,
+      previousInvoiceState: event.previousInvoiceState ?? null,
+      nextInvoiceState: event.nextInvoiceState ?? null,
+      metadata: event.metadata ?? null,
+      createdAt: event.createdAt ?? createdAt,
+    })),
+  };
+}
+
 function buildDefaultMonitoringSummary(): DashboardMonitoringSummary {
   return {
     status: "ok",
@@ -81,12 +130,13 @@ function buildDefaultRateLimitConfig(): DashboardRateLimitConfig {
 }
 
 export function createFixtureAdminServices(fixture: DashboardFixture): AdminServices {
-  const auditEvents: AdminAuditEventInput[] = [];
+  const auditEvents: Array<AdminAuditEventInput & { createdAt: string }> = [];
 
   const snapshot = {
     apps: fixture.apps.map((app) => ({ ...app })),
     withdrawals: fixture.withdrawals.map(toAdminWithdrawal),
     policies: new Map(fixture.policies.map((policy) => [policy.appId, { ...policy }])),
+    settlements: (fixture.settlements ?? []).map(toFixtureSettlement),
     monitoringSummary: fixture.monitoringSummary ? { ...fixture.monitoringSummary } : buildDefaultMonitoringSummary(),
     rateLimitConfig: fixture.rateLimitConfig ? { ...fixture.rateLimitConfig } : buildDefaultRateLimitConfig(),
     backupBundles: (fixture.backupBundles ?? []).map((bundle) => ({ ...bundle })),
@@ -100,7 +150,7 @@ export function createFixtureAdminServices(fixture: DashboardFixture): AdminServ
 
   return {
     async appendAuditEvent(event) {
-      auditEvents.push({ ...event });
+      auditEvents.push({ ...event, createdAt: new Date().toISOString() });
     },
     __listAuditEventsForTests() {
       return auditEvents.map((e) => ({ ...e }));
@@ -153,6 +203,60 @@ export function createFixtureAdminServices(fixture: DashboardFixture): AdminServ
       };
       snapshot.policies.set(input.appId, next);
       return { ...next };
+    },
+    async listSettlements(scope, filters) {
+      const redactPii = scope.role === "COMMUNITY_ADMIN";
+      return snapshot.settlements
+        .filter((row) => inScope(scope, row.intent.appId))
+        .filter((row) => (filters?.appId ? row.intent.appId === filters.appId : true))
+        .filter((row) => (filters?.state ? row.intent.invoiceState === filters.state : true))
+        .sort((a, b) => b.intent.createdAt.localeCompare(a.intent.createdAt))
+        .slice(0, SETTLEMENT_LIST_LIMIT)
+        .map((row) => ({
+          ...row.intent,
+          fromUserId: redactPii ? "" : row.intent.fromUserId,
+          toUserId: redactPii ? "" : row.intent.toUserId,
+        }));
+    },
+    async getSettlementTimeline(scope, invoice) {
+      const row = snapshot.settlements.find((candidate) => candidate.intent.invoice === invoice);
+      if (!row || !inScope(scope, row.intent.appId)) {
+        throw new SettlementNotFoundError(invoice);
+      }
+      const redactPii = scope.role === "COMMUNITY_ADMIN";
+      return {
+        intent: {
+          ...row.intent,
+          fromUserId: redactPii ? "" : row.intent.fromUserId,
+          toUserId: redactPii ? "" : row.intent.toUserId,
+        },
+        events: row.events.map((event) => ({ ...event })),
+        adminActions: auditEvents
+          .filter((event) => event.targetType === "tip_intent" && event.targetId === invoice)
+          .map((event) => ({
+            action: event.action,
+            actorId: event.actorId,
+            actorRole: event.actorRole,
+            reason: event.reason ?? null,
+            createdAt: event.createdAt,
+          }))
+          .reverse(),
+      };
+    },
+    async retrySettlementNow(scope, invoice) {
+      const row = snapshot.settlements.find((candidate) => candidate.intent.invoice === invoice);
+      if (!row || !inScope(scope, row.intent.appId)) {
+        throw new SettlementNotFoundError(invoice);
+      }
+      if (row.intent.invoiceState !== "UNPAID") {
+        throw new SettlementRetryStateError(row.intent.invoiceState);
+      }
+      row.intent.settlementRetryCount = 0;
+      row.intent.settlementNextRetryAt = null;
+      row.intent.settlementLastError = null;
+      row.intent.settlementFailureReason = null;
+      row.intent.settlementLastCheckedAt = new Date().toISOString();
+      return { ...row.intent };
     },
     async loadMonitoringSummary() {
       return { ...snapshot.monitoringSummary };

--- a/fiber-link-service/apps/admin/src/server/services/types.ts
+++ b/fiber-link-service/apps/admin/src/server/services/types.ts
@@ -1,4 +1,4 @@
-import type { UserRole, WithdrawalState } from "@fiber-link/db";
+import type { InvoiceState, UserRole, WithdrawalState } from "@fiber-link/db";
 import type {
   DashboardApp,
   DashboardBackupBundle,
@@ -67,6 +67,63 @@ export type AdminWithdrawalFilters = {
  */
 export const WITHDRAWAL_LIST_LIMIT = 200;
 
+/** Same rationale as {@link WITHDRAWAL_LIST_LIMIT}, for the settlements queue. */
+export const SETTLEMENT_LIST_LIMIT = 200;
+
+/**
+ * Settlement projection of a tip intent for the investigation surfaces:
+ * current state plus every recovery-relevant column the worker maintains.
+ */
+export type AdminSettlementIntent = {
+  id: string;
+  invoice: string;
+  appId: string;
+  postId: string;
+  fromUserId: string;
+  toUserId: string;
+  asset: "CKB" | "USDI";
+  amount: string;
+  invoiceState: InvoiceState;
+  settlementRetryCount: number;
+  settlementNextRetryAt: string | null;
+  settlementLastError: string | null;
+  settlementFailureReason: string | null;
+  settlementLastCheckedAt: string | null;
+  createdAt: string;
+  settledAt: string | null;
+};
+
+/** One `tip_intent_events` row, oldest-first in the timeline. */
+export type AdminSettlementEvent = {
+  id: string;
+  source: string;
+  type: string;
+  previousInvoiceState: InvoiceState | null;
+  nextInvoiceState: InvoiceState | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+};
+
+/** An admin action (retry, ops note) recorded against the invoice, newest-first. */
+export type AdminSettlementAction = {
+  action: string;
+  actorId: string;
+  actorRole: string;
+  reason: string | null;
+  createdAt: string;
+};
+
+export type AdminSettlementTimeline = {
+  intent: AdminSettlementIntent;
+  events: AdminSettlementEvent[];
+  adminActions: AdminSettlementAction[];
+};
+
+export type AdminSettlementFilters = {
+  state?: InvoiceState;
+  appId?: string;
+};
+
 /**
  * The seam every admin tRPC router depends on. The real implementation
  * (`createDbAdminServices`) queries Postgres through the `@fiber-link/db`
@@ -94,6 +151,22 @@ export interface AdminServices {
   summarizeWithdrawals(scope: AdminScope): Promise<DashboardStatusSummary[]>;
   listPolicies(scope: AdminScope): Promise<DashboardWithdrawalPolicy[]>;
   upsertPolicy(scope: AdminScope, input: WithdrawalPolicyInput): Promise<DashboardWithdrawalPolicy>;
+
+  /** Newest first, capped at {@link SETTLEMENT_LIST_LIMIT} rows. */
+  listSettlements(scope: AdminScope, filters?: AdminSettlementFilters): Promise<AdminSettlementIntent[]>;
+  /**
+   * Full investigation view for one invoice: current intent state, the
+   * `tip_intent_events` lifecycle timeline, and prior admin actions (retries,
+   * ops notes) recorded in the audit trail. Throws `SettlementNotFoundError`
+   * for unknown or out-of-scope invoices.
+   */
+  getSettlementTimeline(scope: AdminScope, invoice: string): Promise<AdminSettlementTimeline>;
+  /**
+   * Clear the settlement retry/failure state so the worker re-checks the
+   * invoice on its next poll. Only valid while the invoice is UNPAID (SETTLED
+   * and FAILED are terminal); throws `SettlementRetryStateError` otherwise.
+   */
+  retrySettlementNow(scope: AdminScope, invoice: string): Promise<AdminSettlementIntent>;
 
   loadMonitoringSummary(): Promise<DashboardMonitoringSummary>;
   loadRateLimitConfig(): Promise<DashboardRateLimitConfig>;

--- a/fiber-link-service/packages/db/src/tip-intent-event-repo.test.ts
+++ b/fiber-link-service/packages/db/src/tip-intent-event-repo.test.ts
@@ -98,6 +98,41 @@ describe("tipIntentEventRepo (in-memory)", () => {
     expect(listed.map((event) => event.type)).toEqual(["TIP_CREATED", "TIP_STATUS_SETTLED"]);
   });
 
+  it("lists events by invoice across tip intents", async () => {
+    await repo.append({
+      tipIntentId: "tip-1",
+      invoice: "inv-1",
+      source: "TIP_CREATE",
+      type: "TIP_CREATED",
+      previousInvoiceState: null,
+      nextInvoiceState: "UNPAID",
+      createdAt: new Date("2026-02-21T00:00:00.000Z"),
+    });
+    await repo.append({
+      tipIntentId: "tip-2",
+      invoice: "inv-other",
+      source: "TIP_CREATE",
+      type: "TIP_CREATED",
+      previousInvoiceState: null,
+      nextInvoiceState: "UNPAID",
+      createdAt: new Date("2026-02-21T00:00:01.000Z"),
+    });
+    await repo.append({
+      tipIntentId: "tip-1",
+      invoice: "inv-1",
+      source: "SETTLEMENT_DISCOVERY",
+      type: "SETTLEMENT_SETTLED_CREDIT_APPLIED",
+      previousInvoiceState: "UNPAID",
+      nextInvoiceState: "SETTLED",
+      createdAt: new Date("2026-02-21T00:00:02.000Z"),
+    });
+
+    const listed = await repo.listByInvoice("inv-1");
+    expect(listed.map((event) => event.type)).toEqual(["TIP_CREATED", "SETTLEMENT_SETTLED_CREDIT_APPLIED"]);
+    expect(await repo.listByInvoice("inv-1", { limit: 1 })).toHaveLength(1);
+    expect(await repo.listByInvoice("inv-unknown")).toEqual([]);
+  });
+
   it("returns cloned metadata so tests cannot mutate stored events", async () => {
     await repo.append({
       tipIntentId: "tip-1",

--- a/fiber-link-service/packages/db/src/tip-intent-event-repo.ts
+++ b/fiber-link-service/packages/db/src/tip-intent-event-repo.ts
@@ -35,6 +35,7 @@ export type TipIntentEventListOptions = {
 export type TipIntentEventRepo = {
   append(input: AppendTipIntentEventInput): Promise<TipIntentEventRecord>;
   listByTipIntentId(tipIntentId: string, options?: TipIntentEventListOptions): Promise<TipIntentEventRecord[]>;
+  listByInvoice(invoice: string, options?: TipIntentEventListOptions): Promise<TipIntentEventRecord[]>;
   __listForTests?: () => TipIntentEventRecord[];
   __resetForTests?: () => void;
 };
@@ -99,6 +100,17 @@ export function createDbTipIntentEventRepo(db: DbClient): TipIntentEventRepo {
       const rows = await query;
       return rows.map(toRecord);
     },
+
+    async listByInvoice(invoice, options = {}) {
+      const baseQuery = db
+        .select()
+        .from(tipIntentEvents)
+        .where(eq(tipIntentEvents.invoice, invoice))
+        .orderBy(asc(tipIntentEvents.createdAt), asc(tipIntentEvents.id));
+      const query = options.limit && options.limit > 0 ? baseQuery.limit(options.limit) : baseQuery;
+      const rows = await query;
+      return rows.map(toRecord);
+    },
   };
 }
 
@@ -132,6 +144,21 @@ export function createInMemoryTipIntentEventRepo(): TipIntentEventRepo {
 
     async listByTipIntentId(tipIntentId, options = {}) {
       let items = records.filter((record) => record.tipIntentId === tipIntentId);
+      items = items.sort((left, right) => {
+        const createdAtDiff = left.createdAt.getTime() - right.createdAt.getTime();
+        if (createdAtDiff !== 0) {
+          return createdAtDiff;
+        }
+        return left.id.localeCompare(right.id);
+      });
+      if (options.limit && options.limit > 0) {
+        items = items.slice(0, options.limit);
+      }
+      return items.map(clone);
+    },
+
+    async listByInvoice(invoice, options = {}) {
+      let items = records.filter((record) => record.invoice === invoice);
       items = items.sort((left, right) => {
         const createdAtDiff = left.createdAt.getTime() - right.createdAt.getTime();
         if (createdAtDiff !== 0) {


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #527** (admin audit logging): this branch is based on `claude/admin-audit-logging` because the retry/ops-note actions record audit events through the `recordAuditEvent` helper introduced there. The first commits in this PR belong to #527; only the last commit (`Add settlement investigation timeline and retry workflow to admin`) is new. Once #527 merges I will rebase this branch onto `main` so the diff collapses to the settlement work.

## Summary

Implements #470: operators get a per-invoice settlement investigation workflow in the admin app instead of digging through DB rows and worker logs.

- **`packages/db`**: `TipIntentEventRepo.listByInvoice(invoice, options?)` — the timeline is keyed by the invoice operators actually hold, not the internal tip-intent id (db + in-memory implementations, tests).
- **Services seam** (`AdminServices`):
  - `listSettlements(scope, filters?)` — newest-first settlement queue projection (capped at 200 rows) with state/app filters and the recovery-relevant columns (retry count, next retry, last error, failure reason).
  - `getSettlementTimeline(scope, invoice)` — current intent state + the `tip_intent_events` lifecycle timeline + prior audited admin actions (retries, ops notes) merged in as an investigation log. Unknown and out-of-scope invoices both collapse to not-found so a scoped admin cannot probe for other communities' invoices.
  - `retrySettlementNow(scope, invoice)` — clears settlement retry/failure state (`clearSettlementFailure`) so the worker re-checks the invoice on its next poll. Guarded to `UNPAID` intents: `SETTLED`/`FAILED` are terminal states the worker never re-polls, so clearing them would be a misleading no-op (`PRECONDITION_FAILED`).
- **tRPC router** `settlements.*` (SUPER_ADMIN-only, matching the existing settlements page gate): `list`, `timeline`, `retryNow`, `addOpsNote`. `retryNow` and `addOpsNote` write `admin_audit_events` records through the #468 audit trail (actor, role, requestId, reason), and ops notes surface back in the timeline's investigation log.
- **Admin UI**: the two placeholder settlement pages ("milestone 2") now render the real thing — queue with state filter and failure-reason highlighting; detail page with intent summary, lifecycle timeline, terminal-failure highlighting, a Retry-now button (disabled outside `UNPAID` with an explanation), and an ops-note form.

## Issue acceptance criteria

- ✅ Admin users can open a timeline from the settlement list (invoice links to `/settlements/[invoice]`).
- ✅ Timeline shows creation, status checks, retries, failures, settlement, and credit application events (`tip_intent_events`, oldest-first).
- ✅ Retry/investigation actions are permission-checked (superAdminProcedure + scope re-check in services) and audited (`settlement.retry_now`, `settlement.ops_note.add`).
- ✅ Tests cover timeline retrieval, non-admin denial, and retry/investigation audit records.

## Testing

- `apps/admin`: `bunx vitest run` — 44 tests pass (6 new settlement tests: list/filter, role denial, timeline + NOT_FOUND, retry audit + state clearing, terminal-state rejection, ops-note audit + validation).
- `packages/db`: `bunx vitest run` — 140 tests pass (new `listByInvoice` coverage).
- `bun run typecheck` clean in both workspaces; `bunx biome check` clean; `next build` passes (all 9 admin routes compile).

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_