### PR TITLE
Ops: ledger reconciliation and balance explanation tools in admin (#471)

### DIFF
--- a/fiber-link-service/apps/admin/src/components/layout/app-shell.tsx
+++ b/fiber-link-service/apps/admin/src/components/layout/app-shell.tsx
@@ -1,4 +1,4 @@
-import { Activity, Banknote, Boxes, LayoutDashboard, Wallet, Wrench } from "lucide-react";
+import { Activity, Banknote, BookOpenCheck, Boxes, LayoutDashboard, Wallet, Wrench } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type * as React from "react";
@@ -18,6 +18,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/", label: "Overview", icon: LayoutDashboard },
   { href: "/settlements", label: "Settlements", icon: Banknote, superAdminOnly: true },
   { href: "/withdrawals", label: "Withdrawals", icon: Wallet },
+  { href: "/ledger", label: "Ledger", icon: BookOpenCheck, superAdminOnly: true },
   { href: "/apps", label: "Apps", icon: Boxes },
   { href: "/ops", label: "Ops", icon: Wrench, superAdminOnly: true },
 ];

--- a/fiber-link-service/apps/admin/src/pages/ledger.tsx
+++ b/fiber-link-service/apps/admin/src/pages/ledger.tsx
@@ -1,0 +1,261 @@
+import { useState } from "react";
+import { PageHeader, QueryBoundary, RoleGate, StatCard } from "../components/page";
+import { Badge } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { Select } from "../components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table";
+import { formatDateTime, shorten } from "../lib/format";
+import { trpc } from "../utils/trpc";
+
+type Account = { appId: string; userId: string; asset: "CKB" | "USDI" };
+
+export default function LedgerPage() {
+  const session = trpc.session.me.useQuery();
+  const isSuperAdmin = session.data?.role === "SUPER_ADMIN";
+
+  const [appId, setAppId] = useState("");
+  const [userId, setUserId] = useState("");
+  const [asset, setAsset] = useState<"CKB" | "USDI">("CKB");
+  const [account, setAccount] = useState<Account | null>(null);
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [reconcileAppId, setReconcileAppId] = useState("");
+  const [reconcileArgs, setReconcileArgs] = useState<{ appId?: string } | null>(null);
+
+  const breakdown = trpc.ledger.balanceBreakdown.useQuery(account ?? { appId: "", userId: "", asset: "CKB" }, {
+    enabled: isSuperAdmin && account !== null,
+  });
+  const entries = trpc.ledger.entries.useQuery(
+    account ? { appId: account.appId, userId: account.userId, asset: account.asset, cursor } : { appId: "" },
+    { enabled: isSuperAdmin && account !== null },
+  );
+  const reconcile = trpc.ledger.reconcile.useQuery(reconcileArgs ?? {}, {
+    enabled: isSuperAdmin && reconcileArgs !== null,
+  });
+
+  const anomalyCount = reconcile.data?.anomalies.length ?? 0;
+
+  return (
+    <div>
+      <PageHeader
+        title="Ledger"
+        description="Explain account balances from source credits/debits and reconcile the ledger against tips and withdrawals."
+      />
+      <QueryBoundary isLoading={session.isLoading} error={session.error}>
+        <RoleGate allowed={isSuperAdmin}>
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Account statement</CardTitle>
+                <CardDescription>
+                  Balance breakdown and paginated entries for one app/user/asset account.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <form
+                  className="mb-4 flex flex-wrap items-end gap-3"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    if (appId.trim() && userId.trim()) {
+                      setCursor(undefined);
+                      setAccount({ appId: appId.trim(), userId: userId.trim(), asset });
+                    }
+                  }}
+                >
+                  <div className="w-44">
+                    <Label htmlFor="ledger-app" className="mb-1 block text-xs text-muted-foreground">
+                      App
+                    </Label>
+                    <Input id="ledger-app" value={appId} onChange={(event) => setAppId(event.target.value)} />
+                  </div>
+                  <div className="w-44">
+                    <Label htmlFor="ledger-user" className="mb-1 block text-xs text-muted-foreground">
+                      User
+                    </Label>
+                    <Input id="ledger-user" value={userId} onChange={(event) => setUserId(event.target.value)} />
+                  </div>
+                  <div className="w-28">
+                    <Label htmlFor="ledger-asset" className="mb-1 block text-xs text-muted-foreground">
+                      Asset
+                    </Label>
+                    <Select
+                      id="ledger-asset"
+                      value={asset}
+                      onChange={(event) => setAsset(event.target.value as "CKB" | "USDI")}
+                    >
+                      <option value="CKB">CKB</option>
+                      <option value="USDI">USDI</option>
+                    </Select>
+                  </div>
+                  <Button type="submit" data-testid="ledger-load-account" disabled={!appId.trim() || !userId.trim()}>
+                    Load account
+                  </Button>
+                </form>
+
+                {account ? (
+                  <QueryBoundary
+                    isLoading={breakdown.isLoading || entries.isLoading}
+                    error={breakdown.error ?? entries.error}
+                  >
+                    <section className="mb-4 grid grid-cols-2 gap-4 md:grid-cols-4">
+                      <StatCard label="Balance" value={breakdown.data?.balance ?? "—"} />
+                      <StatCard
+                        label="Credits"
+                        value={breakdown.data ? `${breakdown.data.creditTotal} (${breakdown.data.creditCount})` : "—"}
+                        tone="success"
+                      />
+                      <StatCard
+                        label="Debits"
+                        value={breakdown.data ? `${breakdown.data.debitTotal} (${breakdown.data.debitCount})` : "—"}
+                      />
+                      <StatCard label="Last entry" value={formatDateTime(breakdown.data?.lastEntryAt)} />
+                    </section>
+
+                    {entries.data && entries.data.entries.length > 0 ? (
+                      <>
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>When</TableHead>
+                              <TableHead>Type</TableHead>
+                              <TableHead>Amount</TableHead>
+                              <TableHead>Ref</TableHead>
+                              <TableHead>Idempotency key</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {entries.data.entries.map((row) => (
+                              <TableRow key={row.id} data-testid={`ledger-entry-${row.id}`}>
+                                <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                                  {formatDateTime(row.createdAt)}
+                                </TableCell>
+                                <TableCell>
+                                  <Badge variant={row.type === "credit" ? "success" : "secondary"}>{row.type}</Badge>
+                                </TableCell>
+                                <TableCell className="font-mono">{row.amount}</TableCell>
+                                <TableCell className="font-mono text-xs" title={row.refId}>
+                                  {shorten(row.refId)}
+                                </TableCell>
+                                <TableCell className="font-mono text-xs" title={row.idempotencyKey}>
+                                  {shorten(row.idempotencyKey, 18, 8)}
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                        {entries.data.nextCursor ? (
+                          <Button
+                            className="mt-3"
+                            variant="outline"
+                            data-testid="ledger-next-page"
+                            onClick={() => setCursor(entries.data?.nextCursor ?? undefined)}
+                          >
+                            Next page
+                          </Button>
+                        ) : null}
+                      </>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">No ledger entries for this account.</p>
+                    )}
+                  </QueryBoundary>
+                ) : (
+                  <p className="text-sm text-muted-foreground">Enter an app id and user id to load a statement.</p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Reconciliation</CardTitle>
+                <CardDescription>
+                  Cross-checks settled tips against credits, completed withdrawals against debits, negative balances,
+                  and duplicate references over the last 30 days.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <form
+                  className="mb-4 flex flex-wrap items-end gap-3"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    setReconcileArgs(reconcileAppId.trim() ? { appId: reconcileAppId.trim() } : {});
+                  }}
+                >
+                  <div className="w-44">
+                    <Label htmlFor="reconcile-app" className="mb-1 block text-xs text-muted-foreground">
+                      App (optional)
+                    </Label>
+                    <Input
+                      id="reconcile-app"
+                      value={reconcileAppId}
+                      onChange={(event) => setReconcileAppId(event.target.value)}
+                    />
+                  </div>
+                  <Button type="submit" data-testid="ledger-run-reconcile">
+                    Run reconciliation
+                  </Button>
+                </form>
+
+                {reconcileArgs !== null ? (
+                  <QueryBoundary isLoading={reconcile.isLoading} error={reconcile.error}>
+                    {reconcile.data ? (
+                      <div className="space-y-4" data-testid="ledger-reconcile-report">
+                        <section className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                          <StatCard
+                            label="Anomalies"
+                            value={anomalyCount}
+                            tone={anomalyCount > 0 ? "danger" : "success"}
+                          />
+                          <StatCard label="Tips checked" value={reconcile.data.checked.tipIntents} />
+                          <StatCard label="Withdrawals checked" value={reconcile.data.checked.withdrawals} />
+                          <StatCard label="Entries checked" value={reconcile.data.checked.entries} />
+                        </section>
+                        <p className="text-xs text-muted-foreground">
+                          Window {formatDateTime(reconcile.data.window.from)} →{" "}
+                          {formatDateTime(reconcile.data.window.to)}
+                          {reconcile.data.truncated ? " — row cap reached, narrow the window for a complete pass." : ""}
+                        </p>
+                        {anomalyCount > 0 ? (
+                          <Table>
+                            <TableHeader>
+                              <TableRow>
+                                <TableHead>Kind</TableHead>
+                                <TableHead>Detail</TableHead>
+                                <TableHead>Example entries</TableHead>
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                              {reconcile.data.anomalies.map((anomaly, index) => (
+                                <TableRow key={`${anomaly.kind}-${anomaly.refId ?? index}`}>
+                                  <TableCell>
+                                    <Badge variant="destructive">{anomaly.kind}</Badge>
+                                  </TableCell>
+                                  <TableCell className="text-xs">{anomaly.detail}</TableCell>
+                                  <TableCell className="font-mono text-xs">
+                                    {(anomaly.entryIds ?? [])
+                                      .slice(0, 3)
+                                      .map((id) => shorten(id))
+                                      .join(", ") || "—"}
+                                  </TableCell>
+                                </TableRow>
+                              ))}
+                            </TableBody>
+                          </Table>
+                        ) : (
+                          <p className="text-sm text-muted-foreground">No anomalies detected in the window.</p>
+                        )}
+                      </div>
+                    ) : null}
+                  </QueryBoundary>
+                ) : (
+                  <p className="text-sm text-muted-foreground">Run a reconciliation pass to see the report.</p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </RoleGate>
+      </QueryBoundary>
+    </div>
+  );
+}

--- a/fiber-link-service/apps/admin/src/server/api/root.ts
+++ b/fiber-link-service/apps/admin/src/server/api/root.ts
@@ -1,4 +1,5 @@
 import { appsRouter } from "./routers/apps";
+import { ledgerRouter } from "./routers/ledger";
 import { opsRouter } from "./routers/ops";
 import { sessionRouter } from "./routers/session";
 import { settlementsRouter } from "./routers/settlements";
@@ -12,6 +13,7 @@ export const appRouter = router({
   withdrawals: withdrawalsRouter,
   withdrawalPolicy: withdrawalPolicyRouter,
   settlements: settlementsRouter,
+  ledger: ledgerRouter,
   ops: opsRouter,
 });
 

--- a/fiber-link-service/apps/admin/src/server/api/routers.test.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers.test.ts
@@ -49,6 +49,35 @@ function fixture(): DashboardFixture {
         createdAt: "2026-03-18T00:01:00.000Z",
       },
     ],
+    ledgerEntries: [
+      {
+        id: "le-1",
+        appId: "app-alpha",
+        userId: "author-1",
+        amount: "100",
+        type: "credit",
+        refId: "lnfib1settledalpha",
+        createdAt: "2026-03-18T00:11:00.000Z",
+      },
+      {
+        id: "le-2",
+        appId: "app-alpha",
+        userId: "author-1",
+        amount: "30",
+        type: "debit",
+        refId: "w-orphan",
+        createdAt: "2026-03-18T00:12:00.000Z",
+      },
+      {
+        id: "le-3",
+        appId: "app-beta",
+        userId: "author-9",
+        amount: "5",
+        type: "credit",
+        refId: "tip-unknown",
+        createdAt: "2026-03-18T00:13:00.000Z",
+      },
+    ],
     communityAdminAppIds: ["app-alpha"],
     backupBundles: [
       {
@@ -250,6 +279,80 @@ describe("settlement investigation workflow (#470)", () => {
     await expect(caller.settlements.addOpsNote({ invoice: "lnfib1unpaidalpha", note: "  " })).rejects.toMatchObject({
       code: "BAD_REQUEST",
     });
+  });
+});
+
+describe("ledger reconciliation and balance explanation (#471)", () => {
+  it("pages the ledger statement with an opaque keyset cursor", async () => {
+    const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
+
+    const firstPage = await caller.ledger.entries({ appId: "app-alpha", userId: "author-1", limit: 1 });
+    expect(firstPage.entries.map((entry) => entry.id)).toEqual(["le-2"]);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const secondPage = await caller.ledger.entries({
+      appId: "app-alpha",
+      userId: "author-1",
+      limit: 1,
+      cursor: firstPage.nextCursor ?? undefined,
+    });
+    expect(secondPage.entries.map((entry) => entry.id)).toEqual(["le-1"]);
+    expect(secondPage.nextCursor).toBeNull();
+
+    const credits = await caller.ledger.entries({ appId: "app-alpha", type: "credit" });
+    expect(credits.entries).toHaveLength(1);
+
+    await expect(caller.ledger.entries({ appId: "app-alpha", asset: "DOGE" } as never)).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+    await expect(caller.ledger.entries({ appId: "app-alpha", cursor: "not-a-cursor" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("explains a balance from source credits and debits", async () => {
+    const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
+    const breakdown = await caller.ledger.balanceBreakdown({ appId: "app-alpha", userId: "author-1", asset: "CKB" });
+    expect(breakdown).toMatchObject({
+      balance: "70",
+      creditTotal: "100",
+      debitTotal: "30",
+      creditCount: 1,
+      debitCount: 1,
+    });
+    expect(breakdown.firstEntryAt).toBe("2026-03-18T00:11:00.000Z");
+  });
+
+  it("reports anomaly counts and example entry ids from reconciliation", async () => {
+    const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
+    const report = await caller.ledger.reconcile({});
+
+    expect(report.countsByKind.DEBIT_WITHOUT_COMPLETED_WITHDRAWAL).toBe(1);
+    expect(report.countsByKind.CREDIT_WITHOUT_SETTLED_TIP).toBe(1);
+    expect(report.countsByKind.SETTLED_TIP_MISSING_CREDIT).toBe(0);
+    expect(report.anomalies).toHaveLength(2);
+
+    const orphanDebit = report.anomalies.find((anomaly) => anomaly.kind === "DEBIT_WITHOUT_COMPLETED_WITHDRAWAL");
+    expect(orphanDebit?.entryIds).toEqual(["le-2"]);
+
+    // The settled tip (with its matching credit) and the FAILED withdrawal are clean.
+    expect(report.checked.tipIntents).toBe(2);
+    expect(report.checked.withdrawals).toBe(1);
+
+    const scopedToAlpha = await caller.ledger.reconcile({ appId: "app-alpha" });
+    expect(scopedToAlpha.anomalies).toHaveLength(1);
+    expect(scopedToAlpha.anomalies[0]?.kind).toBe("DEBIT_WITHOUT_COMPLETED_WITHDRAWAL");
+
+    await expect(
+      caller.ledger.reconcile({ from: "2026-03-19T00:00:00.000Z", to: "2026-03-18T00:00:00.000Z" }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("denies ledger procedures to COMMUNITY_ADMIN and anonymous callers", async () => {
+    await expect(
+      createCaller(ctxFor("COMMUNITY_ADMIN", "c1")).ledger.entries({ appId: "app-alpha" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    await expect(createCaller(ctxFor(undefined)).ledger.reconcile({})).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });
 

--- a/fiber-link-service/apps/admin/src/server/api/routers/ledger.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/ledger.ts
@@ -1,0 +1,124 @@
+import { TRPCError } from "@trpc/server";
+import type { AdminLedgerFilters, AdminLedgerReconcileParams } from "../../services/types";
+import { LEDGER_PAGE_MAX_LIMIT, decodeLedgerCursor } from "../../services/types";
+import { router, superAdminProcedure } from "../trpc";
+
+const ASSETS = new Set(["CKB", "USDI"]);
+const ENTRY_TYPES = new Set(["credit", "debit"]);
+
+function requireString(raw: Record<string, unknown>, key: string): string {
+  const value = typeof raw[key] === "string" ? (raw[key] as string).trim() : "";
+  if (!value) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: `${key} is required` });
+  }
+  return value;
+}
+
+function optionalEnum(raw: Record<string, unknown>, key: string, allowed: Set<string>): string | undefined {
+  const value = typeof raw[key] === "string" ? (raw[key] as string).trim() : "";
+  if (!value) {
+    return undefined;
+  }
+  if (!allowed.has(value)) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: `unknown ${key}: ${value}` });
+  }
+  return value;
+}
+
+function asRecord(input: unknown): Record<string, unknown> {
+  if (typeof input !== "object" || input === null) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "invalid ledger input" });
+  }
+  return input as Record<string, unknown>;
+}
+
+function parseEntriesInput(input: unknown): AdminLedgerFilters {
+  const raw = asRecord(input);
+  const filters: AdminLedgerFilters = { appId: requireString(raw, "appId") };
+
+  if (typeof raw.userId === "string" && raw.userId.trim()) {
+    filters.userId = raw.userId.trim();
+  }
+  const asset = optionalEnum(raw, "asset", ASSETS);
+  if (asset) {
+    filters.asset = asset as "CKB" | "USDI";
+  }
+  const type = optionalEnum(raw, "type", ENTRY_TYPES);
+  if (type) {
+    filters.type = type as "credit" | "debit";
+  }
+  if (raw.limit !== undefined) {
+    const limit = Number(raw.limit);
+    if (!Number.isInteger(limit) || limit < 1 || limit > LEDGER_PAGE_MAX_LIMIT) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `limit must be an integer in [1, ${LEDGER_PAGE_MAX_LIMIT}]`,
+      });
+    }
+    filters.limit = limit;
+  }
+  if (typeof raw.cursor === "string" && raw.cursor.trim()) {
+    const after = decodeLedgerCursor(raw.cursor.trim());
+    if (!after) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "invalid cursor" });
+    }
+    filters.after = after;
+  }
+  return filters;
+}
+
+function parseBreakdownInput(input: unknown): { appId: string; userId: string; asset: "CKB" | "USDI" } {
+  const raw = asRecord(input);
+  const asset = optionalEnum(raw, "asset", ASSETS);
+  if (!asset) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "asset is required" });
+  }
+  return {
+    appId: requireString(raw, "appId"),
+    userId: requireString(raw, "userId"),
+    asset: asset as "CKB" | "USDI",
+  };
+}
+
+function parseReconcileInput(input: unknown): AdminLedgerReconcileParams {
+  if (input === undefined || input === null) {
+    return {};
+  }
+  const raw = asRecord(input);
+  const params: AdminLedgerReconcileParams = {};
+
+  if (typeof raw.appId === "string" && raw.appId.trim()) {
+    params.appId = raw.appId.trim();
+  }
+  for (const key of ["from", "to"] as const) {
+    const value = typeof raw[key] === "string" ? (raw[key] as string).trim() : "";
+    if (!value) {
+      continue;
+    }
+    if (Number.isNaN(new Date(value).getTime())) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: `${key} must be an ISO timestamp` });
+    }
+    params[key] = value;
+  }
+  if (params.from && params.to && new Date(params.from).getTime() > new Date(params.to).getTime()) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "from must not be after to" });
+  }
+  return params;
+}
+
+export const ledgerRouter = router({
+  /** Paginated ledger statement for one app account. */
+  entries: superAdminProcedure.input(parseEntriesInput).query(async ({ ctx, input }) => {
+    return ctx.services.listLedgerEntries(ctx.scope, input);
+  }),
+
+  /** Explain a balance from its source credits/debits. */
+  balanceBreakdown: superAdminProcedure.input(parseBreakdownInput).query(async ({ ctx, input }) => {
+    return ctx.services.getLedgerBalanceBreakdown(ctx.scope, input);
+  }),
+
+  /** Cross-check tips/withdrawals against ledger entries inside a window. */
+  reconcile: superAdminProcedure.input(parseReconcileInput).query(async ({ ctx, input }) => {
+    return ctx.services.reconcileLedger(ctx.scope, input);
+  }),
+});

