### PR TITLE
Ops: pagination, filtering, and exact search for admin lists (#473)

### DIFF
--- a/fiber-link-service/apps/admin/src/pages/settlements/index.tsx
+++ b/fiber-link-service/apps/admin/src/pages/settlements/index.tsx
@@ -1,9 +1,12 @@
 import type { InvoiceState } from "@fiber-link/db";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { PageHeader, QueryBoundary, RoleGate, StatCard } from "../../components/page";
 import { SettlementStateBadge } from "../../components/settlement-state-badge";
+import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Select } from "../../components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
@@ -27,19 +30,37 @@ export default function SettlementsPage() {
 
   const rawState = queryValue(router.query.state);
   const stateFilter = INVOICE_STATES.includes(rawState as InvoiceState) ? (rawState as InvoiceState) : undefined;
+  const invoiceFilter = queryValue(router.query.invoice);
+  const userFilter = queryValue(router.query.user);
+  const [searchDraft, setSearchDraft] = useState({ invoice: "", user: "" });
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
 
-  const settlements = trpc.settlements.list.useQuery(stateFilter ? { state: stateFilter } : {}, {
-    enabled: isSuperAdmin && router.isReady,
-  });
+  const settlements = trpc.settlements.list.useQuery(
+    {
+      ...(stateFilter ? { state: stateFilter } : {}),
+      ...(invoiceFilter ? { invoice: invoiceFilter } : {}),
+      ...(userFilter ? { userId: userFilter } : {}),
+      ...(cursor ? { cursor } : {}),
+    },
+    { enabled: isSuperAdmin && router.isReady },
+  );
+  const rows = settlements.data?.items ?? [];
+
+  function replaceQuery(mutate: (next: Record<string, string | string[] | undefined>) => void) {
+    setCursor(undefined);
+    const next = { ...router.query };
+    mutate(next);
+    router.replace({ pathname: router.pathname, query: next }, undefined, { shallow: true });
+  }
 
   function setStateFilter(value: string) {
-    const next = { ...router.query };
-    if (value) {
-      next.state = value;
-    } else {
-      delete next.state;
-    }
-    router.replace({ pathname: router.pathname, query: next }, undefined, { shallow: true });
+    replaceQuery((next) => {
+      if (value) {
+        next.state = value;
+      } else {
+        delete next.state;
+      }
+    });
   }
 
   return (
@@ -64,29 +85,92 @@ export default function SettlementsPage() {
             <StatCard label="Pipeline status" value={monitoring.data?.status ?? "—"} />
           </section>
 
-          <div className="mb-4 w-48">
-            <Label htmlFor="settlement-state-filter" className="mb-1 block text-xs text-muted-foreground">
-              State
-            </Label>
-            <Select
-              id="settlement-state-filter"
-              data-testid="settlement-state-filter"
-              value={stateFilter ?? ""}
-              onChange={(event) => setStateFilter(event.target.value)}
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <div className="w-48">
+              <Label htmlFor="settlement-state-filter" className="mb-1 block text-xs text-muted-foreground">
+                State
+              </Label>
+              <Select
+                id="settlement-state-filter"
+                data-testid="settlement-state-filter"
+                value={stateFilter ?? ""}
+                onChange={(event) => setStateFilter(event.target.value)}
+              >
+                <option value="">All states</option>
+                {INVOICE_STATES.map((state) => (
+                  <option key={state} value={state}>
+                    {state}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <form
+              className="flex flex-wrap items-end gap-2"
+              onSubmit={(event) => {
+                event.preventDefault();
+                replaceQuery((next) => {
+                  const invoice = searchDraft.invoice.trim();
+                  const user = searchDraft.user.trim();
+                  if (invoice) {
+                    next.invoice = invoice;
+                  } else {
+                    delete next.invoice;
+                  }
+                  if (user) {
+                    next.user = user;
+                  } else {
+                    delete next.user;
+                  }
+                });
+              }}
             >
-              <option value="">All states</option>
-              {INVOICE_STATES.map((state) => (
-                <option key={state} value={state}>
-                  {state}
-                </option>
-              ))}
-            </Select>
+              <div className="w-64">
+                <Label htmlFor="settlement-search-invoice" className="mb-1 block text-xs text-muted-foreground">
+                  Invoice (exact)
+                </Label>
+                <Input
+                  id="settlement-search-invoice"
+                  data-testid="settlement-search-invoice"
+                  value={searchDraft.invoice}
+                  onChange={(event) => setSearchDraft((draft) => ({ ...draft, invoice: event.target.value }))}
+                />
+              </div>
+              <div className="w-40">
+                <Label htmlFor="settlement-search-user" className="mb-1 block text-xs text-muted-foreground">
+                  User (exact)
+                </Label>
+                <Input
+                  id="settlement-search-user"
+                  data-testid="settlement-search-user"
+                  value={searchDraft.user}
+                  onChange={(event) => setSearchDraft((draft) => ({ ...draft, user: event.target.value }))}
+                />
+              </div>
+              <Button type="submit" variant="outline" data-testid="settlement-search-submit">
+                Search
+              </Button>
+              {invoiceFilter || userFilter ? (
+                <button
+                  type="button"
+                  className="text-sm text-primary underline-offset-4 hover:underline"
+                  onClick={() => {
+                    setSearchDraft({ invoice: "", user: "" });
+                    replaceQuery((next) => {
+                      delete next.invoice;
+                      delete next.user;
+                    });
+                  }}
+                >
+                  Clear search
+                </button>
+              ) : null}
+            </form>
           </div>
 
           <QueryBoundary
             isLoading={settlements.isLoading}
             error={settlements.error}
-            isEmpty={settlements.data?.length === 0}
+            isEmpty={rows.length === 0}
             emptyMessage="No settlement intents match the current filters."
           >
             <Card>
@@ -105,7 +189,7 @@ export default function SettlementsPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {(settlements.data ?? []).map((row) => (
+                    {rows.map((row) => (
                       <TableRow key={row.id} data-testid={`settlement-row-${row.id}`}>
                         <TableCell className="font-mono text-xs" title={row.invoice}>
                           <Link
@@ -136,6 +220,16 @@ export default function SettlementsPage() {
                 </Table>
               </CardContent>
             </Card>
+            {settlements.data?.nextCursor ? (
+              <Button
+                className="mt-3"
+                variant="outline"
+                data-testid="settlement-next-page"
+                onClick={() => setCursor(settlements.data?.nextCursor ?? undefined)}
+              >
+                Next page
+              </Button>
+            ) : null}
           </QueryBoundary>
         </RoleGate>
       </QueryBoundary>

--- a/fiber-link-service/apps/admin/src/pages/withdrawals.tsx
+++ b/fiber-link-service/apps/admin/src/pages/withdrawals.tsx
@@ -1,8 +1,11 @@
 import type { WithdrawalState } from "@fiber-link/db";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { PageHeader, QueryBoundary } from "../components/page";
+import { Button } from "../components/ui/button";
 import { Card, CardContent } from "../components/ui/card";
+import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { Select } from "../components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table";
@@ -38,22 +41,51 @@ export default function WithdrawalsPage() {
     ? (rawState as WithdrawalState)
     : undefined;
   const appFilter = queryValue(router.query.app);
+  const idFilter = queryValue(router.query.id);
+  const userFilter = queryValue(router.query.user);
+  const txFilter = queryValue(router.query.tx);
+  const [searchDraft, setSearchDraft] = useState({ id: "", user: "", tx: "" });
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
 
   const filters = {
     ...(stateFilter ? { state: stateFilter } : {}),
     ...(appFilter ? { appId: appFilter } : {}),
+    ...(idFilter ? { id: idFilter } : {}),
+    ...(userFilter ? { userId: userFilter } : {}),
+    ...(txFilter ? { txHash: txFilter } : {}),
+    ...(cursor ? { cursor } : {}),
   };
 
   // router.query is empty until hydration completes; waiting for isReady avoids
   // an initial unfiltered fetch that is immediately refetched with URL filters.
   const withdrawals = trpc.withdrawals.list.useQuery(filters, { enabled: Boolean(role) && router.isReady });
+  const rows = withdrawals.data?.items ?? [];
 
   function setFilter(key: string, value: string) {
+    setCursor(undefined);
     const next = { ...router.query };
     if (value) {
       next[key] = value;
     } else {
       delete next[key];
+    }
+    router.replace({ pathname: router.pathname, query: next }, undefined, { shallow: true });
+  }
+
+  function applySearch(event: React.FormEvent) {
+    event.preventDefault();
+    setCursor(undefined);
+    const next = { ...router.query };
+    for (const [key, value] of [
+      ["id", searchDraft.id.trim()],
+      ["user", searchDraft.user.trim()],
+      ["tx", searchDraft.tx.trim()],
+    ] as const) {
+      if (value) {
+        next[key] = value;
+      } else {
+        delete next[key];
+      }
     }
     router.replace({ pathname: router.pathname, query: next }, undefined, { shallow: true });
   }
@@ -93,12 +125,68 @@ export default function WithdrawalsPage() {
             Clear app filter: {appFilter}
           </button>
         ) : null}
+
+        <form className="flex flex-wrap items-end gap-2" onSubmit={applySearch}>
+          <div className="w-48">
+            <Label htmlFor="search-id" className="mb-1 block text-xs text-muted-foreground">
+              Withdrawal ID (exact)
+            </Label>
+            <Input
+              id="search-id"
+              data-testid="withdrawal-search-id"
+              value={searchDraft.id}
+              onChange={(event) => setSearchDraft((draft) => ({ ...draft, id: event.target.value }))}
+            />
+          </div>
+          <div className="w-40">
+            <Label htmlFor="search-user" className="mb-1 block text-xs text-muted-foreground">
+              User (exact)
+            </Label>
+            <Input
+              id="search-user"
+              data-testid="withdrawal-search-user"
+              value={searchDraft.user}
+              onChange={(event) => setSearchDraft((draft) => ({ ...draft, user: event.target.value }))}
+            />
+          </div>
+          <div className="w-48">
+            <Label htmlFor="search-tx" className="mb-1 block text-xs text-muted-foreground">
+              Tx hash (exact)
+            </Label>
+            <Input
+              id="search-tx"
+              data-testid="withdrawal-search-tx"
+              value={searchDraft.tx}
+              onChange={(event) => setSearchDraft((draft) => ({ ...draft, tx: event.target.value }))}
+            />
+          </div>
+          <Button type="submit" variant="outline" data-testid="withdrawal-search-submit">
+            Search
+          </Button>
+          {idFilter || userFilter || txFilter ? (
+            <button
+              type="button"
+              className="text-sm text-primary underline-offset-4 hover:underline"
+              onClick={() => {
+                setSearchDraft({ id: "", user: "", tx: "" });
+                setCursor(undefined);
+                const next = { ...router.query };
+                for (const key of ["id", "user", "tx"]) {
+                  delete next[key];
+                }
+                router.replace({ pathname: router.pathname, query: next }, undefined, { shallow: true });
+              }}
+            >
+              Clear search
+            </button>
+          ) : null}
+        </form>
       </div>
 
       <QueryBoundary
         isLoading={session.isLoading || withdrawals.isLoading}
         error={session.error ?? withdrawals.error}
-        isEmpty={withdrawals.data?.length === 0}
+        isEmpty={rows.length === 0}
         emptyMessage="No withdrawals match the current filters."
       >
         <Card>
@@ -118,7 +206,7 @@ export default function WithdrawalsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {(withdrawals.data ?? []).map((row) => (
+                {rows.map((row) => (
                   <TableRow key={row.id} data-testid={`withdrawal-row-${row.id}`}>
                     <TableCell className="font-mono text-xs" title={row.id}>
                       {shorten(row.id)}
@@ -147,6 +235,16 @@ export default function WithdrawalsPage() {
             </Table>
           </CardContent>
         </Card>
+        {withdrawals.data?.nextCursor ? (
+          <Button
+            className="mt-3"
+            variant="outline"
+            data-testid="withdrawal-next-page"
+            onClick={() => setCursor(withdrawals.data?.nextCursor ?? undefined)}
+          >
+            Next page
+          </Button>
+        ) : null}
       </QueryBoundary>
     </div>
   );

--- a/fiber-link-service/apps/admin/src/server/api/routers.test.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers.test.ts
@@ -111,7 +111,8 @@ describe("admin tRPC routers", () => {
     const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
     expect((await caller.apps.list()).map((a) => a.appId)).toEqual(["app-alpha", "app-beta"]);
     const failed = await caller.withdrawals.list({ state: "FAILED" });
-    expect(failed).toHaveLength(1);
+    expect(failed.items).toHaveLength(1);
+    expect(failed.nextCursor).toBeNull();
   });
 
   it("rejects an unknown withdrawal state filter", async () => {
@@ -181,11 +182,12 @@ describe("settlement investigation workflow (#470)", () => {
   it("lists settlements newest-first and filters by state for SUPER_ADMIN", async () => {
     const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
     const all = await caller.settlements.list({});
-    expect(all.map((s) => s.invoice)).toEqual(["lnfib1unpaidalpha", "lnfib1settledalpha"]);
+    expect(all.items.map((s) => s.invoice)).toEqual(["lnfib1unpaidalpha", "lnfib1settledalpha"]);
+    expect(all.nextCursor).toBeNull();
 
     const settled = await caller.settlements.list({ state: "SETTLED" });
-    expect(settled).toHaveLength(1);
-    expect(settled[0].invoice).toBe("lnfib1settledalpha");
+    expect(settled.items).toHaveLength(1);
+    expect(settled.items[0].invoice).toBe("lnfib1settledalpha");
 
     await expect(caller.settlements.list({ state: "NOPE" } as never)).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
@@ -353,6 +355,61 @@ describe("ledger reconciliation and balance explanation (#471)", () => {
       createCaller(ctxFor("COMMUNITY_ADMIN", "c1")).ledger.entries({ appId: "app-alpha" }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     await expect(createCaller(ctxFor(undefined)).ledger.reconcile({})).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("admin list pagination and exact search (#473)", () => {
+  it("supports exact search on withdrawals by id, user id, and tx hash", async () => {
+    const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
+
+    const byId = await caller.withdrawals.list({ id: "w-1" });
+    expect(byId.items.map((row) => row.id)).toEqual(["w-1"]);
+
+    const byUser = await caller.withdrawals.list({ userId: "u1" });
+    expect(byUser.items).toHaveLength(1);
+
+    const byTx = await caller.withdrawals.list({ txHash: "0xmissing" });
+    expect(byTx.items).toEqual([]);
+
+    await expect(caller.withdrawals.list({ asset: "DOGE" } as never)).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(caller.withdrawals.list({ cursor: "junk" })).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    await expect(caller.withdrawals.list({ createdFrom: "not-a-date" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
+  it("pages settlements newest-first through the keyset cursor", async () => {
+    const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
+
+    const firstPage = await caller.settlements.list({ limit: 1 });
+    expect(firstPage.items.map((row) => row.invoice)).toEqual(["lnfib1unpaidalpha"]);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const secondPage = await caller.settlements.list({ limit: 1, cursor: firstPage.nextCursor ?? undefined });
+    expect(secondPage.items.map((row) => row.invoice)).toEqual(["lnfib1settledalpha"]);
+    expect(secondPage.nextCursor).toBeNull();
+  });
+
+  it("supports exact settlement search by invoice and user", async () => {
+    const caller = createCaller(ctxFor("SUPER_ADMIN", "ops"));
+
+    const byInvoice = await caller.settlements.list({ invoice: "lnfib1settledalpha" });
+    expect(byInvoice.items.map((row) => row.invoice)).toEqual(["lnfib1settledalpha"]);
+
+    const byUser = await caller.settlements.list({ userId: "author-1" });
+    expect(byUser.items).toHaveLength(2);
+
+    const byUnknownUser = await caller.settlements.list({ userId: "nobody" });
+    expect(byUnknownUser.items).toEqual([]);
+  });
+
+  it("keeps community-admin scoping and PII redaction on paged withdrawals", async () => {
+    const caller = createCaller(ctxFor("COMMUNITY_ADMIN", "c1"));
+    const page = await caller.withdrawals.list({ limit: 1 });
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0].appId).toBe("app-alpha");
+    expect(page.items[0].userId).toBe("");
+    expect(page.items[0].toAddress).toBeNull();
   });
 });
 

--- a/fiber-link-service/apps/admin/src/server/api/routers/settlements.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/settlements.ts
@@ -2,7 +2,10 @@ import type { InvoiceState } from "@fiber-link/db";
 import { TRPCError } from "@trpc/server";
 import { SettlementNotFoundError, SettlementRetryStateError } from "../../services/errors";
 import type { AdminSettlementFilters } from "../../services/types";
+import { ADMIN_LIST_MAX_LIMIT, decodeLedgerCursor } from "../../services/types";
 import { recordAuditEvent, router, superAdminProcedure } from "../trpc";
+
+const ASSETS = new Set(["CKB", "USDI"]);
 
 const INVOICE_STATES: readonly InvoiceState[] = ["UNPAID", "SETTLED", "FAILED"];
 
@@ -21,8 +24,21 @@ function parseSettlementFilters(input: unknown): AdminSettlementFilters {
   const raw = input as Record<string, unknown>;
   const filters: AdminSettlementFilters = {};
 
-  if (typeof raw.appId === "string" && raw.appId.trim()) {
-    filters.appId = raw.appId.trim();
+  for (const key of ["appId", "userId", "invoice"] as const) {
+    const value = typeof raw[key] === "string" ? (raw[key] as string).trim() : "";
+    if (value) {
+      filters[key] = value;
+    }
+  }
+  for (const key of ["createdFrom", "createdTo"] as const) {
+    const value = typeof raw[key] === "string" ? (raw[key] as string).trim() : "";
+    if (!value) {
+      continue;
+    }
+    if (Number.isNaN(new Date(value).getTime())) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: `${key} must be an ISO timestamp` });
+    }
+    filters[key] = value;
   }
   if (typeof raw.state === "string" && raw.state.trim()) {
     const state = raw.state.trim();
@@ -30,6 +46,30 @@ function parseSettlementFilters(input: unknown): AdminSettlementFilters {
       throw new TRPCError({ code: "BAD_REQUEST", message: `unknown settlement state: ${state}` });
     }
     filters.state = state as InvoiceState;
+  }
+  if (typeof raw.asset === "string" && raw.asset.trim()) {
+    const asset = raw.asset.trim();
+    if (!ASSETS.has(asset)) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: `unknown asset: ${asset}` });
+    }
+    filters.asset = asset as "CKB" | "USDI";
+  }
+  if (raw.limit !== undefined) {
+    const limit = Number(raw.limit);
+    if (!Number.isInteger(limit) || limit < 1 || limit > ADMIN_LIST_MAX_LIMIT) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `limit must be an integer in [1, ${ADMIN_LIST_MAX_LIMIT}]`,
+      });
+    }
+    filters.limit = limit;
+  }
+  if (typeof raw.cursor === "string" && raw.cursor.trim()) {
+    const after = decodeLedgerCursor(raw.cursor.trim());
+    if (!after) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "invalid cursor" });
+    }
+    filters.after = after;
   }
   return filters;
 }

--- a/fiber-link-service/apps/admin/src/server/api/routers/withdrawals.ts
+++ b/fiber-link-service/apps/admin/src/server/api/routers/withdrawals.ts
@@ -2,7 +2,26 @@ import type { WithdrawalState } from "@fiber-link/db";
 import { TRPCError } from "@trpc/server";
 import { WITHDRAWAL_STATE_ORDER } from "../../../dashboard/dashboard-page-model";
 import type { AdminWithdrawalFilters } from "../../services/types";
+import { ADMIN_LIST_MAX_LIMIT, decodeLedgerCursor } from "../../services/types";
 import { adminProcedure, router } from "../trpc";
+
+const ASSETS = new Set(["CKB", "USDI"]);
+
+function optionalTrimmed(raw: Record<string, unknown>, key: string): string | undefined {
+  const value = typeof raw[key] === "string" ? (raw[key] as string).trim() : "";
+  return value ? value : undefined;
+}
+
+function optionalIsoTimestamp(raw: Record<string, unknown>, key: string): string | undefined {
+  const value = optionalTrimmed(raw, key);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (Number.isNaN(new Date(value).getTime())) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: `${key} must be an ISO timestamp` });
+  }
+  return value;
+}
 
 function parseWithdrawalFilters(input: unknown): AdminWithdrawalFilters {
   if (input === undefined || input === null) {
@@ -15,25 +34,55 @@ function parseWithdrawalFilters(input: unknown): AdminWithdrawalFilters {
   const raw = input as Record<string, unknown>;
   const filters: AdminWithdrawalFilters = {};
 
-  if (typeof raw.appId === "string" && raw.appId.trim()) {
-    filters.appId = raw.appId.trim();
-  }
-  if (typeof raw.state === "string" && raw.state.trim()) {
-    const state = raw.state.trim();
+  filters.appId = optionalTrimmed(raw, "appId");
+  filters.userId = optionalTrimmed(raw, "userId");
+  filters.id = optionalTrimmed(raw, "id");
+  filters.txHash = optionalTrimmed(raw, "txHash");
+  filters.createdFrom = optionalIsoTimestamp(raw, "createdFrom");
+  filters.createdTo = optionalIsoTimestamp(raw, "createdTo");
+
+  const state = optionalTrimmed(raw, "state");
+  if (state) {
     if (!WITHDRAWAL_STATE_ORDER.includes(state as WithdrawalState)) {
       throw new TRPCError({ code: "BAD_REQUEST", message: `unknown withdrawal state: ${state}` });
     }
     filters.state = state as WithdrawalState;
   }
+  const asset = optionalTrimmed(raw, "asset");
+  if (asset) {
+    if (!ASSETS.has(asset)) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: `unknown asset: ${asset}` });
+    }
+    filters.asset = asset as "CKB" | "USDI";
+  }
+  if (raw.limit !== undefined) {
+    const limit = Number(raw.limit);
+    if (!Number.isInteger(limit) || limit < 1 || limit > ADMIN_LIST_MAX_LIMIT) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `limit must be an integer in [1, ${ADMIN_LIST_MAX_LIMIT}]`,
+      });
+    }
+    filters.limit = limit;
+  }
+  const cursor = optionalTrimmed(raw, "cursor");
+  if (cursor) {
+    const after = decodeLedgerCursor(cursor);
+    if (!after) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "invalid cursor" });
+    }
+    filters.after = after;
+  }
   return filters;
 }
 
 export const withdrawalsRouter = router({
+  /** Newest-first page with keyset cursor; exact search by id/txHash/user. */
   list: adminProcedure.input(parseWithdrawalFilters).query(async ({ ctx, input }) => {
     return ctx.services.listWithdrawals(ctx.scope, input);
   }),
 
-  /** Per-state counts over the whole scope; the list itself is capped. */
+  /** Per-state counts over the whole scope; the list itself is paged. */
   stateSummary: adminProcedure.query(async ({ ctx }) => {
     return ctx.services.summarizeWithdrawals(ctx.scope);
   }),

--- a/fiber-link-service/apps/admin/src/server/services/db-services.test.ts
+++ b/fiber-link-service/apps/admin/src/server/services/db-services.test.ts
@@ -95,7 +95,7 @@ describe("db admin services", () => {
   it("maps withdrawal rows and keeps userId for SUPER_ADMIN", async () => {
     const { db } = makeDb({ withdrawals: [WITHDRAWAL_ROW] });
     const services = createDbAdminServices(db);
-    const rows = await services.listWithdrawals({ role: "SUPER_ADMIN" });
+    const { items: rows } = await services.listWithdrawals({ role: "SUPER_ADMIN" });
     expect(rows[0]).toMatchObject({
       id: "w-1",
       userId: "user-1",
@@ -112,7 +112,7 @@ describe("db admin services", () => {
   it("trims userId for COMMUNITY_ADMIN withdrawals", async () => {
     const { db } = makeDb({ memberships: [{ appId: "app-alpha" }], withdrawals: [WITHDRAWAL_ROW] });
     const services = createDbAdminServices(db);
-    const rows = await services.listWithdrawals({ role: "COMMUNITY_ADMIN", adminUserId: "c" });
+    const { items: rows } = await services.listWithdrawals({ role: "COMMUNITY_ADMIN", adminUserId: "c" });
     expect(rows[0]?.userId).toBe("");
     expect(rows[0]?.toAddress).toBeNull();
   });

--- a/fiber-link-service/apps/admin/src/server/services/db-services.ts
+++ b/fiber-link-service/apps/admin/src/server/services/db-services.ts
@@ -45,23 +45,35 @@ import {
 } from "../dashboard-rate-limit";
 import { PolicyScopeError, SettlementNotFoundError, SettlementRetryStateError, UnknownAppError } from "./errors";
 import {
+  ADMIN_LIST_DEFAULT_LIMIT,
+  ADMIN_LIST_MAX_LIMIT,
   type AdminLedgerBalanceBreakdown,
+  type AdminLedgerCursor,
   type AdminLedgerFilters,
   type AdminLedgerPage,
   type AdminLedgerReconcileParams,
   type AdminLedgerReconciliationResult,
   type AdminScope,
   type AdminServices,
+  type AdminSettlementFilters,
   type AdminSettlementIntent,
+  type AdminSettlementPage,
   type AdminSettlementTimeline,
-  type AdminWithdrawal,
   type AdminWithdrawalFilters,
+  type AdminWithdrawalPage,
   LEDGER_PAGE_DEFAULT_LIMIT,
   LEDGER_PAGE_MAX_LIMIT,
-  SETTLEMENT_LIST_LIMIT,
-  WITHDRAWAL_LIST_LIMIT,
   encodeLedgerCursor,
 } from "./types";
+
+function clampListLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit ?? ADMIN_LIST_DEFAULT_LIMIT, 1), ADMIN_LIST_MAX_LIMIT);
+}
+
+/** Keyset "strictly older than" predicate over (createdAt, id), newest-first. */
+function keysetAfter(after: AdminLedgerCursor | undefined) {
+  return after ? { createdAt: new Date(after.createdAt), id: after.id } : undefined;
+}
 
 /** Per-source row cap for one reconciliation pass; the report flags truncation. */
 const RECONCILE_MAX_ROWS = 2000;
@@ -193,17 +205,20 @@ export function createDbAdminServices(db: DbClient = createDbClient()): AdminSer
       return rows.map((row) => ({ appId: row.appId, createdAt: row.createdAt.toISOString() }));
     },
 
-    async listWithdrawals(scope, filters?: AdminWithdrawalFilters): Promise<AdminWithdrawal[]> {
+    async listWithdrawals(scope, filters?: AdminWithdrawalFilters): Promise<AdminWithdrawalPage> {
       const scoped = await resolveScopedAppIds(db, scope);
       if (scoped !== "ALL" && scoped.length === 0) {
-        return [];
+        return { items: [], nextCursor: null };
       }
 
+      const limit = clampListLimit(filters?.limit);
+      const after = keysetAfter(filters?.after);
       const rows = await db.query.withdrawals.findMany({
         columns: WITHDRAWAL_COLUMNS,
-        orderBy: (w, { desc }) => [desc(w.createdAt)],
-        limit: WITHDRAWAL_LIST_LIMIT,
-        where: (w, { and, eq, inArray }) => {
+        orderBy: (w, { desc }) => [desc(w.createdAt), desc(w.id)],
+        // One extra row purely to detect whether a next page exists.
+        limit: limit + 1,
+        where: (w, { and, or, eq, gte, lte, lt, inArray }) => {
           const clauses = [];
           if (scoped !== "ALL") {
             clauses.push(inArray(w.appId, scoped));
@@ -214,30 +229,65 @@ export function createDbAdminServices(db: DbClient = createDbClient()): AdminSer
           if (filters?.state) {
             clauses.push(eq(w.state, filters.state));
           }
+          if (filters?.userId) {
+            clauses.push(eq(w.userId, filters.userId));
+          }
+          if (filters?.asset) {
+            clauses.push(eq(w.asset, filters.asset));
+          }
+          if (filters?.id) {
+            clauses.push(eq(w.id, filters.id));
+          }
+          if (filters?.txHash) {
+            clauses.push(eq(w.txHash, filters.txHash));
+          }
+          if (filters?.createdFrom) {
+            clauses.push(gte(w.createdAt, new Date(filters.createdFrom)));
+          }
+          if (filters?.createdTo) {
+            clauses.push(lte(w.createdAt, new Date(filters.createdTo)));
+          }
+          if (after) {
+            const keyset = or(
+              lt(w.createdAt, after.createdAt),
+              and(eq(w.createdAt, after.createdAt), lt(w.id, after.id)),
+            );
+            if (keyset) {
+              clauses.push(keyset);
+            }
+          }
           return clauses.length > 0 ? and(...clauses) : undefined;
         },
       });
 
+      const page = rows.slice(0, limit);
+      const last = page[page.length - 1];
       // COMMUNITY_ADMIN must not see end-user PII (user id or payout
       // destination); redact server-side so the restriction is enforced before
       // the data leaves the procedure, independent of which columns the UI shows.
       const redactPii = scope.role === "COMMUNITY_ADMIN";
-      return rows.map((row) => ({
-        id: row.id,
-        appId: row.appId,
-        userId: redactPii ? "" : row.userId,
-        asset: row.asset,
-        amount: row.amount,
-        toAddress: redactPii ? null : (row.toAddress ?? null),
-        state: row.state,
-        retryCount: row.retryCount ?? 0,
-        nextRetryAt: isoOrNull(row.nextRetryAt),
-        lastError: row.lastError ?? null,
-        txHash: row.txHash ?? null,
-        createdAt: row.createdAt.toISOString(),
-        updatedAt: row.updatedAt.toISOString(),
-        completedAt: isoOrNull(row.completedAt),
-      }));
+      return {
+        items: page.map((row) => ({
+          id: row.id,
+          appId: row.appId,
+          userId: redactPii ? "" : row.userId,
+          asset: row.asset,
+          amount: row.amount,
+          toAddress: redactPii ? null : (row.toAddress ?? null),
+          state: row.state,
+          retryCount: row.retryCount ?? 0,
+          nextRetryAt: isoOrNull(row.nextRetryAt),
+          lastError: row.lastError ?? null,
+          txHash: row.txHash ?? null,
+          createdAt: row.createdAt.toISOString(),
+          updatedAt: row.updatedAt.toISOString(),
+          completedAt: isoOrNull(row.completedAt),
+        })),
+        nextCursor:
+          rows.length > limit && last
+            ? encodeLedgerCursor({ createdAt: last.createdAt.toISOString(), id: last.id })
+            : null,
+      };
     },
 
     async summarizeWithdrawals(scope): Promise<DashboardStatusSummary[]> {
@@ -336,16 +386,19 @@ export function createDbAdminServices(db: DbClient = createDbClient()): AdminSer
       };
     },
 
-    async listSettlements(scope, filters): Promise<AdminSettlementIntent[]> {
+    async listSettlements(scope, filters?: AdminSettlementFilters): Promise<AdminSettlementPage> {
       const scoped = await resolveScopedAppIds(db, scope);
       if (scoped !== "ALL" && scoped.length === 0) {
-        return [];
+        return { items: [], nextCursor: null };
       }
 
+      const limit = clampListLimit(filters?.limit);
+      const after = keysetAfter(filters?.after);
       const rows = await db.query.tipIntents.findMany({
         orderBy: (t, { desc }) => [desc(t.createdAt), desc(t.id)],
-        limit: SETTLEMENT_LIST_LIMIT,
-        where: (t, { and, eq, inArray }) => {
+        // One extra row purely to detect whether a next page exists.
+        limit: limit + 1,
+        where: (t, { and, or, eq, gte, lte, lt, inArray }) => {
           const clauses = [];
           if (scoped !== "ALL") {
             clauses.push(inArray(t.appId, scoped));
@@ -356,12 +409,41 @@ export function createDbAdminServices(db: DbClient = createDbClient()): AdminSer
           if (filters?.state) {
             clauses.push(eq(t.invoiceState, filters.state));
           }
+          if (filters?.invoice) {
+            clauses.push(eq(t.invoice, filters.invoice));
+          }
+          if (filters?.asset) {
+            clauses.push(eq(t.asset, filters.asset));
+          }
+          if (filters?.userId) {
+            const either = or(eq(t.fromUserId, filters.userId), eq(t.toUserId, filters.userId));
+            if (either) {
+              clauses.push(either);
+            }
+          }
+          if (filters?.createdFrom) {
+            clauses.push(gte(t.createdAt, new Date(filters.createdFrom)));
+          }
+          if (filters?.createdTo) {
+            clauses.push(lte(t.createdAt, new Date(filters.createdTo)));
+          }
+          if (after) {
+            const keyset = or(
+              lt(t.createdAt, after.createdAt),
+              and(eq(t.createdAt, after.createdAt), lt(t.id, after.id)),
+            );
+            if (keyset) {
+              clauses.push(keyset);
+            }
+          }
           return clauses.length > 0 ? and(...clauses) : undefined;
         },
       });
 
+      const page = rows.slice(0, limit);
+      const last = page[page.length - 1];
       const redactPii = scope.role === "COMMUNITY_ADMIN";
-      return rows.map((row) => ({
+      const items = page.map((row) => ({
         id: row.id,
         invoice: row.invoice,
         appId: row.appId,
@@ -379,6 +461,13 @@ export function createDbAdminServices(db: DbClient = createDbClient()): AdminSer
         createdAt: row.createdAt.toISOString(),
         settledAt: isoOrNull(row.settledAt),
       }));
+      return {
+        items,
+        nextCursor:
+          rows.length > limit && last
+            ? encodeLedgerCursor({ createdAt: last.createdAt.toISOString(), id: last.id })
+            : null,
+      };
     },
 
     async getSettlementTimeline(scope, invoice): Promise<AdminSettlementTimeline> {

--- a/fiber-link-service/apps/admin/src/server/services/fixture-services.test.ts
+++ b/fiber-link-service/apps/admin/src/server/services/fixture-services.test.ts
@@ -62,9 +62,9 @@ describe("fixture admin services", () => {
   it("filters withdrawals by state and app", async () => {
     const services = createFixtureAdminServices(buildFixture());
     const failed = await services.listWithdrawals(SUPER, { state: "FAILED" });
-    expect(failed.map((w) => w.id)).toEqual(["w-1"]);
+    expect(failed.items.map((w) => w.id)).toEqual(["w-1"]);
     const beta = await services.listWithdrawals(SUPER, { appId: "app-beta" });
-    expect(beta.map((w) => w.id)).toEqual(["w-2"]);
+    expect(beta.items.map((w) => w.id)).toEqual(["w-2"]);
   });
 
   it("summarizes withdrawal states per scope in canonical order", async () => {
@@ -79,7 +79,7 @@ describe("fixture admin services", () => {
 
   it("redacts userId and toAddress for COMMUNITY_ADMIN withdrawals", async () => {
     const services = createFixtureAdminServices(buildFixture());
-    const rows = await services.listWithdrawals(COMMUNITY);
+    const { items: rows } = await services.listWithdrawals(COMMUNITY);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.appId).toBe("app-alpha");
     expect(rows[0]?.userId).toBe("");
@@ -88,7 +88,7 @@ describe("fixture admin services", () => {
 
   it("keeps userId and toAddress for SUPER_ADMIN withdrawals", async () => {
     const services = createFixtureAdminServices(buildFixture());
-    const rows = await services.listWithdrawals(SUPER, { appId: "app-alpha" });
+    const { items: rows } = await services.listWithdrawals(SUPER, { appId: "app-alpha" });
     expect(rows[0]?.userId).toBe("user-1");
     expect(rows[0]?.toAddress).toBe("ckb1qalpha");
   });

--- a/fiber-link-service/apps/admin/src/server/services/fixture-services.ts
+++ b/fiber-link-service/apps/admin/src/server/services/fixture-services.ts
@@ -14,6 +14,8 @@ import { buildDashboardBackupRestorePlan } from "../dashboard-backups";
 import { buildDashboardRateLimitChangeSet, parseDashboardRateLimitInput } from "../dashboard-rate-limit";
 import { PolicyScopeError, SettlementNotFoundError, SettlementRetryStateError, UnknownAppError } from "./errors";
 import {
+  ADMIN_LIST_DEFAULT_LIMIT,
+  ADMIN_LIST_MAX_LIMIT,
   type AdminAuditEventInput,
   type AdminLedgerEntry,
   type AdminScope,
@@ -24,10 +26,12 @@ import {
   type AdminWithdrawalFilters,
   LEDGER_PAGE_DEFAULT_LIMIT,
   LEDGER_PAGE_MAX_LIMIT,
-  SETTLEMENT_LIST_LIMIT,
-  WITHDRAWAL_LIST_LIMIT,
   encodeLedgerCursor,
 } from "./types";
+
+function clampListLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit ?? ADMIN_LIST_DEFAULT_LIMIT, 1), ADMIN_LIST_MAX_LIMIT);
+}
 
 /**
  * On-disk fixture shape pointed at by `ADMIN_DASHBOARD_FIXTURE_PATH`. Withdrawal
@@ -189,13 +193,35 @@ export function createFixtureAdminServices(fixture: DashboardFixture): AdminServ
     },
     async listWithdrawals(scope, filters?: AdminWithdrawalFilters) {
       const redactPii = scope.role === "COMMUNITY_ADMIN";
-      return snapshot.withdrawals
+      const limit = clampListLimit(filters?.limit);
+      let items = snapshot.withdrawals
         .filter((row) => inScope(scope, row.appId))
         .filter((row) => (filters?.appId ? row.appId === filters.appId : true))
         .filter((row) => (filters?.state ? row.state === filters.state : true))
-        .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-        .slice(0, WITHDRAWAL_LIST_LIMIT)
-        .map((row) => ({ ...row, userId: redactPii ? "" : row.userId, toAddress: redactPii ? null : row.toAddress }));
+        .filter((row) => (filters?.userId ? row.userId === filters.userId : true))
+        .filter((row) => (filters?.asset ? row.asset === filters.asset : true))
+        .filter((row) => (filters?.id ? row.id === filters.id : true))
+        .filter((row) => (filters?.txHash ? row.txHash === filters.txHash : true))
+        .filter((row) => (filters?.createdFrom ? row.createdAt >= filters.createdFrom : true))
+        .filter((row) => (filters?.createdTo ? row.createdAt <= filters.createdTo : true))
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id));
+      const after = filters?.after;
+      if (after) {
+        items = items.filter(
+          (row) => row.createdAt < after.createdAt || (row.createdAt === after.createdAt && row.id < after.id),
+        );
+      }
+      const page = items.slice(0, limit);
+      const last = page[page.length - 1];
+      return {
+        items: page.map((row) => ({
+          ...row,
+          userId: redactPii ? "" : row.userId,
+          toAddress: redactPii ? null : row.toAddress,
+        })),
+        nextCursor:
+          items.length > limit && last ? encodeLedgerCursor({ createdAt: last.createdAt, id: last.id }) : null,
+      };
     },
     async summarizeWithdrawals(scope) {
       return summarizeWithdrawalStates(snapshot.withdrawals.filter((row) => inScope(scope, row.appId)));
@@ -231,17 +257,40 @@ export function createFixtureAdminServices(fixture: DashboardFixture): AdminServ
     },
     async listSettlements(scope, filters) {
       const redactPii = scope.role === "COMMUNITY_ADMIN";
-      return snapshot.settlements
+      const limit = clampListLimit(filters?.limit);
+      let items = snapshot.settlements
         .filter((row) => inScope(scope, row.intent.appId))
         .filter((row) => (filters?.appId ? row.intent.appId === filters.appId : true))
         .filter((row) => (filters?.state ? row.intent.invoiceState === filters.state : true))
-        .sort((a, b) => b.intent.createdAt.localeCompare(a.intent.createdAt))
-        .slice(0, SETTLEMENT_LIST_LIMIT)
-        .map((row) => ({
+        .filter((row) => (filters?.invoice ? row.intent.invoice === filters.invoice : true))
+        .filter((row) => (filters?.asset ? row.intent.asset === filters.asset : true))
+        .filter((row) =>
+          filters?.userId ? row.intent.fromUserId === filters.userId || row.intent.toUserId === filters.userId : true,
+        )
+        .filter((row) => (filters?.createdFrom ? row.intent.createdAt >= filters.createdFrom : true))
+        .filter((row) => (filters?.createdTo ? row.intent.createdAt <= filters.createdTo : true))
+        .sort((a, b) => b.intent.createdAt.localeCompare(a.intent.createdAt) || b.intent.id.localeCompare(a.intent.id));
+      const after = filters?.after;
+      if (after) {
+        items = items.filter(
+          (row) =>
+            row.intent.createdAt < after.createdAt ||
+            (row.intent.createdAt === after.createdAt && row.intent.id < after.id),
+        );
+      }
+      const page = items.slice(0, limit);
+      const last = page[page.length - 1];
+      return {
+        items: page.map((row) => ({
           ...row.intent,
           fromUserId: redactPii ? "" : row.intent.fromUserId,
           toUserId: redactPii ? "" : row.intent.toUserId,
-        }));
+        })),
+        nextCursor:
+          items.length > limit && last
+            ? encodeLedgerCursor({ createdAt: last.intent.createdAt, id: last.intent.id })
+            : null,
+      };
     },
     async getSettlementTimeline(scope, invoice) {
       const row = snapshot.settlements.find((candidate) => candidate.intent.invoice === invoice);

--- a/fiber-link-service/apps/admin/src/server/services/types.ts
+++ b/fiber-link-service/apps/admin/src/server/services/types.ts
@@ -58,17 +58,26 @@ export type AdminWithdrawal = {
 export type AdminWithdrawalFilters = {
   state?: WithdrawalState;
   appId?: string;
+  userId?: string;
+  asset?: "CKB" | "USDI";
+  /** Exact withdrawal id match. */
+  id?: string;
+  /** Exact transaction hash match. */
+  txHash?: string;
+  /** ISO timestamps bounding createdAt (inclusive). */
+  createdFrom?: string;
+  createdTo?: string;
+  limit?: number;
+  /** Opaque cursor as sent over the wire; the router decodes it into `after`. */
+  cursor?: string;
+  after?: AdminLedgerCursor;
 };
 
-/**
- * Cap for `listWithdrawals`. The queue view is filter-driven; an unbounded
- * SELECT over a production withdrawals table would ship the whole table to the
- * browser on every page load.
- */
-export const WITHDRAWAL_LIST_LIMIT = 200;
-
-/** Same rationale as {@link WITHDRAWAL_LIST_LIMIT}, for the settlements queue. */
-export const SETTLEMENT_LIST_LIMIT = 200;
+export type AdminWithdrawalPage = {
+  items: AdminWithdrawal[];
+  /** Opaque keyset cursor for the next page, or null when exhausted. */
+  nextCursor: string | null;
+};
 
 /**
  * Settlement projection of a tip intent for the investigation surfaces:
@@ -122,7 +131,30 @@ export type AdminSettlementTimeline = {
 export type AdminSettlementFilters = {
   state?: InvoiceState;
   appId?: string;
+  /** Matches either the tipper or the recipient. */
+  userId?: string;
+  asset?: "CKB" | "USDI";
+  /** Exact invoice match. */
+  invoice?: string;
+  /** ISO timestamps bounding createdAt (inclusive). */
+  createdFrom?: string;
+  createdTo?: string;
+  limit?: number;
+  /** Opaque cursor as sent over the wire; the router decodes it into `after`. */
+  cursor?: string;
+  after?: AdminLedgerCursor;
 };
+
+export type AdminSettlementPage = {
+  items: AdminSettlementIntent[];
+  /** Opaque keyset cursor for the next page, or null when exhausted. */
+  nextCursor: string | null;
+};
+
+/** Default page size for the admin withdrawal/settlement queues. */
+export const ADMIN_LIST_DEFAULT_LIMIT = 50;
+/** Hard page-size cap for the admin withdrawal/settlement queues. */
+export const ADMIN_LIST_MAX_LIMIT = 100;
 
 /** Ledger statement page size bounds; +1 row is fetched internally to detect more pages. */
 export const LEDGER_PAGE_DEFAULT_LIMIT = 50;
@@ -226,8 +258,8 @@ export interface AdminServices {
   __listAuditEventsForTests?: () => AdminAuditEventInput[];
 
   listApps(scope: AdminScope): Promise<DashboardApp[]>;
-  /** Newest first, capped at {@link WITHDRAWAL_LIST_LIMIT} rows. */
-  listWithdrawals(scope: AdminScope, filters?: AdminWithdrawalFilters): Promise<AdminWithdrawal[]>;
+  /** Newest first with keyset pagination; page size capped at {@link ADMIN_LIST_MAX_LIMIT}. */
+  listWithdrawals(scope: AdminScope, filters?: AdminWithdrawalFilters): Promise<AdminWithdrawalPage>;
   /**
    * Per-state withdrawal counts over the WHOLE scope (not the capped list),
    * zero-filled in canonical state order.
@@ -236,8 +268,8 @@ export interface AdminServices {
   listPolicies(scope: AdminScope): Promise<DashboardWithdrawalPolicy[]>;
   upsertPolicy(scope: AdminScope, input: WithdrawalPolicyInput): Promise<DashboardWithdrawalPolicy>;
 
-  /** Newest first, capped at {@link SETTLEMENT_LIST_LIMIT} rows. */
-  listSettlements(scope: AdminScope, filters?: AdminSettlementFilters): Promise<AdminSettlementIntent[]>;
+  /** Newest first with keyset pagination; page size capped at {@link ADMIN_LIST_MAX_LIMIT}. */
+  listSettlements(scope: AdminScope, filters?: AdminSettlementFilters): Promise<AdminSettlementPage>;
   /**
    * Full investigation view for one invoice: current intent state, the
    * `tip_intent_events` lifecycle timeline, and prior admin actions (retries,


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #531 → #530 → #528**: based on `claude/worker-metrics` because it extends the settlements list shipped in #528 and shares the cursor helpers from #530. Only the last commit (`Add pagination, filtering, and exact search to admin lists`) is new here; I will rebase onto `main` as the stack merges so the diff collapses to this change.

## Summary

Implements #473: the admin withdrawal and settlement queues move from a fixed 200-row window to cursor-paginated, searchable lists suited to incident response.

- **Services**: `listWithdrawals` / `listSettlements` now return `{ items, nextCursor }` pages using keyset `(createdAt, id)` pagination — default 50, max 100 rows per page, one extra row fetched internally to detect the next page. `nextCursor` is an opaque base64url cursor (same helpers as the ledger statement).
- **New filters**:
  - both lists: `userId`, `asset`, `createdFrom`/`createdTo` (ISO, inclusive);
  - withdrawals: exact `id` and exact `txHash`;
  - settlements: exact `invoice`; `userId` matches either the tipper or the recipient.
- **Routers** validate every input (state/asset enums, ISO timestamps, bounded `limit`, cursor decoding) and return `BAD_REQUEST` on junk.
- **UI**: the withdrawals page gains URL-persisted exact-search inputs (withdrawal ID / user / tx hash) and a Next-page control; the settlements page gains invoice/user search and Next-page.
- **Scoping preserved**: COMMUNITY_ADMIN app scoping and PII redaction (user id, payout destination) flow through the paged path unchanged.
- CSV/JSON export from the issue's "also consider" list is left for a follow-up.

## Issue acceptance criteria

- ✅ Admin withdrawals and settlements support cursor pagination.
- ✅ Admin users can search by invoice, withdrawal id, user id, tx hash, and state.
- ✅ Responses include paging metadata (`nextCursor`; null when exhausted).
- ✅ Tests cover filters, pagination order, and scoped community-admin access.

## Testing

- `apps/admin`: `bunx vitest run src/server` — 71 tests pass (4 new: exact search per field + input validation, settlement cursor traversal order, settlement invoice/user search, community-admin scoping + redaction on paged results; existing list tests updated to the page shape).
- `bun run typecheck`, `bunx biome check`, and `next build` all clean.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1VqayqJKoPTv4j6u5v8WA)_