--- a/fiber-link-service/apps/admin/src/server/services/db-services.ts
+++ b/fiber-link-service/apps/admin/src/server/services/db-services.ts
@@ -1,16 +1,23 @@
 import {
   type DbClient,
+  type LedgerReconciliationEntry,
+  type LedgerReconciliationTipIntent,
+  type LedgerReconciliationWithdrawal,
   TipIntentNotFoundError,
   type TipIntentRecord,
   type WithdrawalState,
   createDbAdminAuditRepo,
   createDbClient,
+  createDbLedgerRepo,
   createDbTipIntentEventRepo,
   createDbTipIntentRepo,
+  ledgerEntries,
+  reconcileLedger,
+  tipIntents,
   withdrawalPolicies,
   withdrawals,
 } from "@fiber-link/db";
-import { inArray, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import {
   type DashboardApp,
   type DashboardBackupBundle,
@@ -38,15 +45,28 @@ import {
 } from "../dashboard-rate-limit";
 import { PolicyScopeError, SettlementNotFoundError, SettlementRetryStateError, UnknownAppError } from "./errors";
 import {
+  type AdminLedgerBalanceBreakdown,
+  type AdminLedgerFilters,
+  type AdminLedgerPage,
+  type AdminLedgerReconcileParams,
+  type AdminLedgerReconciliationResult,
   type AdminScope,
   type AdminServices,
   type AdminSettlementIntent,
   type AdminSettlementTimeline,
   type AdminWithdrawal,
   type AdminWithdrawalFilters,
+  LEDGER_PAGE_DEFAULT_LIMIT,
+  LEDGER_PAGE_MAX_LIMIT,
   SETTLEMENT_LIST_LIMIT,
   WITHDRAWAL_LIST_LIMIT,
+  encodeLedgerCursor,
 } from "./types";
+
+/** Per-source row cap for one reconciliation pass; the report flags truncation. */
+const RECONCILE_MAX_ROWS = 2000;
+/** Default reconciliation window when `from` is omitted. */
+const RECONCILE_DEFAULT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
 const APP_COLUMNS = { appId: true, createdAt: true } as const;
 
@@ -130,6 +150,7 @@ export function createDbAdminServices(db: DbClient = createDbClient()): AdminSer
   const auditRepo = createDbAdminAuditRepo(db);
   const tipIntentRepo = createDbTipIntentRepo(db);
   const tipIntentEventRepo = createDbTipIntentEventRepo(db);
+  const ledgerRepo = createDbLedgerRepo(db);
 
   /** Resolve an in-scope tip intent or collapse to "not found" (no probing). */
   async function findScopedTipIntent(scope: AdminScope, invoice: string): Promise<TipIntentRecord> {
@@ -404,6 +425,243 @@ export function createDbAdminServices(db: DbClient = createDbClient()): AdminSer
       }
       const updated = await tipIntentRepo.clearSettlementFailure(invoice, { now: new Date() });
       return toSettlementIntent(updated);
+    },
+
+    async listLedgerEntries(scope, filters: AdminLedgerFilters): Promise<AdminLedgerPage> {
+      const scoped = await resolveScopedAppIds(db, scope);
+      if (scoped !== "ALL" && !scoped.includes(filters.appId)) {
+        return { entries: [], nextCursor: null };
+      }
+
+      const limit = Math.min(Math.max(filters.limit ?? LEDGER_PAGE_DEFAULT_LIMIT, 1), LEDGER_PAGE_MAX_LIMIT);
+      const rows = await ledgerRepo.listEntries({
+        appId: filters.appId,
+        userId: filters.userId,
+        asset: filters.asset,
+        type: filters.type,
+        // Fetch one extra row purely to detect whether a next page exists.
+        limit: limit + 1,
+        after: filters.after ? { createdAt: new Date(filters.after.createdAt), id: filters.after.id } : undefined,
+      });
+
+      const page = rows.slice(0, limit);
+      const last = page[page.length - 1];
+      return {
+        entries: page.map((row) => ({
+          id: row.id,
+          appId: row.appId,
+          userId: row.userId,
+          asset: row.asset,
+          amount: row.amount,
+          type: row.type,
+          refId: row.refId,
+          idempotencyKey: row.idempotencyKey,
+          createdAt: row.createdAt.toISOString(),
+        })),
+        nextCursor:
+          rows.length > limit && last
+            ? encodeLedgerCursor({ createdAt: last.createdAt.toISOString(), id: last.id })
+            : null,
+      };
+    },
+
+    async getLedgerBalanceBreakdown(scope, params): Promise<AdminLedgerBalanceBreakdown> {
+      const scoped = await resolveScopedAppIds(db, scope);
+      if (scoped !== "ALL" && !scoped.includes(params.appId)) {
+        // Out-of-scope apps read as empty accounts rather than existence oracles.
+        return {
+          appId: params.appId,
+          userId: params.userId,
+          asset: params.asset,
+          balance: "0",
+          creditTotal: "0",
+          debitTotal: "0",
+          creditCount: 0,
+          debitCount: 0,
+          firstEntryAt: null,
+          lastEntryAt: null,
+        };
+      }
+
+      const breakdown = await ledgerRepo.getBalanceBreakdown(params);
+      return {
+        ...breakdown,
+        firstEntryAt: isoOrNull(breakdown.firstEntryAt),
+        lastEntryAt: isoOrNull(breakdown.lastEntryAt),
+      };
+    },
+
+    async reconcileLedger(scope, params: AdminLedgerReconcileParams): Promise<AdminLedgerReconciliationResult> {
+      const scoped = await resolveScopedAppIds(db, scope);
+      const to = params.to ? new Date(params.to) : new Date();
+      const from = params.from ? new Date(params.from) : new Date(to.getTime() - RECONCILE_DEFAULT_WINDOW_MS);
+      const window = { from: from.toISOString(), to: to.toISOString() };
+
+      const outOfScope = scoped !== "ALL" && (params.appId ? !scoped.includes(params.appId) : scoped.length === 0);
+      if (outOfScope) {
+        // Out-of-scope apps read as an empty (clean) report rather than an
+        // existence oracle for other communities' data.
+        return {
+          ...reconcileLedger({ tipIntents: [], withdrawals: [], entries: [] }),
+          window,
+          truncated: false,
+        };
+      }
+
+      const appClauses = (column: typeof tipIntents.appId | typeof withdrawals.appId | typeof ledgerEntries.appId) => {
+        const clauses = [];
+        if (params.appId) {
+          clauses.push(eq(column, params.appId));
+        } else if (scoped !== "ALL") {
+          clauses.push(inArray(column, scoped));
+        }
+        return clauses;
+      };
+
+      const [tipRows, withdrawalRows, entryRowsInWindow] = await Promise.all([
+        db
+          .select({
+            id: tipIntents.id,
+            appId: tipIntents.appId,
+            toUserId: tipIntents.toUserId,
+            asset: tipIntents.asset,
+            amount: tipIntents.amount,
+            invoiceState: tipIntents.invoiceState,
+          })
+          .from(tipIntents)
+          .where(and(gte(tipIntents.createdAt, from), lte(tipIntents.createdAt, to), ...appClauses(tipIntents.appId)))
+          .limit(RECONCILE_MAX_ROWS),
+        db
+          .select({
+            id: withdrawals.id,
+            appId: withdrawals.appId,
+            userId: withdrawals.userId,
+            asset: withdrawals.asset,
+            amount: withdrawals.amount,
+            state: withdrawals.state,
+          })
+          .from(withdrawals)
+          .where(
+            and(gte(withdrawals.createdAt, from), lte(withdrawals.createdAt, to), ...appClauses(withdrawals.appId)),
+          )
+          .limit(RECONCILE_MAX_ROWS),
+        db
+          .select()
+          .from(ledgerEntries)
+          .where(
+            and(
+              gte(ledgerEntries.createdAt, from),
+              lte(ledgerEntries.createdAt, to),
+              ...appClauses(ledgerEntries.appId),
+            ),
+          )
+          .limit(RECONCILE_MAX_ROWS),
+      ]);
+
+      // Ledger writes can land slightly outside the window that produced the
+      // tip/withdrawal row (and vice versa), so pull the rows referenced by
+      // what we already have before classifying. Otherwise boundary rows show
+      // up as false "missing credit"/"unknown reference" anomalies.
+      const knownRefIds = [...tipRows.map((row) => row.id), ...withdrawalRows.map((row) => row.id)];
+      const extraEntryRows =
+        knownRefIds.length > 0
+          ? await db
+              .select()
+              .from(ledgerEntries)
+              .where(inArray(ledgerEntries.refId, knownRefIds))
+              .limit(RECONCILE_MAX_ROWS)
+          : [];
+
+      const entryById = new Map(
+        [...entryRowsInWindow, ...extraEntryRows].map((row) => [
+          row.id,
+          {
+            id: row.id,
+            appId: row.appId,
+            userId: row.userId,
+            asset: row.asset,
+            amount: typeof row.amount === "string" ? row.amount : String(row.amount),
+            type: row.type,
+            refId: row.refId,
+          } satisfies LedgerReconciliationEntry,
+        ]),
+      );
+      const entries = Array.from(entryById.values());
+
+      const tipIds = new Set(tipRows.map((row) => row.id));
+      const withdrawalIds = new Set(withdrawalRows.map((row) => row.id));
+      const creditRefIds = entries
+        .filter((entry) => entry.type === "credit" && !tipIds.has(entry.refId))
+        .map((entry) => entry.refId);
+      const debitRefIds = entries
+        .filter((entry) => entry.type === "debit" && !withdrawalIds.has(entry.refId))
+        .map((entry) => entry.refId);
+
+      const [extraTipRows, extraWithdrawalRows] = await Promise.all([
+        creditRefIds.length > 0
+          ? db
+              .select({
+                id: tipIntents.id,
+                appId: tipIntents.appId,
+                toUserId: tipIntents.toUserId,
+                asset: tipIntents.asset,
+                amount: tipIntents.amount,
+                invoiceState: tipIntents.invoiceState,
+              })
+              .from(tipIntents)
+              .where(inArray(tipIntents.id, creditRefIds))
+              .limit(RECONCILE_MAX_ROWS)
+          : Promise.resolve([]),
+        debitRefIds.length > 0
+          ? db
+              .select({
+                id: withdrawals.id,
+                appId: withdrawals.appId,
+                userId: withdrawals.userId,
+                asset: withdrawals.asset,
+                amount: withdrawals.amount,
+                state: withdrawals.state,
+              })
+              .from(withdrawals)
+              .where(inArray(withdrawals.id, debitRefIds))
+              .limit(RECONCILE_MAX_ROWS)
+          : Promise.resolve([]),
+      ]);
+
+      const toTip = (row: (typeof tipRows)[number]): LedgerReconciliationTipIntent => ({
+        id: row.id,
+        appId: row.appId,
+        toUserId: row.toUserId,
+        asset: row.asset,
+        amount: typeof row.amount === "string" ? row.amount : String(row.amount),
+        invoiceState: row.invoiceState,
+      });
+      const toWithdrawal = (row: (typeof withdrawalRows)[number]): LedgerReconciliationWithdrawal => ({
+        id: row.id,
+        appId: row.appId,
+        userId: row.userId,
+        asset: row.asset,
+        amount: typeof row.amount === "string" ? row.amount : String(row.amount),
+        state: row.state,
+      });
+
+      const report = reconcileLedger({
+        tipIntents: [...tipRows, ...extraTipRows].map(toTip),
+        withdrawals: [...withdrawalRows, ...extraWithdrawalRows].map(toWithdrawal),
+        entries,
+      });
+
+      const truncated =
+        tipRows.length >= RECONCILE_MAX_ROWS ||
+        withdrawalRows.length >= RECONCILE_MAX_ROWS ||
+        entryRowsInWindow.length >= RECONCILE_MAX_ROWS ||
+        extraEntryRows.length >= RECONCILE_MAX_ROWS;
+
+      return {
+        ...report,
+        window,
+        truncated,
+      };
     },
 
     async loadMonitoringSummary(): Promise<DashboardMonitoringSummary> {

--- a/fiber-link-service/apps/admin/src/server/services/fixture-services.ts
+++ b/fiber-link-service/apps/admin/src/server/services/fixture-services.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { reconcileLedger } from "@fiber-link/db";
 import {
   type DashboardApp,
   type DashboardBackupBundle,
@@ -14,14 +15,18 @@ import { buildDashboardRateLimitChangeSet, parseDashboardRateLimitInput } from "
 import { PolicyScopeError, SettlementNotFoundError, SettlementRetryStateError, UnknownAppError } from "./errors";
 import {
   type AdminAuditEventInput,
+  type AdminLedgerEntry,
   type AdminScope,
   type AdminServices,
   type AdminSettlementEvent,
   type AdminSettlementIntent,
   type AdminWithdrawal,
   type AdminWithdrawalFilters,
+  LEDGER_PAGE_DEFAULT_LIMIT,
+  LEDGER_PAGE_MAX_LIMIT,
   SETTLEMENT_LIST_LIMIT,
   WITHDRAWAL_LIST_LIMIT,
+  encodeLedgerCursor,
 } from "./types";
 
 /**
@@ -38,11 +43,16 @@ export type DashboardFixtureSettlement = Partial<AdminSettlementIntent> &
     events?: Array<Partial<AdminSettlementEvent> & Pick<AdminSettlementEvent, "type">>;
   };
 
+/** Ledger fixture rows only need the accounting identity; timestamps default. */
+export type DashboardFixtureLedgerEntry = Partial<AdminLedgerEntry> &
+  Pick<AdminLedgerEntry, "id" | "appId" | "userId" | "amount" | "type" | "refId">;
+
 export type DashboardFixture = {
   apps: DashboardApp[];
   withdrawals: Array<DashboardWithdrawal & Partial<AdminWithdrawal>>;
   policies: DashboardWithdrawalPolicy[];
   settlements?: DashboardFixtureSettlement[];
+  ledgerEntries?: DashboardFixtureLedgerEntry[];
   communityAdminAppIds?: string[];
   monitoringSummary?: DashboardMonitoringSummary;
   rateLimitConfig?: DashboardRateLimitConfig;
@@ -106,6 +116,20 @@ function toFixtureSettlement(row: DashboardFixtureSettlement): {
   };
 }
 
+function toFixtureLedgerEntry(row: DashboardFixtureLedgerEntry): AdminLedgerEntry {
+  return {
+    id: row.id,
+    appId: row.appId,
+    userId: row.userId,
+    asset: row.asset ?? "CKB",
+    amount: row.amount,
+    type: row.type,
+    refId: row.refId,
+    idempotencyKey: row.idempotencyKey ?? `fixture:${row.type}:${row.refId}`,
+    createdAt: row.createdAt ?? "2026-03-18T00:00:00.000Z",
+  };
+}
+
 function buildDefaultMonitoringSummary(): DashboardMonitoringSummary {
   return {
     status: "ok",
@@ -137,6 +161,7 @@ export function createFixtureAdminServices(fixture: DashboardFixture): AdminServ
     withdrawals: fixture.withdrawals.map(toAdminWithdrawal),
     policies: new Map(fixture.policies.map((policy) => [policy.appId, { ...policy }])),
     settlements: (fixture.settlements ?? []).map(toFixtureSettlement),
+    ledgerEntries: (fixture.ledgerEntries ?? []).map(toFixtureLedgerEntry),
     monitoringSummary: fixture.monitoringSummary ? { ...fixture.monitoringSummary } : buildDefaultMonitoringSummary(),
     rateLimitConfig: fixture.rateLimitConfig ? { ...fixture.rateLimitConfig } : buildDefaultRateLimitConfig(),
     backupBundles: (fixture.backupBundles ?? []).map((bundle) => ({ ...bundle })),
@@ -257,6 +282,101 @@ export function createFixtureAdminServices(fixture: DashboardFixture): AdminServ
       row.intent.settlementFailureReason = null;
       row.intent.settlementLastCheckedAt = new Date().toISOString();
       return { ...row.intent };
+    },
+    async listLedgerEntries(scope, filters) {
+      if (!inScope(scope, filters.appId)) {
+        return { entries: [], nextCursor: null };
+      }
+      const limit = Math.min(Math.max(filters.limit ?? LEDGER_PAGE_DEFAULT_LIMIT, 1), LEDGER_PAGE_MAX_LIMIT);
+      let items = snapshot.ledgerEntries.filter((row) => row.appId === filters.appId);
+      if (filters.userId) {
+        items = items.filter((row) => row.userId === filters.userId);
+      }
+      if (filters.asset) {
+        items = items.filter((row) => row.asset === filters.asset);
+      }
+      if (filters.type) {
+        items = items.filter((row) => row.type === filters.type);
+      }
+      items = items.slice().sort((a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id));
+      const after = filters.after;
+      if (after) {
+        items = items.filter(
+          (row) => row.createdAt < after.createdAt || (row.createdAt === after.createdAt && row.id < after.id),
+        );
+      }
+      const page = items.slice(0, limit);
+      const last = page[page.length - 1];
+      return {
+        entries: page.map((row) => ({ ...row })),
+        nextCursor:
+          items.length > limit && last ? encodeLedgerCursor({ createdAt: last.createdAt, id: last.id }) : null,
+      };
+    },
+    async getLedgerBalanceBreakdown(scope, params) {
+      const relevant = inScope(scope, params.appId)
+        ? snapshot.ledgerEntries.filter(
+            (row) => row.appId === params.appId && row.userId === params.userId && row.asset === params.asset,
+          )
+        : [];
+      const credits = relevant.filter((row) => row.type === "credit");
+      const debits = relevant.filter((row) => row.type === "debit");
+      const total = (rows: AdminLedgerEntry[]) => rows.reduce((acc, row) => acc + Number(row.amount), 0);
+      const timestamps = relevant.map((row) => row.createdAt).sort();
+      return {
+        appId: params.appId,
+        userId: params.userId,
+        asset: params.asset,
+        balance: String(total(credits) - total(debits)),
+        creditTotal: String(total(credits)),
+        debitTotal: String(total(debits)),
+        creditCount: credits.length,
+        debitCount: debits.length,
+        firstEntryAt: timestamps[0] ?? null,
+        lastEntryAt: timestamps[timestamps.length - 1] ?? null,
+      };
+    },
+    async reconcileLedger(scope, params) {
+      const now = new Date();
+      const window = {
+        from: params.from ?? new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+        to: params.to ?? now.toISOString(),
+      };
+      const appMatches = (appId: string) => inScope(scope, appId) && (params.appId ? appId === params.appId : true);
+      const report = reconcileLedger({
+        tipIntents: snapshot.settlements
+          .filter((row) => appMatches(row.intent.appId))
+          .map((row) => ({
+            id: row.intent.id,
+            appId: row.intent.appId,
+            toUserId: row.intent.toUserId,
+            asset: row.intent.asset,
+            amount: row.intent.amount,
+            invoiceState: row.intent.invoiceState,
+          })),
+        withdrawals: snapshot.withdrawals
+          .filter((row) => appMatches(row.appId))
+          .map((row) => ({
+            id: row.id,
+            appId: row.appId,
+            userId: row.userId,
+            asset: row.asset,
+            amount: row.amount,
+            state: row.state,
+          })),
+        entries: snapshot.ledgerEntries
+          .filter((row) => appMatches(row.appId))
+          .map((row) => ({
+            id: row.id,
+            appId: row.appId,
+            userId: row.userId,
+            asset: row.asset,
+            amount: row.amount,
+            type: row.type,
+            refId: row.refId,
+          })),
+      });
+      return { ...report, window, truncated: false };
     },
     async loadMonitoringSummary() {
       return { ...snapshot.monitoringSummary };

--- a/fiber-link-service/apps/admin/src/server/services/types.ts
+++ b/fiber-link-service/apps/admin/src/server/services/types.ts
@@ -1,4 +1,4 @@
-import type { InvoiceState, UserRole, WithdrawalState } from "@fiber-link/db";
+import type { InvoiceState, LedgerReconciliationReport, UserRole, WithdrawalState } from "@fiber-link/db";
 import type {
   DashboardApp,
   DashboardBackupBundle,
@@ -124,6 +124,90 @@ export type AdminSettlementFilters = {
   appId?: string;
 };
 
+/** Ledger statement page size bounds; +1 row is fetched internally to detect more pages. */
+export const LEDGER_PAGE_DEFAULT_LIMIT = 50;
+export const LEDGER_PAGE_MAX_LIMIT = 100;
+
+export type AdminLedgerEntry = {
+  id: string;
+  appId: string;
+  userId: string;
+  asset: "CKB" | "USDI";
+  amount: string;
+  type: "credit" | "debit";
+  refId: string;
+  idempotencyKey: string;
+  createdAt: string;
+};
+
+export type AdminLedgerCursor = {
+  createdAt: string;
+  id: string;
+};
+
+export type AdminLedgerFilters = {
+  appId: string;
+  userId?: string;
+  asset?: "CKB" | "USDI";
+  type?: "credit" | "debit";
+  limit?: number;
+  /** Opaque cursor as sent over the wire; the router decodes it into `after`. */
+  cursor?: string;
+  after?: AdminLedgerCursor;
+};
+
+export type AdminLedgerPage = {
+  entries: AdminLedgerEntry[];
+  /** Opaque keyset cursor for the next page, or null when exhausted. */
+  nextCursor: string | null;
+};
+
+export type AdminLedgerBalanceBreakdown = {
+  appId: string;
+  userId: string;
+  asset: "CKB" | "USDI";
+  balance: string;
+  creditTotal: string;
+  debitTotal: string;
+  creditCount: number;
+  debitCount: number;
+  firstEntryAt: string | null;
+  lastEntryAt: string | null;
+};
+
+export type AdminLedgerReconcileParams = {
+  appId?: string;
+  /** ISO timestamps; default window is the last 30 days ending now. */
+  from?: string;
+  to?: string;
+};
+
+export type AdminLedgerReconciliationResult = LedgerReconciliationReport & {
+  window: { from: string; to: string };
+  /** True when any source query hit its row cap; narrow the window to get a complete pass. */
+  truncated: boolean;
+};
+
+/** Opaque, URL-safe encoding of the keyset cursor. */
+export function encodeLedgerCursor(cursor: AdminLedgerCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+export function decodeLedgerCursor(raw: string): AdminLedgerCursor | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8")) as Partial<AdminLedgerCursor>;
+    if (typeof parsed.createdAt !== "string" || typeof parsed.id !== "string") {
+      return null;
+    }
+    if (Number.isNaN(new Date(parsed.createdAt).getTime())) {
+      return null;
+    }
+    return { createdAt: parsed.createdAt, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * The seam every admin tRPC router depends on. The real implementation
  * (`createDbAdminServices`) queries Postgres through the `@fiber-link/db`
@@ -167,6 +251,16 @@ export interface AdminServices {
    * and FAILED are terminal); throws `SettlementRetryStateError` otherwise.
    */
   retrySettlementNow(scope: AdminScope, invoice: string): Promise<AdminSettlementIntent>;
+
+  /** Paginated ledger statement for one app (optionally narrowed to user/asset/type). */
+  listLedgerEntries(scope: AdminScope, filters: AdminLedgerFilters): Promise<AdminLedgerPage>;
+  /** Explain one account's balance from its source credits and debits. */
+  getLedgerBalanceBreakdown(
+    scope: AdminScope,
+    params: { appId: string; userId: string; asset: "CKB" | "USDI" },
+  ): Promise<AdminLedgerBalanceBreakdown>;
+  /** Cross-check tips/withdrawals against ledger entries inside a time window. */
+  reconcileLedger(scope: AdminScope, params: AdminLedgerReconcileParams): Promise<AdminLedgerReconciliationResult>;
 
   loadMonitoringSummary(): Promise<DashboardMonitoringSummary>;
   loadRateLimitConfig(): Promise<DashboardRateLimitConfig>;

--- a/fiber-link-service/packages/db/src/index.ts
+++ b/fiber-link-service/packages/db/src/index.ts
@@ -7,6 +7,7 @@ export * from "./liquidity-request-repo";
 export * from "./tip-intent-repo";
 export * from "./tip-intent-event-repo";
 export * from "./ledger-repo";
+export * from "./ledger-reconciliation";
 export * from "./amount";
 export * from "./retry";
 export * from "./analytics-repo";

--- a/fiber-link-service/packages/db/src/ledger-reconciliation.test.ts
+++ b/fiber-link-service/packages/db/src/ledger-reconciliation.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  type LedgerReconciliationEntry,
+  type LedgerReconciliationTipIntent,
+  type LedgerReconciliationWithdrawal,
+  reconcileLedger,
+} from "./ledger-reconciliation";
+
+function tip(overrides: Partial<LedgerReconciliationTipIntent> = {}): LedgerReconciliationTipIntent {
+  return {
+    id: "tip-1",
+    appId: "app-1",
+    toUserId: "author-1",
+    asset: "CKB",
+    amount: "100",
+    invoiceState: "SETTLED",
+    ...overrides,
+  };
+}
+
+function withdrawal(overrides: Partial<LedgerReconciliationWithdrawal> = {}): LedgerReconciliationWithdrawal {
+  return {
+    id: "w-1",
+    appId: "app-1",
+    userId: "author-1",
+    asset: "CKB",
+    amount: "40",
+    state: "COMPLETED",
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<LedgerReconciliationEntry> = {}): LedgerReconciliationEntry {
+  return {
+    id: "e-1",
+    appId: "app-1",
+    userId: "author-1",
+    asset: "CKB",
+    amount: "100",
+    type: "credit",
+    refId: "tip-1",
+    ...overrides,
+  };
+}
+
+describe("reconcileLedger", () => {
+  it("reports a clean ledger with zero anomalies", () => {
+    const report = reconcileLedger({
+      tipIntents: [tip()],
+      withdrawals: [withdrawal()],
+      entries: [entry(), entry({ id: "e-2", type: "debit", refId: "w-1", amount: "40" })],
+    });
+
+    expect(report.anomalies).toEqual([]);
+    expect(Object.values(report.countsByKind).every((count) => count === 0)).toBe(true);
+    expect(report.checked).toEqual({ tipIntents: 1, withdrawals: 1, entries: 2, accounts: 1 });
+  });
+
+  it("flags a settled tip without a credit", () => {
+    const report = reconcileLedger({ tipIntents: [tip()], withdrawals: [], entries: [] });
+    expect(report.countsByKind.SETTLED_TIP_MISSING_CREDIT).toBe(1);
+    expect(report.anomalies[0]).toMatchObject({ kind: "SETTLED_TIP_MISSING_CREDIT", refId: "tip-1" });
+  });
+
+  it("does not require credits for UNPAID or FAILED tips", () => {
+    const report = reconcileLedger({
+      tipIntents: [tip({ invoiceState: "UNPAID" }), tip({ id: "tip-2", invoiceState: "FAILED" })],
+      withdrawals: [],
+      entries: [],
+    });
+    expect(report.anomalies).toEqual([]);
+  });
+
+  it("flags a credit whose tip intent is unknown or not settled", () => {
+    const report = reconcileLedger({
+      tipIntents: [tip({ id: "tip-unpaid", invoiceState: "UNPAID" })],
+      withdrawals: [],
+      entries: [entry({ id: "e-orphan", refId: "tip-missing" }), entry({ id: "e-early", refId: "tip-unpaid" })],
+    });
+    expect(report.countsByKind.CREDIT_WITHOUT_SETTLED_TIP).toBe(2);
+    const details = report.anomalies.map((anomaly) => anomaly.detail);
+    expect(details.some((detail) => detail.includes("unknown tip intent tip-missing"))).toBe(true);
+    expect(details.some((detail) => detail.includes("is UNPAID"))).toBe(true);
+    expect(report.anomalies[0].entryIds).toEqual(["e-orphan"]);
+  });
+
+  it("flags a completed or broadcasted withdrawal without a debit", () => {
+    const report = reconcileLedger({
+      tipIntents: [],
+      withdrawals: [
+        withdrawal(),
+        withdrawal({ id: "w-2", state: "BROADCASTED" }),
+        withdrawal({ id: "w-3", state: "PENDING" }),
+      ],
+      entries: [],
+    });
+    expect(report.countsByKind.COMPLETED_WITHDRAWAL_MISSING_DEBIT).toBe(2);
+  });
+
+  it("flags a debit without a completed/broadcasted withdrawal", () => {
+    const report = reconcileLedger({
+      tipIntents: [],
+      withdrawals: [withdrawal({ id: "w-pending", state: "PENDING" })],
+      entries: [
+        entry({ id: "e-orphan", type: "debit", refId: "w-missing", amount: "5" }),
+        entry({ id: "e-early", type: "debit", refId: "w-pending", amount: "5" }),
+      ],
+    });
+    expect(report.countsByKind.DEBIT_WITHOUT_COMPLETED_WITHDRAWAL).toBe(2);
+  });
+
+  it("flags a negative balance account", () => {
+    const report = reconcileLedger({
+      tipIntents: [tip()],
+      withdrawals: [withdrawal({ amount: "150" })],
+      entries: [entry(), entry({ id: "e-2", type: "debit", refId: "w-1", amount: "150" })],
+    });
+    expect(report.countsByKind.NEGATIVE_BALANCE_ACCOUNT).toBe(1);
+    const anomaly = report.anomalies.find((item) => item.kind === "NEGATIVE_BALANCE_ACCOUNT");
+    expect(anomaly?.account).toEqual({ appId: "app-1", userId: "author-1", asset: "CKB" });
+    expect(anomaly?.detail).toContain("-50");
+  });
+
+  it("flags duplicate entries sharing one reference", () => {
+    const report = reconcileLedger({
+      tipIntents: [tip()],
+      withdrawals: [withdrawal()],
+      entries: [
+        entry(),
+        entry({ id: "e-dup" }),
+        entry({ id: "e-3", type: "debit", refId: "w-1", amount: "10" }),
+        entry({ id: "e-4", type: "debit", refId: "w-1", amount: "10" }),
+      ],
+    });
+    expect(report.countsByKind.DUPLICATE_REFERENCE_ENTRIES).toBe(2);
+    const duplicate = report.anomalies.find(
+      (item) => item.kind === "DUPLICATE_REFERENCE_ENTRIES" && item.refId === "tip-1",
+    );
+    expect(duplicate?.entryIds).toEqual(["e-1", "e-dup"]);
+  });
+
+  it("keeps accounts with different assets separate for balance checks", () => {
+    const report = reconcileLedger({
+      tipIntents: [tip(), tip({ id: "tip-2", asset: "USDI", amount: "5" })],
+      withdrawals: [],
+      entries: [entry(), entry({ id: "e-2", refId: "tip-2", asset: "USDI", amount: "5" })],
+    });
+    expect(report.checked.accounts).toBe(2);
+    expect(report.anomalies).toEqual([]);
+  });
+});

--- a/fiber-link-service/packages/db/src/ledger-reconciliation.ts
+++ b/fiber-link-service/packages/db/src/ledger-reconciliation.ts
@@ -1,0 +1,229 @@
+import { formatDecimal, parseDecimal, pow10 } from "./amount";
+import type { LedgerEntryType } from "./ledger-repo";
+
+/**
+ * Pure ledger reconciliation over pre-fetched rows, mirroring the style of the
+ * worker's withdrawal-parity checker: callers (admin services, scripts, tests)
+ * fetch the rows however they like and this module only classifies anomalies.
+ *
+ * Reference model (see idempotency.ts and the write sites):
+ * - a settled tip intent produces exactly one ledger credit with
+ *   `refId = tipIntent.id`;
+ * - a broadcasted/completed withdrawal produces exactly one ledger debit with
+ *   `refId = withdrawal.id`.
+ */
+
+export type LedgerReconciliationTipIntent = {
+  id: string;
+  appId: string;
+  toUserId: string;
+  asset: string;
+  amount: string;
+  invoiceState: string;
+};
+
+export type LedgerReconciliationWithdrawal = {
+  id: string;
+  appId: string;
+  userId: string;
+  asset: string;
+  amount: string;
+  state: string;
+};
+
+export type LedgerReconciliationEntry = {
+  id: string;
+  appId: string;
+  userId: string;
+  asset: string;
+  amount: string;
+  type: LedgerEntryType;
+  refId: string;
+};
+
+export const LEDGER_ANOMALY_KINDS = [
+  "SETTLED_TIP_MISSING_CREDIT",
+  "CREDIT_WITHOUT_SETTLED_TIP",
+  "COMPLETED_WITHDRAWAL_MISSING_DEBIT",
+  "DEBIT_WITHOUT_COMPLETED_WITHDRAWAL",
+  "NEGATIVE_BALANCE_ACCOUNT",
+  "DUPLICATE_REFERENCE_ENTRIES",
+] as const;
+
+export type LedgerAnomalyKind = (typeof LEDGER_ANOMALY_KINDS)[number];
+
+export type LedgerAnomaly = {
+  kind: LedgerAnomalyKind;
+  detail: string;
+  /** Tip intent id or withdrawal id the anomaly refers to, when applicable. */
+  refId?: string;
+  /** Example ledger entry ids so operators can jump straight to the rows. */
+  entryIds?: string[];
+  account?: { appId: string; userId: string; asset: string };
+};
+
+export type LedgerReconciliationReport = {
+  anomalies: LedgerAnomaly[];
+  countsByKind: Record<LedgerAnomalyKind, number>;
+  checked: {
+    tipIntents: number;
+    withdrawals: number;
+    entries: number;
+    accounts: number;
+  };
+};
+
+/** Debits are written on the PROCESSING -> BROADCASTED transition and remain valid through COMPLETED. */
+const DEBIT_BEARING_WITHDRAWAL_STATES = new Set(["BROADCASTED", "COMPLETED"]);
+
+function signedSum(entries: LedgerReconciliationEntry[]): { value: bigint; scale: number } {
+  const parsed = entries.map((entry) => {
+    const decimal = parseDecimal(entry.amount);
+    const sign = entry.type === "debit" ? -1n : 1n;
+    return { value: decimal.value * sign, scale: decimal.scale };
+  });
+  const maxScale = parsed.reduce((max, item) => Math.max(max, item.scale), 0);
+  const value = parsed.reduce((acc, item) => acc + item.value * pow10(maxScale - item.scale), 0n);
+  return { value, scale: maxScale };
+}
+
+export function reconcileLedger(input: {
+  tipIntents: LedgerReconciliationTipIntent[];
+  withdrawals: LedgerReconciliationWithdrawal[];
+  entries: LedgerReconciliationEntry[];
+}): LedgerReconciliationReport {
+  const anomalies: LedgerAnomaly[] = [];
+
+  const creditsByRef = new Map<string, LedgerReconciliationEntry[]>();
+  const debitsByRef = new Map<string, LedgerReconciliationEntry[]>();
+  for (const entry of input.entries) {
+    const byRef = entry.type === "credit" ? creditsByRef : debitsByRef;
+    const linked = byRef.get(entry.refId) ?? [];
+    linked.push(entry);
+    byRef.set(entry.refId, linked);
+  }
+
+  const tipById = new Map(input.tipIntents.map((tip) => [tip.id, tip]));
+  const withdrawalById = new Map(input.withdrawals.map((withdrawal) => [withdrawal.id, withdrawal]));
+
+  for (const tip of input.tipIntents) {
+    if (tip.invoiceState !== "SETTLED") {
+      continue;
+    }
+    if ((creditsByRef.get(tip.id) ?? []).length === 0) {
+      anomalies.push({
+        kind: "SETTLED_TIP_MISSING_CREDIT",
+        refId: tip.id,
+        detail: `settled tip intent ${tip.id} has no ledger credit`,
+      });
+    }
+  }
+
+  for (const [refId, credits] of creditsByRef) {
+    const entryIds = credits.map((entry) => entry.id);
+    const tip = tipById.get(refId);
+    if (!tip) {
+      anomalies.push({
+        kind: "CREDIT_WITHOUT_SETTLED_TIP",
+        refId,
+        entryIds,
+        detail: `ledger credit references unknown tip intent ${refId}`,
+      });
+    } else if (tip.invoiceState !== "SETTLED") {
+      anomalies.push({
+        kind: "CREDIT_WITHOUT_SETTLED_TIP",
+        refId,
+        entryIds,
+        detail: `ledger credit exists but tip intent ${refId} is ${tip.invoiceState}`,
+      });
+    }
+    if (credits.length > 1) {
+      anomalies.push({
+        kind: "DUPLICATE_REFERENCE_ENTRIES",
+        refId,
+        entryIds,
+        detail: `${credits.length} credit entries share ref ${refId}`,
+      });
+    }
+  }
+
+  for (const withdrawal of input.withdrawals) {
+    if (!DEBIT_BEARING_WITHDRAWAL_STATES.has(withdrawal.state)) {
+      continue;
+    }
+    if ((debitsByRef.get(withdrawal.id) ?? []).length === 0) {
+      anomalies.push({
+        kind: "COMPLETED_WITHDRAWAL_MISSING_DEBIT",
+        refId: withdrawal.id,
+        detail: `${withdrawal.state} withdrawal ${withdrawal.id} has no ledger debit`,
+      });
+    }
+  }
+
+  for (const [refId, debits] of debitsByRef) {
+    const entryIds = debits.map((entry) => entry.id);
+    const withdrawal = withdrawalById.get(refId);
+    if (!withdrawal) {
+      anomalies.push({
+        kind: "DEBIT_WITHOUT_COMPLETED_WITHDRAWAL",
+        refId,
+        entryIds,
+        detail: `ledger debit references unknown withdrawal ${refId}`,
+      });
+    } else if (!DEBIT_BEARING_WITHDRAWAL_STATES.has(withdrawal.state)) {
+      anomalies.push({
+        kind: "DEBIT_WITHOUT_COMPLETED_WITHDRAWAL",
+        refId,
+        entryIds,
+        detail: `ledger debit exists but withdrawal ${refId} is ${withdrawal.state}`,
+      });
+    }
+    if (debits.length > 1) {
+      anomalies.push({
+        kind: "DUPLICATE_REFERENCE_ENTRIES",
+        refId,
+        entryIds,
+        detail: `${debits.length} debit entries share ref ${refId}`,
+      });
+    }
+  }
+
+  const byAccount = new Map<string, LedgerReconciliationEntry[]>();
+  for (const entry of input.entries) {
+    const key = JSON.stringify([entry.appId, entry.userId, entry.asset]);
+    const linked = byAccount.get(key) ?? [];
+    linked.push(entry);
+    byAccount.set(key, linked);
+  }
+  for (const entries of byAccount.values()) {
+    const { appId, userId, asset } = entries[0];
+    const sum = signedSum(entries);
+    if (sum.value < 0n) {
+      anomalies.push({
+        kind: "NEGATIVE_BALANCE_ACCOUNT",
+        account: { appId, userId, asset },
+        entryIds: entries.slice(0, 5).map((entry) => entry.id),
+        detail: `account ${appId}/${userId}/${asset} has negative balance ${formatDecimal(sum.value, sum.scale)}`,
+      });
+    }
+  }
+
+  const countsByKind = Object.fromEntries(LEDGER_ANOMALY_KINDS.map((kind) => [kind, 0])) as Record<
+    LedgerAnomalyKind,
+    number
+  >;
+  for (const anomaly of anomalies) {
+    countsByKind[anomaly.kind] += 1;
+  }
+
+  return {
+    anomalies,
+    countsByKind,
+    checked: {
+      tipIntents: input.tipIntents.length,
+      withdrawals: input.withdrawals.length,
+      entries: input.entries.length,
+      accounts: byAccount.size,
+    },
+  };
+}

--- a/fiber-link-service/packages/db/src/ledger-repo.test.ts
+++ b/fiber-link-service/packages/db/src/ledger-repo.test.ts
@@ -88,6 +88,94 @@ describe("ledgerRepo (in-memory)", () => {
     expect(balance).toBe("7.25");
   });
 
+  it("lists entries newest-first with filters and keyset pagination", async () => {
+    await repo.creditOnce({
+      appId: "app1",
+      userId: "u1",
+      asset: "CKB",
+      amount: "10",
+      refId: "tip-1",
+      idempotencyKey: "k-1",
+    });
+    await repo.debitOnce({
+      appId: "app1",
+      userId: "u1",
+      asset: "CKB",
+      amount: "4",
+      refId: "w-1",
+      idempotencyKey: "k-2",
+    });
+    await repo.creditOnce({
+      appId: "app1",
+      userId: "u2",
+      asset: "USDI",
+      amount: "7",
+      refId: "tip-2",
+      idempotencyKey: "k-3",
+    });
+
+    const all = await repo.listEntries({ appId: "app1" });
+    expect(all).toHaveLength(3);
+
+    const credits = await repo.listEntries({ appId: "app1", type: "credit" });
+    expect(credits.map((item) => item.refId).sort()).toEqual(["tip-1", "tip-2"]);
+
+    const scoped = await repo.listEntries({ appId: "app1", userId: "u1", asset: "CKB" });
+    expect(scoped).toHaveLength(2);
+
+    const firstPage = await repo.listEntries({ appId: "app1", limit: 2 });
+    expect(firstPage).toHaveLength(2);
+    const last = firstPage[firstPage.length - 1];
+    const secondPage = await repo.listEntries({
+      appId: "app1",
+      limit: 2,
+      after: { createdAt: last.createdAt, id: last.id },
+    });
+    expect(secondPage).toHaveLength(1);
+    expect([...firstPage, ...secondPage].map((item) => item.id)).toHaveLength(3);
+  });
+
+  it("explains a balance via getBalanceBreakdown", async () => {
+    await repo.creditOnce({
+      appId: "app1",
+      userId: "u1",
+      asset: "CKB",
+      amount: "10.5",
+      refId: "tip-1",
+      idempotencyKey: "k-1",
+    });
+    await repo.creditOnce({
+      appId: "app1",
+      userId: "u1",
+      asset: "CKB",
+      amount: "2",
+      refId: "tip-2",
+      idempotencyKey: "k-2",
+    });
+    await repo.debitOnce({
+      appId: "app1",
+      userId: "u1",
+      asset: "CKB",
+      amount: "4",
+      refId: "w-1",
+      idempotencyKey: "k-3",
+    });
+
+    const breakdown = await repo.getBalanceBreakdown({ appId: "app1", userId: "u1", asset: "CKB" });
+    expect(breakdown.balance).toBe("8.5");
+    expect(breakdown.creditTotal).toBe("12.5");
+    expect(breakdown.debitTotal).toBe("4");
+    expect(breakdown.creditCount).toBe(2);
+    expect(breakdown.debitCount).toBe(1);
+    expect(breakdown.firstEntryAt).not.toBeNull();
+    expect(breakdown.lastEntryAt).not.toBeNull();
+
+    const empty = await repo.getBalanceBreakdown({ appId: "app1", userId: "nobody", asset: "CKB" });
+    expect(empty.balance).toBe("0");
+    expect(empty.creditCount).toBe(0);
+    expect(empty.firstEntryAt).toBeNull();
+  });
+
   it("rejects non-positive ledger writes", async () => {
     await expect(
       repo.creditOnce({

--- a/fiber-link-service/packages/db/src/ledger-repo.ts
+++ b/fiber-link-service/packages/db/src/ledger-repo.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, lt, or, sql } from "drizzle-orm";
 import { assertPositiveAmount, formatDecimal, parseDecimal, pow10 } from "./amount";
 import type { DbClient } from "./client";
 import { type Asset, ledgerEntries } from "./schema";
@@ -25,10 +25,44 @@ export type LedgerEntryRecord = LedgerWriteInput & {
 
 export type LedgerWriteResult = { applied: boolean; entry?: LedgerEntryRecord };
 
+export type LedgerEntryListCursor = {
+  createdAt: Date;
+  id: string;
+};
+
+export type LedgerEntryListOptions = {
+  appId: string;
+  userId?: string;
+  asset?: LedgerAsset;
+  type?: LedgerEntryType;
+  limit?: number;
+  after?: LedgerEntryListCursor;
+};
+
+export type LedgerBalanceBreakdown = {
+  appId: string;
+  userId: string;
+  asset: LedgerAsset;
+  balance: string;
+  creditTotal: string;
+  debitTotal: string;
+  creditCount: number;
+  debitCount: number;
+  firstEntryAt: Date | null;
+  lastEntryAt: Date | null;
+};
+
+export const LEDGER_ENTRY_LIST_DEFAULT_LIMIT = 50;
+export const LEDGER_ENTRY_LIST_MAX_LIMIT = 200;
+
 export type LedgerRepo = {
   creditOnce(input: LedgerWriteInput): Promise<LedgerWriteResult>;
   debitOnce(input: LedgerWriteInput): Promise<LedgerWriteResult>;
   getBalance(input: { appId: string; userId: string; asset: LedgerAsset }): Promise<string>;
+  /** Newest first with keyset (createdAt, id) pagination; limit is clamped to {@link LEDGER_ENTRY_LIST_MAX_LIMIT}. */
+  listEntries(options: LedgerEntryListOptions): Promise<LedgerEntryRecord[]>;
+  /** Explain an account balance from its source credits/debits. */
+  getBalanceBreakdown(input: { appId: string; userId: string; asset: LedgerAsset }): Promise<LedgerBalanceBreakdown>;
   __listForTests?: () => LedgerEntryRecord[];
   __resetForTests?: () => void;
 };
@@ -138,6 +172,74 @@ export function createDbLedgerRepo(db: DbClient): LedgerRepo {
 
       return row ? String(row.balance) : "0";
     },
+
+    async listEntries(options) {
+      const limit = Math.min(
+        Math.max(options.limit ?? LEDGER_ENTRY_LIST_DEFAULT_LIMIT, 1),
+        LEDGER_ENTRY_LIST_MAX_LIMIT,
+      );
+      const clauses = [eq(ledgerEntries.appId, options.appId)];
+      if (options.userId) {
+        clauses.push(eq(ledgerEntries.userId, options.userId));
+      }
+      if (options.asset) {
+        clauses.push(eq(ledgerEntries.asset, options.asset));
+      }
+      if (options.type) {
+        clauses.push(eq(ledgerEntries.type, options.type));
+      }
+      if (options.after) {
+        const keyset = or(
+          lt(ledgerEntries.createdAt, options.after.createdAt),
+          and(eq(ledgerEntries.createdAt, options.after.createdAt), lt(ledgerEntries.id, options.after.id)),
+        );
+        if (keyset) {
+          clauses.push(keyset);
+        }
+      }
+
+      const rows = await db
+        .select()
+        .from(ledgerEntries)
+        .where(and(...clauses))
+        .orderBy(desc(ledgerEntries.createdAt), desc(ledgerEntries.id))
+        .limit(limit);
+      return rows.map(toRecord);
+    },
+
+    async getBalanceBreakdown(input) {
+      const [row] = await db
+        .select({
+          balance: sql<string>`COALESCE(SUM(CASE WHEN ${ledgerEntries.type} = 'credit' THEN ${ledgerEntries.amount} ELSE -${ledgerEntries.amount} END), 0)`,
+          creditTotal: sql<string>`COALESCE(SUM(${ledgerEntries.amount}) FILTER (WHERE ${ledgerEntries.type} = 'credit'), 0)`,
+          debitTotal: sql<string>`COALESCE(SUM(${ledgerEntries.amount}) FILTER (WHERE ${ledgerEntries.type} = 'debit'), 0)`,
+          creditCount: sql<number>`(COUNT(*) FILTER (WHERE ${ledgerEntries.type} = 'credit'))::int`,
+          debitCount: sql<number>`(COUNT(*) FILTER (WHERE ${ledgerEntries.type} = 'debit'))::int`,
+          firstEntryAt: sql<Date | null>`MIN(${ledgerEntries.createdAt})`,
+          lastEntryAt: sql<Date | null>`MAX(${ledgerEntries.createdAt})`,
+        })
+        .from(ledgerEntries)
+        .where(
+          and(
+            eq(ledgerEntries.appId, input.appId),
+            eq(ledgerEntries.userId, input.userId),
+            eq(ledgerEntries.asset, input.asset),
+          ),
+        );
+
+      return {
+        appId: input.appId,
+        userId: input.userId,
+        asset: input.asset,
+        balance: row ? String(row.balance) : "0",
+        creditTotal: row ? String(row.creditTotal) : "0",
+        debitTotal: row ? String(row.debitTotal) : "0",
+        creditCount: row ? Number(row.creditCount) : 0,
+        debitCount: row ? Number(row.debitCount) : 0,
+        firstEntryAt: row?.firstEntryAt ? new Date(row.firstEntryAt) : null,
+        lastEntryAt: row?.lastEntryAt ? new Date(row.lastEntryAt) : null,
+      };
+    },
   };
 }
 
@@ -180,6 +282,61 @@ export function createInMemoryLedgerRepo(): LedgerRepo {
         (item) => item.appId === input.appId && item.userId === input.userId && item.asset === input.asset,
       );
       return sumEntries(relevant);
+    },
+
+    async listEntries(options) {
+      const limit = Math.min(
+        Math.max(options.limit ?? LEDGER_ENTRY_LIST_DEFAULT_LIMIT, 1),
+        LEDGER_ENTRY_LIST_MAX_LIMIT,
+      );
+      let items = entries.filter((item) => item.appId === options.appId);
+      if (options.userId) {
+        items = items.filter((item) => item.userId === options.userId);
+      }
+      if (options.asset) {
+        items = items.filter((item) => item.asset === options.asset);
+      }
+      if (options.type) {
+        items = items.filter((item) => item.type === options.type);
+      }
+      items = items.slice().sort((left, right) => {
+        const createdAtDiff = right.createdAt.getTime() - left.createdAt.getTime();
+        if (createdAtDiff !== 0) {
+          return createdAtDiff;
+        }
+        return right.id.localeCompare(left.id);
+      });
+      const after = options.after;
+      if (after) {
+        items = items.filter(
+          (item) =>
+            item.createdAt.getTime() < after.createdAt.getTime() ||
+            (item.createdAt.getTime() === after.createdAt.getTime() && item.id < after.id),
+        );
+      }
+      return items.slice(0, limit).map(clone);
+    },
+
+    async getBalanceBreakdown(input) {
+      const relevant = entries.filter(
+        (item) => item.appId === input.appId && item.userId === input.userId && item.asset === input.asset,
+      );
+      const credits = relevant.filter((item) => item.type === "credit");
+      const debits = relevant.filter((item) => item.type === "debit");
+      const timestamps = relevant.map((item) => item.createdAt.getTime());
+      return {
+        appId: input.appId,
+        userId: input.userId,
+        asset: input.asset,
+        balance: sumEntries(relevant),
+        creditTotal: sumEntries(credits),
+        // sumEntries signs debits negative; total debit volume is the magnitude.
+        debitTotal: sumEntries(debits).replace(/^-/, ""),
+        creditCount: credits.length,
+        debitCount: debits.length,
+        firstEntryAt: timestamps.length > 0 ? new Date(Math.min(...timestamps)) : null,
+        lastEntryAt: timestamps.length > 0 ? new Date(Math.max(...timestamps)) : null,
+      };
     },
 
     __listForTests() {


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #528** (settlement timeline): based on `claude/settlement-timeline` because both PRs extend the same admin services seam (`types.ts`, `db-services.ts`, `fixture-services.ts`, `root.ts`, `routers.test.ts`) and would otherwise conflict. Only the last commit (`Add ledger reconciliation and balance explanation tools to admin`) is new here; I will rebase onto `main` once #528 merges so the diff collapses to the ledger work.

## Summary

Implements #471: admin ledger operations so operators can explain balances and detect accounting anomalies without ad hoc SQL.

- **`packages/db` ledger repo**: `listEntries` (newest-first keyset pagination on `(createdAt, id)` with app/user/asset/type filters) and `getBalanceBreakdown` (balance, credit/debit totals + counts, first/last entry timestamps), in both db and in-memory implementations.
- **`packages/db/src/ledger-reconciliation.ts`**: a pure `reconcileLedger()` classifier over pre-fetched tips/withdrawals/entries, mirroring the worker's withdrawal-parity checker. Anomaly categories (each with example ledger entry ids):
  - `SETTLED_TIP_MISSING_CREDIT`
  - `CREDIT_WITHOUT_SETTLED_TIP` (unknown ref or non-settled intent)
  - `COMPLETED_WITHDRAWAL_MISSING_DEBIT` (COMPLETED and BROADCASTED both require a debit — the debit is written on the PROCESSING→BROADCASTED transition)
  - `DEBIT_WITHOUT_COMPLETED_WITHDRAWAL`
  - `NEGATIVE_BALANCE_ACCOUNT` (bigint decimal math via the existing `amount` helpers, no float drift)
  - `DUPLICATE_REFERENCE_ENTRIES`
- **Admin services**: `listLedgerEntries` / `getLedgerBalanceBreakdown` / `reconcileLedger`. The db reconcile pass fetches a bounded window (default: last 30 days; 2000 rows per source with a `truncated` flag) **plus** the rows referenced across the window boundary, so a credit written just outside the window doesn't produce a false "missing credit". Out-of-scope apps read as empty results rather than existence oracles.
- **tRPC router** `ledger.*` (SUPER_ADMIN-only): `entries`, `balanceBreakdown`, `reconcile`, with validated inputs (asset/type enums, opaque base64url cursor decoding, ISO window ordering, limit bounds).
- **Admin UI**: new `/ledger` page — account statement (balance breakdown cards + paginated entry table with "Next page") and a reconciliation report (anomaly count cards, per-anomaly detail rows, truncation notice); Ledger nav entry (SUPER_ADMIN-only).

## Issue acceptance criteria

- ✅ Admin users can view a paginated ledger statement for an account (`ledger.entries` + `/ledger` UI).
- ✅ Admin users can explain a balance from source credits/debits (`ledger.balanceBreakdown`).
- ✅ Reconciliation reports anomaly counts (`countsByKind`) and example row ids (`entryIds`).
- ✅ Tests cover normal reconciliation and at least one anomaly for each category (9 classifier tests in `ledger-reconciliation.test.ts`, plus repo pagination/breakdown tests and router tests for paging, anomaly reporting, input validation, and role denial).

## Testing

- `packages/db`: `bunx vitest run` — 184 tests pass (9 new classifier tests, 2 new repo tests).
- `apps/admin`: `bunx vitest run src/server` — 67 tests pass (4 new ledger router tests).
- `bun run typecheck` clean in both workspaces; `bunx biome check` clean; `next build` passes with the new `/ledger` route.

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_